### PR TITLE
Added dot in topic validation format

### DIFF
--- a/lib/karafka/routing/route.rb
+++ b/lib/karafka/routing/route.rb
@@ -9,8 +9,9 @@ module Karafka
     # - parser - What parsed do we want to use to unparse the data (optional)
     # - interchanger - What interchanger to encode/decode data do we want to use (optional)
     class Route
-      # Only ASCII alphanumeric characters and underscore and dash are allowed in topics and groups
-      NAME_FORMAT = /\A(\w|\-)+\z/
+      # Only ASCII alphanumeric characters, underscore, dash and dots
+      # are allowed in topics and groups
+      NAME_FORMAT = /\A(\w|\-|\.)+\z/
 
       # Options that we can set per each route
       ATTRIBUTES = %i(

--- a/spec/lib/karafka/base_responder_spec.rb
+++ b/spec/lib/karafka/base_responder_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Karafka::BaseResponder do
-  let(:topic_name) { "topic#{rand(1000)}" }
+  let(:topic_name) { 'topic_123.abc-xyz' }
   let(:input_data) { rand }
 
   let(:working_class) do
@@ -24,9 +24,13 @@ RSpec.describe Karafka::BaseResponder do
       end
 
       context 'when we register invalid topic' do
-        let(:topic_name) { rand.to_s }
+        %w(
+          & /31 ół !@
+        ).each do |topic_name|
+          let(:topic_name) { topic_name }
 
-        it { expect { responder_class }.to raise_error Karafka::Errors::InvalidTopicName }
+          it { expect { responder_class }.to raise_error(Karafka::Errors::InvalidTopicName) }
+        end
       end
     end
   end

--- a/spec/lib/karafka/responders/topic_spec.rb
+++ b/spec/lib/karafka/responders/topic_spec.rb
@@ -1,13 +1,17 @@
 RSpec.describe Karafka::Responders::Topic do
   subject(:topic) { described_class.new(name, options) }
-  let(:name) { rand(1000).to_s }
+  let(:name) { 'topic_123.abc-xyz' }
   let(:options) { {} }
 
   describe '.new' do
     context 'when name is invalid' do
-      let(:name) { rand.to_f.to_s }
+      %w(
+        & /31 ół !@
+      ).each do |topic_name|
+        let(:name) { topic_name }
 
-      it { expect { topic }.to raise_error(Karafka::Errors::InvalidTopicName) }
+        it { expect { topic }.to raise_error(Karafka::Errors::InvalidTopicName) }
+      end
     end
 
     context 'when name is valid' do

--- a/spec/lib/karafka/routing/route_spec.rb
+++ b/spec/lib/karafka/routing/route_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe Karafka::Routing::Route do
     end
 
     context 'when topic name is valid' do
-      let(:topic) { rand(1000).to_s }
+      let(:topic) { 'topic_123.abc-xyz' }
 
       before { route.group = group }
 
@@ -246,7 +246,7 @@ RSpec.describe Karafka::Routing::Route do
       end
 
       context 'and group name is valid' do
-        let(:group) { rand(1000).to_s }
+        let(:group) { 'topic_123.abc-xyz' }
 
         it { expect { route.validate! }.not_to raise_error }
       end


### PR DESCRIPTION
__What are you trying to accomplish with this PR?__
Dots are valid in Kafka topic syntax. After starting a project with Karafka, i found out i couldn't map any route to my topics since they are namespaced using dots. 

__How is this accomplished?__
Adding the `\.` option in the `NAME_FORMAT` regex fixed my issue without causing any further problem.

I also tweaked the tests a bit by removing the `rand(...).to_s` to a valid string containing alphanumeric character, an underscore, a dash and a dot.

@mensfeld