### PR TITLE
update readme section about custom monitors which are now singletons

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,7 +665,7 @@ class App < Karafka::App
   setup do |config|
     # Other setup stuff...
     config.logger = MyCustomLogger.new
-    config.monitor = CustomMonitor.new
+    config.monitor = CustomMonitor.instance
   end
 end
 ```


### PR DESCRIPTION
I recently implemented a custom monitor following the example in the readme. Everything was super straight forward except it seems the base class was changed to a singleton after the docs were written. Running the code as is produces:

```
NoMethodError: private method `new' called for CustomMonitor:Class
```

I updated the readme to reflect how to construct the singleton object.