### PR TITLE
haml-lint changed name to haml_lint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,44 @@
+AllCops:
+  TargetRubyVersion: 2.3
+  Exclude:
+    - bin/**/*
+    - db/**/*
+    - .gemspec/**/*
+    - .bundle/**/*
+    - vendor/**/*
+    - config/**/*
+    - script/**/*
+    - !ruby/regexp /old_and_unused\.rb$/
+    - !ruby/regexp /polishgeeks-[^\/]{2,}\.rb/
+  Include:
+    - '**/Rakefile'
+    - '**/config.ru'
+    - lib/tasks/**/*.rake
+    - lib/tasks/**/*.rb
+    - lib/capistrano/**/*.rb
+    - lib/capistrano/**/*.cap
+AlignParameters:
+  Enabled: false
+ClassLength:
+  CountComments: false
+  Max: 200
+LineLength:
+  Max: 99
+MethodLength:
+  CountComments: false
+  Max: 15
+Metrics/AbcSize:
+  Max: 25
+Style/MultilineOperationIndentation:
+  EnforcedStyle: indented
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+RSpec/AnyInstance:
+  Enabled: false
+RSpec/MultipleDescribes:
+  Enabled: false
+RSpec/InstanceVariable:
+  Enabled: false
+RSpec/FilePath:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem 'polishgeeks-dev-tools'
+  gem 'polishgeeks-dev-tools', '~> 1.3.1'
   gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,9 +16,6 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.6)
-      activesupport (= 4.2.6)
-      builder (~> 3.1)
     activesupport (4.2.6)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
@@ -41,8 +38,9 @@ GEM
       sass (~> 3.0)
       slim (>= 1.3.6, < 4.0)
       terminal-table (~> 1.4)
-    bson (4.0.4)
-    builder (3.2.2)
+    bundler-audit (0.5.0)
+      bundler (~> 1.2)
+      thor (~> 0.18)
     celluloid (0.17.3)
       celluloid-essentials
       celluloid-extras
@@ -87,9 +85,10 @@ GEM
       sexp_processor (~> 4.4)
     haml (4.0.7)
       tilt
-    haml-lint (0.13.0)
+    haml_lint (0.17.1)
       haml (~> 4.0)
-      rubocop (>= 0.25.0)
+      rake (>= 10, < 12)
+      rubocop (>= 0.36.0)
       sysexits (~> 1.1)
     highline (1.7.8)
     hitimes (1.2.3)
@@ -100,29 +99,18 @@ GEM
       addressable (~> 2.3)
     method_source (0.8.2)
     minitest (5.8.4)
-    mongo (2.2.4)
-      bson (~> 4.0)
-    mongoid (5.1.1)
-      activemodel (~> 4.0)
-      mongo (~> 2.1)
-      origin (~> 2.2)
-      tzinfo (>= 0.3.37)
-    mongoid-rspec (3.0.0)
-      mongoid (~> 5.0)
-      rake
-      rspec (~> 3.3)
     null-logger (0.1.1)
-    origin (2.2.0)
-    parser (2.3.0.6)
+    parser (2.3.0.7)
       ast (~> 2.2)
-    polishgeeks-dev-tools (1.2.1)
+    polishgeeks-dev-tools (1.3.1)
       brakeman
+      bundler-audit
       faker
-      haml-lint
-      mongoid-rspec
+      haml_lint
       pry
       rspec
       rubocop
+      rubocop-rspec
       rubycritic
       shoulda
       simplecov
@@ -140,7 +128,7 @@ GEM
     rainbow (2.1.0)
     rake (10.5.0)
     redis (3.2.2)
-    reek (3.11)
+    reek (4.0.1)
       codeclimate-engine-rb (~> 0.3.1)
       parser (~> 2.3, >= 2.3.0.6)
       rainbow (~> 2.0)
