### PR TITLE
fix error on startup from waterdrop

### DIFF
--- a/lib/karafka/templates/app.rb.example
+++ b/lib/karafka/templates/app.rb.example
@@ -8,7 +8,7 @@ Karafka::Loader.new.load(Karafka::App.root)
 # App class
 class App < Karafka::App
   setup do |config|
-    config.kafka = { hosts: %w( 127.0.0.1:9092 ) }
+    config.kafka.hosts = %w( 127.0.0.1:9092 )
     config.name = 'example_app'
     config.redis = {
       url: 'redis://localhost:6379'


### PR DESCRIPTION
doing a clean install then:
bundle exec karafka
gave:
NoMethodError: undefined method hosts' for {:hosts=>["127.0.0.1:9092"]}:Hash from waterdrop: lib/karafka/setup/configurators/water_drop.rb:12:inblock in setup'