### PR TITLE
Add zookeeper_base_znode config value

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Karafka has following configuration options:
 | redis                  | true     | Hash              | Hash with Redis configuration options                                                       |
 | wait_timeout           | true     | Integer (Seconds) | How long do we wait for incoming messages on a single socket (topic)                        |
 | zookeeper_hosts        | true     | Array<String>     | Zookeeper server hosts                                                                      |
+| zookeeper_base_znode   | false    | String            | Base znode that stores kafka brokers data                                                   |
 | monitor                | false    | Object            | Monitor instance (defaults to Karafka::Monitor)                                             |
 | logger                 | false    | Object            | Logger instance (defaults to Karafka::Logger)                                               |
 | kafka_hosts            | false    | Array<String>     | Kafka server hosts - if not provided Karafka will autodiscover them based on Zookeeper data |

--- a/lib/karafka/cli/topics.rb
+++ b/lib/karafka/cli/topics.rb
@@ -12,7 +12,8 @@ module Karafka
 
         Karafka::App.config.zookeeper_hosts.each do |host|
           zookeeper = Zookeeper.new(host)
-          topics += zookeeper.get_children(path: '/brokers/topics')[:children]
+          path = File.join(::Karafka::App.config.zookeeper_base_znode || '', 'brokers', 'topics')
+          topics += zookeeper.get_children(path: path)[:children]
         end
 
         topics.sort.each { |topic| puts topic }

--- a/lib/karafka/config.rb
+++ b/lib/karafka/config.rb
@@ -26,6 +26,7 @@ module Karafka
       redis
       wait_timeout
       zookeeper_hosts
+      zookeeper_base_znode
       kafka_hosts
     ).freeze
 

--- a/lib/karafka/connection/broker_manager.rb
+++ b/lib/karafka/connection/broker_manager.rb
@@ -25,14 +25,14 @@ module Karafka
       # @param id [String] id of Kafka broker
       # @return [::Karafka::Connection::Broker] single Kafka broker details
       def find(id)
-        zk.get("#{BROKERS_PATH}/#{id}").first
+        zk.get("#{brokers_full_path}/#{id}").first
       end
 
       # @return [Array<String>] ids of all the brokers
       # @example
       #   ids #=> ['0', '2', '3']
       def ids
-        zk.children(BROKERS_PATH)
+        zk.children(brokers_full_path)
       end
 
       # @return [::ZK] Zookeeper high level client
@@ -40,6 +40,11 @@ module Karafka
         @zk ||= ::ZK.new(
           ::Karafka::App.config.zookeeper_hosts.join(',')
         )
+      end
+
+      # @return [String] Full path to brokers znode
+      def brokers_full_path
+        File.join(::Karafka::App.config.zookeeper_base_znode || '', BROKERS_PATH)
       end
     end
   end

--- a/spec/lib/karafka/cli/topics_spec.rb
+++ b/spec/lib/karafka/cli/topics_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Karafka::Cli::Topics do
 
       expect(zookeeper_host)
         .to receive(:get_children)
-        .with(path: '/brokers/topics')
+        .with(path: '/base_znode/brokers/topics')
         .and_return(topics)
     end
 

--- a/spec/lib/karafka/connection/broker_manager_spec.rb
+++ b/spec/lib/karafka/connection/broker_manager_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Karafka::Connection::BrokerManager do
     it 'expect to get a proper broker data' do
       expect(zk)
         .to receive(:get)
-        .with("#{described_class::BROKERS_PATH}/#{id}")
+        .with("/base_znode#{described_class::BROKERS_PATH}/#{id}")
         .and_return([broker_data])
 
       expect(subject.send(:find, id)).to eq broker_data
@@ -60,7 +60,7 @@ RSpec.describe Karafka::Connection::BrokerManager do
 
       expect(zk)
         .to receive(:children)
-        .with(described_class::BROKERS_PATH)
+        .with("/base_znode#{described_class::BROKERS_PATH}")
         .and_return(result)
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,6 +46,7 @@ module Karafka
   class App
     setup do |config|
       config.kafka_hosts = ['localhost:9092']
+      config.zookeeper_base_znode = '/base_znode'
       config.zookeeper_hosts = ['localhost:2181']
       config.wait_timeout = 10 # 10 seconds
       config.max_concurrency = 1 # 1 thread for specs


### PR DESCRIPTION
Our zookeeper setup does not store the kafka broker data at the root znode. This adds a configuration setting to specify the base path