@@ -157,29 +145,31 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
-    rubocop (0.38.0)
-      parser (>= 2.3.0.6, < 3.0)
+    rubocop (0.39.0)
+      parser (>= 2.3.0.7, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
+    rubocop-rspec (1.4.1)
+      rubocop (= 0.39.0)
     ruby-progressbar (1.7.5)
     ruby2ruby (2.3.0)
       ruby_parser (~> 3.1)
       sexp_processor (~> 4.0)
     ruby_parser (3.8.1)
       sexp_processor (~> 4.1)
-    rubycritic (2.8.0)
+    rubycritic (2.9.0)
       colorize
       flay (= 2.7.0)
       flog (= 4.3.2)
       launchy (= 2.4.3)
-      parser (~> 2.3)
-      reek (= 3.11)
+      parser (= 2.3.0.7)
+      reek (= 4.0.1)
       ruby_parser (~> 3.8)
       virtus (~> 1.0)
     safe_yaml (1.0.4)
-    sass (3.4.21)
+    sass (3.4.22)
     sexp_processor (4.7.0)
     shoulda (3.5.0)
       shoulda-context (~> 1.0, >= 1.0.1)
@@ -211,7 +201,7 @@ GEM
       hitimes
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    unicode-display_width (1.0.2)
+    unicode-display_width (1.0.3)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -237,7 +227,7 @@ PLATFORMS
 DEPENDENCIES
   bundler
   karafka!
-  polishgeeks-dev-tools
+  polishgeeks-dev-tools (~> 1.3.1)
   timecop
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Optionally you can use **group** method to define group for this topic. Use it i
 ```ruby
 topic :incoming_messages do
   group :load_balanced_group
-  controler MessagesController
+  controller MessagesController
 end
 ```
 
@@ -244,7 +244,7 @@ However, if you want to use a raw Sidekiq worker (without any Karafka additional
 
 ```ruby
 topic :incoming_messages do
-  controler MessagesController
+  controller MessagesController
   worker MyCustomController
 end
 ```

--- a/lib/karafka/connection/broker_manager.rb
+++ b/lib/karafka/connection/broker_manager.rb
@@ -9,7 +9,7 @@ module Karafka
     # we can connect
     class BrokerManager
       # Path at Zookeeper under which brokers details are being stored
-      BROKERS_PATH = '/brokers/ids'.freeze
+      BROKERS_PATH = '/brokers/ids'
 
       # @return [Array<Karafka::Connection::Broker>] Array with details about all the brokers
       # @example Create new manager and get details about the brokers

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -2,5 +2,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '0.4.1'.freeze
+  VERSION = '0.4.1'
 end

--- a/spec/lib/karafka/app_spec.rb
+++ b/spec/lib/karafka/app_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Karafka::App do
   subject { described_class }
 
   describe '#run' do
-    it 'should run in supervision, start consuming and sleep' do
+    it 'runs in supervision, start consuming and sleep' do
       expect(subject)
         .to receive(:sleep)
 
@@ -27,7 +27,7 @@ RSpec.describe Karafka::App do
       subject.run
     end
 
-    it 'should define a proper action for sigint' do
+    it 'defines a proper action for sigint' do
       expect(Karafka::Process.instance)
         .to receive(:supervise)
 
@@ -47,7 +47,7 @@ RSpec.describe Karafka::App do
       subject.run
     end
 
-    it 'should define a proper action for sigquit' do
+    it 'defines a proper action for sigquit' do
       expect(Karafka::Process.instance)
         .to receive(:supervise)
 
@@ -71,7 +71,7 @@ RSpec.describe Karafka::App do
   describe '#config' do
     let(:config) { double }
 
-    it 'should alias to Config' do
+    it 'aliases to Config' do
       expect(Karafka::Config)
         .to receive(:config)
         .and_return(config)
@@ -83,13 +83,13 @@ RSpec.describe Karafka::App do
   describe '#routes' do
     let(:routes) { Karafka::Routing::Builder.instance }
 
-    it 'should return routes builder' do
+    it 'returns routes builder' do
       expect(subject.routes).to eq routes
     end
   end
 
   describe '#setup' do
-    it 'should delegate it to Config setup and set framework to initializing state' do
+    it 'delegates it to Config setup and set framework to initializing state' do
       expect(Karafka::Config)
         .to receive(:setup)
         .once

--- a/spec/lib/karafka/base_controller_spec.rb
+++ b/spec/lib/karafka/base_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Karafka::BaseController do
 
     describe '#schedule' do
       context 'when there are no callbacks' do
-        it 'should just schedule via perform_async' do
+        it 'justs schedule via perform_async' do
           expect(subject).to receive(:perform_async)
 
           subject.schedule
@@ -28,7 +28,7 @@ RSpec.describe Karafka::BaseController do
       let(:message) { double }
       let(:params) { double }
 
-      it 'should create params instance and assign it' do
+      it 'creates params instance and assign it' do
         expect(Karafka::Params::Params)
           .to receive(:build)
           .with(
@@ -50,7 +50,7 @@ RSpec.describe Karafka::BaseController do
         subject.instance_variable_set(:@params, params)
       end
 
-      it 'should retrieve params data' do
+      it 'retrieves params data' do
         expect(params)
           .to receive(:retrieve)
           .and_return(params)
@@ -104,7 +104,7 @@ RSpec.describe Karafka::BaseController do
           end.new
         end
 
-        it 'should not enqueue' do
+        it 'does not enqueue' do
           expect(subject).not_to receive(:enqueue)
 
           subject.schedule
@@ -126,7 +126,7 @@ RSpec.describe Karafka::BaseController do
 
         let(:params) { double }
 
-        it 'should execute perform_async' do
+        it 'executes perform_async' do
           expect(subject).to receive(:perform_async)
 
           subject.schedule
@@ -150,7 +150,7 @@ RSpec.describe Karafka::BaseController do
           end.new
         end
 
-        it 'should not enqueue' do
+        it 'does not enqueue' do
           expect(subject).not_to receive(:enqueue)
 
           subject.schedule
@@ -172,7 +172,7 @@ RSpec.describe Karafka::BaseController do
           end.new
         end
 
-        it 'should enqueue with perform_async' do
+        it 'enqueues with perform_async' do
           expect(subject).to receive(:perform_async)
 
           subject.schedule

--- a/spec/lib/karafka/base_worker_spec.rb
+++ b/spec/lib/karafka/base_worker_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Karafka::BaseWorker do
           .at_least(:once)
 
         expect(controller_instance)
-          .to_not receive(:after_failure)
+          .not_to receive(:after_failure)
 
         subject.after_failure(*args)
       end

--- a/spec/lib/karafka/base_worker_spec.rb
+++ b/spec/lib/karafka/base_worker_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Karafka::BaseWorker do
         .at_least(:once)
     end
 
-    it 'should set params and perform controller action' do
+    it 'sets params and perform controller action' do
       expect(controller_instance)
         .to receive(:perform)
 
@@ -36,7 +36,7 @@ RSpec.describe Karafka::BaseWorker do
       expect(subject.params).to eq args.last
     end
 
-    it 'should set topic and perform controller action' do
+    it 'sets topic and perform controller action' do
       expect(controller_instance)
         .to receive(:perform)
 
@@ -55,7 +55,7 @@ RSpec.describe Karafka::BaseWorker do
     end
 
     context 'when after_failure method is not defined on the controller' do
-      it 'should do nothing' do
+      it 'does nothing' do
         expect(controller_instance)
           .to receive(:respond_to?)
           .and_return(false)
@@ -69,7 +69,7 @@ RSpec.describe Karafka::BaseWorker do
     end
 
     context 'when after_failure method is defined on the controller' do
-      it 'should execute it' do
+      it 'executes it' do
         expect(controller_instance)
           .to receive(:respond_to?)
           .and_return(true)

--- a/spec/lib/karafka/configurators/internals_spec.rb
+++ b/spec/lib/karafka/configurators/internals_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Karafka::Configurators::Internals do
       it 'expect not to assign App logger to Karafka logger' do
         subject.setup
 
-        expect(Karafka.logger).to_not eq logger
+        expect(Karafka.logger).not_to eq logger
       end
     end
 
@@ -47,7 +47,7 @@ RSpec.describe Karafka::Configurators::Internals do
       it 'expect not to assign App monitor to Karafka monitor' do
         subject.setup
 
-        expect(Karafka.monitor).to_not eq monitor
+        expect(Karafka.monitor).not_to eq monitor
       end
     end
   end

--- a/spec/lib/karafka/connection/actor_cluster_spec.rb
+++ b/spec/lib/karafka/connection/actor_cluster_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Karafka::Connection::ActorCluster do
       context 'when we decide to stop the application' do
         let(:running?) { false }
 
-        it 'should not start listening' do
+        it 'does not start listening' do
           expect(listener)
             .not_to receive(:fetch)
 
@@ -41,7 +41,7 @@ RSpec.describe Karafka::Connection::ActorCluster do
       context 'when the application is running' do
         let(:running?) { true }
 
-        it 'should start listening' do
+        it 'starts listening' do
           expect(listener)
             .to receive(:fetch)
             .with(block)
@@ -72,7 +72,7 @@ RSpec.describe Karafka::Connection::ActorCluster do
           .and_return(true, false)
       end
 
-      it 'should notice it and retry' do
+      it 'notices it and retry' do
         expect(Karafka.monitor)
           .to receive(:notice_error)
           .with(described_class, StandardError)
@@ -92,7 +92,7 @@ RSpec.describe Karafka::Connection::ActorCluster do
         .and_return(listener)
     end
 
-    it 'should create new listeners based on the controllers' do
+    it 'creates new listeners based on the controllers' do
       expect(subject.send(:listeners)).to eq [listener]
     end
   end

--- a/spec/lib/karafka/connection/consumer_spec.rb
+++ b/spec/lib/karafka/connection/consumer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Karafka::Connection::Consumer do
     let(:controller_instance) { double(to_h: {}) }
 
     context 'everything works well' do
-      it 'should route to a proper controller and schedule task' do
+      it 'routes to a proper controller and schedule task' do
         expect(Karafka::Connection::Message)
           .to receive(:new)
           .with(topic, raw_message_value)
@@ -55,7 +55,7 @@ RSpec.describe Karafka::Connection::Consumer do
                 .and_raise(error)
             end
 
-            it 'should notice and not reraise error' do
+            it 'notices and not reraise error' do
               expect { subject.consume(raw_message) }.not_to raise_error
             end
           end

--- a/spec/lib/karafka/connection/listener_spec.rb
+++ b/spec/lib/karafka/connection/listener_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Karafka::Connection::Listener do
             .with(described_class, error)
         end
 
-        it 'should notice the error wthout closing the consumer' do
+        it 'notices the error wthout closing the consumer' do
           expect(subject)
             .to receive(:queue_consumer)
             .and_raise(error.new)
@@ -105,7 +105,7 @@ RSpec.describe Karafka::Connection::Listener do
         subject.instance_variable_set(:'@queue_consumer', queue_consumer)
       end
 
-      it 'should just return it' do
+      it 'justs return it' do
         expect(Poseidon::ConsumerGroup)
           .to receive(:new)
           .never
@@ -120,7 +120,7 @@ RSpec.describe Karafka::Connection::Listener do
         subject.instance_variable_set(:'@queue_consumer', nil)
       end
 
-      it 'should create an instance and return' do
+      it 'creates an instance and return' do
         expect(Karafka::Connection::QueueConsumer)
           .to receive(:new)
           .with(route)

--- a/spec/lib/karafka/connection/message_spec.rb
+++ b/spec/lib/karafka/connection/message_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Karafka::Connection::Message do
   subject { described_class.new(topic, content) }
 
   describe '.initialize' do
-    it 'should store both topic and content' do
+    it 'stores both topic and content' do
       expect(subject.topic).to eq topic
       expect(subject.content).to eq content
     end

--- a/spec/lib/karafka/connection/queue_consumer_spec.rb
+++ b/spec/lib/karafka/connection/queue_consumer_spec.rb
@@ -22,13 +22,13 @@ RSpec.describe Karafka::Connection::QueueConsumer do
   subject { described_class.new(route) }
 
   describe 'preconditions' do
-    it 'should have socket timeout bigger then wait timeout' do
+    it 'has socket timeout bigger then wait timeout' do
       expect(max_wait_ms < socket_timeout_ms).to be true
     end
   end
 
   describe '.new' do
-    it 'should just remember route' do
+    it 'just remembers route' do
       expect(subject.instance_variable_get(:@route)).to eq route
     end
   end
@@ -58,7 +58,7 @@ RSpec.describe Karafka::Connection::QueueConsumer do
           .not_to receive(:sleep)
       end
 
-      it 'should forward to target, fetch and commit' do
+      it 'forwards to target, fetch and commit' do
         fetch = lambda do
           subject.fetch do |rec_partition, rec_message_bulk|
             expect(rec_partition).to eq partition
@@ -85,7 +85,7 @@ RSpec.describe Karafka::Connection::QueueConsumer do
               .and_raise(error)
           end
 
-          it 'should try closing the connection' do
+          it 'tries closing the connection' do
             expect(subject)
               .to receive(:close)
 
@@ -115,7 +115,7 @@ RSpec.describe Karafka::Connection::QueueConsumer do
           .with(described_class::CLAIM_SLEEP_TIME)
       end
 
-      it 'should close the connection and wait' do
+      it 'closes the connection and wait' do
         fetch = lambda do
           subject.fetch
         end
@@ -140,7 +140,7 @@ RSpec.describe Karafka::Connection::QueueConsumer do
           )
       end
 
-      it 'should create Poseidon::ConsumerGroup instance' do
+      it 'creates Poseidon::ConsumerGroup instance' do
         expect(subject)
           .not_to receive(:close)
 
@@ -157,7 +157,7 @@ RSpec.describe Karafka::Connection::QueueConsumer do
               .and_raise(error)
           end
 
-          it 'should try to close it' do
+          it 'tries to close it' do
             expect(subject)
               .to receive(:close)
 
@@ -212,7 +212,7 @@ RSpec.describe Karafka::Connection::QueueConsumer do
       let(:target) { nil }
       let(:method_target) { double }
 
-      it 'should do nothing' do
+      it 'does nothing' do
         allow(subject)
           .to receive(:target)
           .and_return(method_target)
@@ -230,7 +230,7 @@ RSpec.describe Karafka::Connection::QueueConsumer do
     context 'when target is existing and we can close it' do
       let(:target) { double }
 
-      it 'should just reload and close it' do
+      it 'just reloads and close it' do
         expect(target)
           .to receive(:reload)
 
@@ -259,7 +259,7 @@ RSpec.describe Karafka::Connection::QueueConsumer do
             .and_raise(error)
         end
 
-        it 'should delete @target assignment so new target will be created' do
+        it 'deletes @target assignment so new target will be created' do
           subject.send(:close)
           expect(subject.instance_variable_get(:@target)).to eq nil
         end

--- a/spec/lib/karafka/helpers/multi_delegator_spec.rb
+++ b/spec/lib/karafka/helpers/multi_delegator_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Karafka::Helpers::MultiDelegator do
         .to(target1, target2)
     end
 
-    it 'should delegate to all' do
+    it 'delegates to all' do
       methods.each do |mname|
         expect(target1).to receive(mname)
         expect(target2).to receive(mname)

--- a/spec/lib/karafka/logger_spec.rb
+++ b/spec/lib/karafka/logger_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Karafka::Logger do
     let(:log_file) { Karafka::App.root.join('log', "#{env}.log") }
     let(:logger) { Karafka::Logger.new(STDOUT) }
 
-    it 'should create an instance that will log in the app root' do
+    it 'creates an instance that will log in the app root' do
       expect(subject)
         .to receive(:target)
         .and_return(target)
@@ -27,7 +27,7 @@ RSpec.describe Karafka::Logger do
     let(:delegate_scope) { double }
     let(:file) { double }
 
-    it 'should delegate write and close to STDOUT and file' do
+    it 'delegates write and close to STDOUT and file' do
       expect(Karafka::Helpers::MultiDelegator)
         .to receive(:delegate)
         .with(:write, :close)
@@ -49,7 +49,7 @@ RSpec.describe Karafka::Logger do
     let(:file) { double }
     let(:log_file) { Karafka::App.root.join('log', "#{Karafka.env}.log") }
 
-    it 'should open a log_file in append mode' do
+    it 'opens a log_file in append mode' do
       expect(File)
         .to receive(:open)
         .with(log_file, 'a')

--- a/spec/lib/karafka/logger_spec.rb
+++ b/spec/lib/karafka/logger_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Karafka::Logger do
   describe '#build' do
     let(:target) { double }
     let(:log_file) { Karafka::App.root.join('log', "#{env}.log") }
-    let(:logger) { Karafka::Logger.new(STDOUT) }
+    let(:logger) { described_class.new(STDOUT) }
 
     it 'creates an instance that will log in the app root' do
       expect(subject)

--- a/spec/lib/karafka/process_spec.rb
+++ b/spec/lib/karafka/process_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Karafka::Process do
     let(:callback) { -> {} }
 
     describe "on_#{signal.to_s.downcase}" do
-      it 'should assign given callback to appropriate signal key' do
+      it 'assigns given callback to appropriate signal key' do
         subject.send(:"on_#{signal.to_s.downcase}", &callback)
         expect(subject.instance_variable_get(:@callbacks)[signal]).to include callback
       end
@@ -15,7 +15,7 @@ RSpec.describe Karafka::Process do
   end
 
   describe '#supervise' do
-    it 'should trap signals and yield' do
+    it 'traps signals and yield' do
       described_class::HANDLED_SIGNALS.each do |signal|
         expect(subject)
           .to receive(:trap_signal)
@@ -39,7 +39,7 @@ RSpec.describe Karafka::Process do
         .and_yield
     end
 
-    it 'should trap signals, log it and run callbacks if defined' do
+    it 'traps signals, log it and run callbacks if defined' do
       expect(subject)
         .to receive(:notice_signal)
         .with(signal)
@@ -53,7 +53,7 @@ RSpec.describe Karafka::Process do
 
   describe '#notice_signal' do
     let(:signal) { rand.to_s }
-    it 'should log info with signal code into Karafka logger' do
+    it 'logs info with signal code into Karafka logger' do
       expect(Thread)
         .to receive(:new)
         .and_yield

--- a/spec/lib/karafka/routing/builder_spec.rb
+++ b/spec/lib/karafka/routing/builder_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Karafka::Routing::Builder do
     context 'when there are no attributes' do
       before { subject.clear }
 
-      it { expect { subject.send(:validate!, attribute, error) }.to_not raise_error }
+      it { expect { subject.send(:validate!, attribute, error) }.not_to raise_error }
     end
 
     context 'when there are objects without duplication of attribute' do
@@ -104,7 +104,7 @@ RSpec.describe Karafka::Routing::Builder do
         subject << route.class.new.tap { |route| route.topic = rand.to_s }
       end
 
-      it { expect { subject.send(:validate!, attribute, error) }.to_not raise_error }
+      it { expect { subject.send(:validate!, attribute, error) }.not_to raise_error }
     end
   end
 end

--- a/spec/lib/karafka/routing/route_spec.rb
+++ b/spec/lib/karafka/routing/route_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe Karafka::Routing::Route do
       context 'and group name is valid' do
         let(:group) { rand(1000).to_s }
 
-        it { expect { subject.validate! }.to_not raise_error }
+        it { expect { subject.validate! }.not_to raise_error }
       end
     end
   end

--- a/spec/lib/karafka/runner_spec.rb
+++ b/spec/lib/karafka/runner_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Karafka::Runner do
           .and_return(consumer)
       end
 
-      it 'should start asynchronously fetch loop for each actor_cluster' do
+      it 'starts asynchronously fetch loop for each actor_cluster' do
         expect(actor_cluster)
           .to receive(:async)
           .and_return(async_scope)
@@ -42,7 +42,7 @@ RSpec.describe Karafka::Runner do
           .and_raise(error)
       end
 
-      it 'should stop the app and reraise' do
+      it 'stops the app and reraise' do
         expect(Karafka::App)
           .to receive(:stop!)
 
@@ -79,14 +79,14 @@ RSpec.describe Karafka::Runner do
   describe '#consumer' do
     let(:subject) { described_class.new.send(:consumer) }
 
-    it 'should be a proc' do
+    it 'is a proc' do
       expect(subject).to be_a Proc
     end
 
     context 'when we invoke a consumer block' do
       let(:message) { double }
 
-      it 'should consume the message' do
+      it 'consumes the message' do
         expect_any_instance_of(Karafka::Connection::Consumer)
           .to receive(:consume)
           .with(message)

--- a/spec/lib/karafka/workers/builder_spec.rb
+++ b/spec/lib/karafka/workers/builder_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Karafka::Workers::Builder do
   let(:controller_class) { double }
 
   describe '.new' do
-    it 'should assign internally controller_class' do
+    it 'assigns internally controller_class' do
       expect(subject.instance_variable_get('@controller_class')).to eq controller_class
     end
   end
@@ -29,7 +29,7 @@ RSpec.describe Karafka::Workers::Builder do
           .exactly(2).times
       end
 
-      it 'should not build it again' do
+      it 'does not build it again' do
         expect(subject.build).to eq Karafka
       end
     end
@@ -47,7 +47,7 @@ RSpec.describe Karafka::Workers::Builder do
               .exactly(2).times
           end
 
-          it 'should build it' do
+          it 'builds it' do
             expect(subject.build.to_s).to eq "Karafka#{random}Worker"
           end
         end
@@ -67,7 +67,7 @@ RSpec.describe Karafka::Workers::Builder do
               .and_return(Karafka)
           end
 
-          it 'should build it in this scope' do
+          it 'builds it in this scope' do
             expect(subject.build.to_s).to eq "Karafka::Karafka#{random}Worker"
           end
         end

--- a/spec/lib/karafka_spec.rb
+++ b/spec/lib/karafka_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Karafka do
 
     context 'when KARAFKA_BOOT_FILE is not defined' do
       let(:boot_file) { nil }
-      let(:default) { File.join(Karafka.root, 'app.rb') }
+      let(:default) { File.join(described_class.root, 'app.rb') }
 
       it 'expect to use default one' do
         expect(subject.boot_file).to eq Pathname.new(default)

--- a/spec/lib/karafka_spec.rb
+++ b/spec/lib/karafka_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Karafka do
   describe '#logger=' do
     let(:logger) { double }
 
-    it 'should assign logger' do
+    it 'assigns logger' do
       subject.logger = logger
       expect(subject.instance_variable_get(:'@logger')).to eq logger
     end
@@ -28,7 +28,7 @@ RSpec.describe Karafka do
         subject.instance_variable_set(:'@monitor', monitor)
       end
 
-      it 'should use monitor that was defined' do
+      it 'uses monitor that was defined' do
         expect(subject.monitor).to eq monitor
       end
     end
@@ -40,7 +40,7 @@ RSpec.describe Karafka do
         subject.instance_variable_set(:'@monitor', nil)
       end
 
-      it 'should build a default monitor' do
+      it 'builds a default monitor' do
         expect(Karafka::Monitor)
           .to receive(:instance)
           .and_return(monitor)
@@ -58,7 +58,7 @@ RSpec.describe Karafka do
         subject.instance_variable_set(:'@monitor', monitor)
       end
 
-      it 'should use monitor that was defined' do
+      it 'uses monitor that was defined' do
         expect(subject.monitor).to eq monitor
       end
     end
@@ -70,7 +70,7 @@ RSpec.describe Karafka do
         subject.instance_variable_set(:'@monitor', nil)
       end
 
-      it 'should build a default monitor' do
+      it 'builds a default monitor' do
         expect(Karafka::Monitor)
           .to receive(:instance)
           .and_return(monitor)


### PR DESCRIPTION
Fixes on `bundle install`:

    An error occurred while installing haml-lint (0.13.0), and Bundler cannot continue.
    Make sure that `gem install haml-lint -v '0.13.0'` succeeds before bundling.

See also: https://github.com/polishgeeks/polishgeeks-dev-tools/issues/58.