### PR TITLE
Added a zookeeper 'namespace' option.

### DIFF
--- a/lib/karafka/connection/broker_manager.rb
+++ b/lib/karafka/connection/broker_manager.rb
@@ -25,14 +25,14 @@ module Karafka
       # @param id [String] id of Kafka broker
       # @return [::Karafka::Connection::Broker] single Kafka broker details
       def find(id)
-        zk.get("#{BROKERS_PATH}/#{id}").first
+        zk.get("#{namespace}#{BROKERS_PATH}/#{id}").first
       end
 
       # @return [Array<String>] ids of all the brokers
       # @example
       #   ids #=> ['0', '2', '3']
       def ids
-        zk.children(BROKERS_PATH)
+        zk.children("#{namespace}#{BROKERS_PATH}")
       end
 
       # @return [::ZK] Zookeeper high level client
@@ -40,6 +40,15 @@ module Karafka
         @zk ||= ::ZK.new(
           ::Karafka::App.config.zookeeper.hosts.join(',')
         )
+      end
+
+      # @return [String] namespace in ZK
+      def namespace
+        ns = ::Karafka::App.config.zookeeper.namespace
+        return '' if ns.nil? || ns == ''
+        ns = "/#{ns}" unless ns.start_with?('/')
+        ns = ns[0..-2] if ns.end_with?('/')
+        ns
       end
     end
   end

--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -30,6 +30,7 @@ module Karafka
       # option zookeeper [Hash] zookeeper configuration options (hosts with ports and chroot)
       setting :zookeeper do
         setting :hosts
+        setting :namespace
       end
       # option kafka [Hash] - optional - kafka configuration options (hosts)
       setting :kafka do


### PR DESCRIPTION
Zookeeper instances can be namespaces, meaning that all znodes are
prefixed with the same name. This means that broker information would be
found at /namespace/brokers/ids instead of /brokers/ids.

This feature branch adds support for this, defaulting to an empty
namespace. Specs have been added to test the functionality.