### PR TITLE
Make sure the log directory exists

### DIFF
--- a/lib/karafka/logger.rb
+++ b/lib/karafka/logger.rb
@@ -33,8 +33,12 @@ module Karafka
       # @return [File] file to which we want to write our logs
       # @note File is being opened in append mode ('a')
       def file
+        log_dir = Karafka::App.root.join('log')
+        unless Dir.exist?(log_dir)
+          Dir.mkdir(log_dir)
+        end
         File.open(
-          Karafka::App.root.join('log', "#{Karafka.env}.log"),
+          log_dir.join("#{Karafka.env}.log"),
           'a'
         )
       end

--- a/lib/karafka/logger.rb
+++ b/lib/karafka/logger.rb
@@ -15,6 +15,7 @@ module Karafka
       # Returns a logger instance with appropriate settings, log level and environment
       def instance
         instance = new(target)
+        ensure_dir_exists
         instance.level = ENV_MAP[Karafka.env] || ENV_MAP[:default]
         instance
       end
@@ -30,13 +31,19 @@ module Karafka
           .to(STDOUT, file)
       end
 
+      # @return [Pathname] the directory in which the logs will be written
+      def log_dir
+        Karafka::App.root.join('log')
+      end
+
+      # Makes sure the log directory exists
+      def ensure_dir_exists
+        Dir.mkdir(log_dir) unless Dir.exist?(log_dir)
+      end
+
       # @return [File] file to which we want to write our logs
       # @note File is being opened in append mode ('a')
       def file
-        log_dir = Karafka::App.root.join('log')
-        unless Dir.exist?(log_dir)
-          Dir.mkdir(log_dir)
-        end
         File.open(
           log_dir.join("#{Karafka.env}.log"),
           'a'

--- a/lib/karafka/logger.rb
+++ b/lib/karafka/logger.rb
@@ -14,8 +14,8 @@ module Karafka
     class << self
       # Returns a logger instance with appropriate settings, log level and environment
       def instance
-        instance = new(target)
         ensure_dir_exists
+        instance = new(target)
         instance.level = ENV_MAP[Karafka.env] || ENV_MAP[:default]
         instance
       end

--- a/spec/lib/karafka/logger_spec.rb
+++ b/spec/lib/karafka/logger_spec.rb
@@ -48,6 +48,20 @@ RSpec.describe Karafka::Logger do
   describe '#file' do
     let(:file) { double }
     let(:log_file) { Karafka::App.root.join('log', "#{Karafka.env}.log") }
+    # A Pathname, because this is what is returned by File.join
+    let(:log_dir) { Pathname.new(File.dirname(log_file)) }
+
+    it 'makes sure the "log" dir exists' do
+      expect(Dir)
+        .to receive(:exist?)
+        .with( log_dir )
+        .and_return( false )
+      expect(Dir)
+        .to receive(:mkdir)
+        .with( log_dir )
+        .and_return( 0 ) # Don't ask me why, but this is what Dir.mkdir returns normally
+      subject.send(:file)
+    end
 
     it 'opens a log_file in append mode' do
       expect(File)

--- a/spec/lib/karafka/logger_spec.rb
+++ b/spec/lib/karafka/logger_spec.rb
@@ -6,8 +6,10 @@ RSpec.describe Karafka::Logger do
 
   describe '#instance' do
     let(:target) { double }
-    let(:log_file) { Karafka::App.root.join('log', "#{env}.log") }
     let(:logger) { described_class.new(STDOUT) }
+    let(:log_file) { Karafka::App.root.join('log', "#{Karafka.env}.log") }
+    # A Pathname, because this is what is returned by File.join
+    let(:log_dir) { Pathname.new(File.dirname(log_file)) }
 
     it 'creates an instance that will log in the app root' do
       expect(subject)
@@ -19,6 +21,18 @@ RSpec.describe Karafka::Logger do
         .with(target)
         .and_return(logger)
 
+      subject.instance
+    end
+
+    it 'makes sure the "log" dir exists' do
+      expect(Dir)
+        .to receive(:exist?)
+        .with(log_dir)
+        .and_return(false)
+      expect(Dir)
+        .to receive(:mkdir)
+        .with(log_dir)
+        .and_return(0) # Don't ask me why, but this is what Dir.mkdir returns normally
       subject.instance
     end
   end
@@ -48,20 +62,6 @@ RSpec.describe Karafka::Logger do
   describe '#file' do
     let(:file) { double }
     let(:log_file) { Karafka::App.root.join('log', "#{Karafka.env}.log") }
-    # A Pathname, because this is what is returned by File.join
-    let(:log_dir) { Pathname.new(File.dirname(log_file)) }
-
-    it 'makes sure the "log" dir exists' do
-      expect(Dir)
-        .to receive(:exist?)
-        .with( log_dir )
-        .and_return( false )
-      expect(Dir)
-        .to receive(:mkdir)
-        .with( log_dir )
-        .and_return( 0 ) # Don't ask me why, but this is what Dir.mkdir returns normally
-      subject.send(:file)
-    end
 
     it 'opens a log_file in append mode' do
       expect(File)


### PR DESCRIPTION
When you follow the Readme to create a new Karafka application, it will
throw an error stating that the log dir does not exist. This directory
cannot be created by the CLI install command, because the logger needs
to be initialized before that.

This commit adds a check for the directory, and adds a spec for this as
well