### PR TITLE
Changed template to work with how the zk gem expects it

### DIFF
--- a/lib/karafka/templates/app.rb.example
+++ b/lib/karafka/templates/app.rb.example
@@ -11,7 +11,7 @@ class App < Karafka::App
     # In most of the cases, Karafka will figure out kafka hosts automatically based on the zookeeper
     #   data. Set it manually only if you know what you are doing
     # config.kafka = { hosts: %w( 127.0.0.1:9092 ) }
-    config.zookeeper = { hosts: %w( 127.0.0.1:2181 ) }
+    config.zookeeper.hosts = %w( 127.0.0.1:2181 )
     config.wait_timeout = 60 # 1 minute
     config.max_concurrency = 5
     config.name = 'example_app'


### PR DESCRIPTION
Original code resulted in:

karafka/lib/karafka/connection/broker_manager.rb:41:in `zk': undefined
  method `hosts' for ["127.0.0.1:2181"]:Array (NoMethodError)

when starting using 'bundle exec karafka server'