### PR TITLE
Add support to batch incoming messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - #119 - add support for authentication using SSL
 - #121 - JSON as a default for standalone responders usage
 - #122 - Allow on capistrano role customization
+- #125 - Add support to batch incoming messages
+- Renamed *inline* to *inline_mode* to stay consistent with flags that change the way karafka works (#125)
 
 ## 0.5.0.1
 - Fixed inconsistency in responders non-required topic definition. Now only required: false available

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Karafka not only handles incoming messages but also provides tools for building 
         - [Parser](#parser)
         - [Interchanger](#interchanger)
         - [Responder](#responder)
-        - [Inline flag](#inline-flag)
+        - [Inline mode flag](#inline-mode-flag)
         - [Batch mode flag](#batch-mode-flag)
     - [Receiving messages](#receiving-messages)
         - [Processing messages directly (without Sidekiq)](#processing-messages-directly-without-sidekiq)
@@ -113,8 +113,8 @@ Karafka has following configuration options:
 |-------------------------------|----------|-------------------|------------------------------------------------------------------------------------------------------------|
 | name                          | true     | String            | Application name                                                                                           |
 | redis                         | true     | Hash              | Hash with Redis configuration options                                                                      |
-| inline                        | false    | Boolean           | Do we want to perform logic without enqueuing it with Sidekiq (directly and asap)                          |
-| batch_mode                    | false    | Boolean           | Should the incoming messages be consumed in batch, or one at a time                                        |
+| inline_mode                   | false    | Boolean           | Do we want to perform logic without enqueuing it with Sidekiq (directly and asap)                          |
+| batch_mode                    | false    | Boolean           | Should the incoming messages be consumed in batches, or one at a time                                      |
 | monitor                       | false    | Object            | Monitor instance (defaults to Karafka::Monitor)                                                            |
 | logger                        | false    | Object            | Logger instance (defaults to Karafka::Logger)                                                              |
 | kafka.hosts                   | false    | Array<String>     | Kafka server hosts. If 1 provided, Karafka will discover cluster structure automatically                   |
@@ -134,7 +134,7 @@ To apply this configuration, you need to use a *setup* method from the Karafka::
 class App < Karafka::App
   setup do |config|
     config.kafka.hosts = %w( 127.0.0.1:9092 )
-    config.inline = false
+    config.inline_mode = false
     config.batch_mode = false
     config.redis = {
       url: 'redis://redis.example.com:7372/1'
@@ -227,7 +227,7 @@ There are also several other methods available (optional):
   - *parser* - Class name - name of a parser class that we want to use to parse incoming data
   - *interchanger* - Class name - name of a interchanger class that we want to use to format data that we put/fetch into/from *#perform_async*
   - *responder* - Class name - name of a responder that we want to use to generate responses to other Kafka topics based on our processed data
-  - *inline* - Boolean - Do we want to perform logic without enqueuing it with Sidekiq (directly and asap) - overwrites global app setting
+  - *inline_mode* - Boolean - Do we want to perform logic without enqueuing it with Sidekiq (directly and asap) - overwrites global app setting
   - *batch_mode* - Boolean - Handle the incoming messages in batch, or one at a time - overwrites global app setting
 
 ```ruby
@@ -239,7 +239,7 @@ App.routes.draw do
     parser Parsers::BinaryToJson
     interchanger Interchangers::Binary
     responder BinaryVideoProcessingResponder
-    inline true
+    inline_mode true
     batch_mode true
   end
 
@@ -391,9 +391,9 @@ end
 
 For more details about responders, please go to the [using responders](#using-responders) section.
 
-##### Inline flag
+##### Inline mode flag
 
-Inline flag allows you to disable Sidekiq usage by performing your #perform method business logic in the main Karafka server process.
+Inline mode flag allows you to disable Sidekiq usage by performing your #perform method business logic in the main Karafka server process.
 
 This flag be useful when you want to:
 
@@ -404,10 +404,9 @@ Note: Keep in mind, that by using this, you can significantly slow down Karafka.
 
 ##### Batch mode flag
 
-Batch mode allows you to increase the overall throughput of your kafka consumer by handling incoming messages in batch, instead of one at a time.
+Batch mode allows you to increase the overall throughput of your kafka consumer by handling incoming messages in batches, instead of one at a time.
 
-Note: The downside of increasing throughput is a slight increase in latency.
-
+Note: The downside of increasing throughput is a slight increase in latency. Also keep in mind, that the client commits the offset of the batch's messages only **after** the entire batch has been scheduled into Sidekiq (or processed in case of inline mode).
 
 ### Receiving messages
 
@@ -432,7 +431,7 @@ If you don't want to use Sidekiq for processing and you would rather process mes
 ```ruby
 class App < Karafka::App
   setup do |config|
-    config.inline = true
+    config.inline_mode = true
     # Rest of the config
   end
 end
@@ -444,7 +443,7 @@ or per route (when you want to treat some routes in a different way):
 App.routes.draw do
   topic :binary_video_details do
     controller Videos::DetailsController
-    inline true
+    inline_mode true
   end
 end
 ```

--- a/lib/karafka/base_controller.rb
+++ b/lib/karafka/base_controller.rb
@@ -103,7 +103,7 @@ module Karafka
     # will schedule a perform task in sidekiq
     def schedule
       run_callbacks :schedule do
-        inline ? perform_inline : perform_async
+        inline_mode ? perform_inline : perform_async
       end
     end
 

--- a/lib/karafka/cli/info.rb
+++ b/lib/karafka/cli/info.rb
@@ -12,7 +12,8 @@ module Karafka
         info = [
           "Karafka framework version: #{Karafka::VERSION}",
           "Application name: #{config.name}",
-          "Inline mode: #{config.inline}",
+          "Inline mode: #{config.inline_mode}",
+          "Batch mode: #{config.batch_mode}",
           "Number of threads: #{config.concurrency}",
           "Boot file: #{Karafka.boot_file}",
           "Environment: #{Karafka.env}",

--- a/lib/karafka/connection/topic_consumer.rb
+++ b/lib/karafka/connection/topic_consumer.rb
@@ -61,7 +61,7 @@ module Karafka
       end
 
       # @return [Kafka] returns a Kafka
-      # @note We don't cache it internally because we cache kafka_consumer thta uses kafka
+      # @note We don't cache it internally because we cache kafka_consumer that uses kafka
       #   object instance
       def kafka
         Kafka.new(

--- a/lib/karafka/connection/topic_consumer.rb
+++ b/lib/karafka/connection/topic_consumer.rb
@@ -15,16 +15,10 @@ module Karafka
       # @yieldparam [Kafka::FetchedMessage] kafka fetched message
       # @note This will yield with a raw message - no preprocessing or reformatting
       def fetch_loop
-        if @route.batch_mode
-          kafka_consumer.each_batch do |batch|
-            batch.messages.each do |message|
-              yield(message)
-            end
-          end
-        else
-          kafka_consumer.each_message do |message|
-            yield(message)
-          end
+        send(
+          @route.batch_mode ? :consume_each_batch : :consume_each_message
+        ) do |message|
+          yield message
         end
       end
 
@@ -36,24 +30,39 @@ module Karafka
 
       private
 
+      # Consumes messages from Kafka in batches
+      # @yieldparam [Kafka::FetchedMessage] kafka fetched message
+      def consume_each_batch
+        kafka_consumer.each_batch do |batch|
+          batch.messages.each do |message|
+            yield(message)
+          end
+        end
+      end
+
+      # Consumes messages from Kafka one by one
+      # @yieldparam [Kafka::FetchedMessage] kafka fetched message
+      def consume_each_message
+        kafka_consumer.each_message do |message|
+          yield(message)
+        end
+      end
+
       # @return [Kafka::Consumer] returns a ready to consume Kafka consumer
       #   that is set up to consume a given routes topic
       def kafka_consumer
-        return @kafka_consumer if @kafka_consumer
-
-        @kafka_consumer = kafka.consumer(
+        @kafka_consumer ||= kafka.consumer(
           group_id: @route.group,
           session_timeout: ::Karafka::App.config.kafka.session_timeout,
           offset_commit_interval: ::Karafka::App.config.kafka.offset_commit_interval,
           offset_commit_threshold: ::Karafka::App.config.kafka.offset_commit_threshold,
           heartbeat_interval: ::Karafka::App.config.kafka.heartbeat_interval
-        )
-
-        @kafka_consumer.subscribe(@route.topic)
-        @kafka_consumer
+        ).tap { |consumer| consumer.subscribe(@route.topic) }
       end
 
       # @return [Kafka] returns a Kafka
+      # @note We don't cache it internally because we cache kafka_consumer thta uses kafka
+      #   object instance
       def kafka
         Kafka.new(
           seed_brokers: ::Karafka::App.config.kafka.hosts,

--- a/lib/karafka/connection/topic_consumer.rb
+++ b/lib/karafka/connection/topic_consumer.rb
@@ -15,8 +15,16 @@ module Karafka
       # @yieldparam [Kafka::FetchedMessage] kafka fetched message
       # @note This will yield with a raw message - no preprocessing or reformatting
       def fetch_loop
-        kafka_consumer.each_message do |message|
-          yield(message)
+        if @route.batch_mode
+          kafka_consumer.each_batch do |batch|
+            batch.messages.each do |message|
+              yield(message)
+            end
+          end
+        else
+          kafka_consumer.each_message do |message|
+            yield(message)
+          end
         end
       end
 

--- a/lib/karafka/connection/topic_consumer.rb
+++ b/lib/karafka/connection/topic_consumer.rb
@@ -18,7 +18,7 @@ module Karafka
         send(
           @route.batch_mode ? :consume_each_batch : :consume_each_message
         ) do |message|
-          yield message
+          yield(message)
         end
       end
 

--- a/lib/karafka/routing/builder.rb
+++ b/lib/karafka/routing/builder.rb
@@ -19,6 +19,7 @@ module Karafka
         interchanger
         responder
         inline
+        batch_mode
       ).freeze
 
       # All those options should be set on the route level

--- a/lib/karafka/routing/builder.rb
+++ b/lib/karafka/routing/builder.rb
@@ -18,7 +18,7 @@ module Karafka
         parser
         interchanger
         responder
-        inline
+        inline_mode
         batch_mode
       ).freeze
 

--- a/lib/karafka/routing/route.rb
+++ b/lib/karafka/routing/route.rb
@@ -21,7 +21,7 @@ module Karafka
         parser
         interchanger
         responder
-        inline
+        inline_mode
         batch_mode
       ).freeze
 
@@ -79,9 +79,9 @@ module Karafka
       # @return [Boolean] Should we perform execution in the background (default) or
       #   inline. This can be set globally and overwritten by a per route setting
       # @note This method can be set to false, so direct assigment ||= would not work
-      def inline
-        return @inline unless @inline.nil?
-        @inline = Karafka::App.config.inline
+      def inline_mode
+        return @inline_mode unless @inline_mode.nil?
+        @inline_mode = Karafka::App.config.inline_mode
       end
 
       # @return [Boolean] Should the consumer handle incoming events one at a time, or in batch

--- a/lib/karafka/routing/route.rb
+++ b/lib/karafka/routing/route.rb
@@ -22,6 +22,7 @@ module Karafka
         interchanger
         responder
         inline
+        batch_mode
       ).freeze
 
       ATTRIBUTES.each { |attr| attr_writer(attr) }
@@ -81,6 +82,12 @@ module Karafka
       def inline
         return @inline unless @inline.nil?
         @inline = Karafka::App.config.inline
+      end
+
+      # @return [Boolean] Should the consumer handle incoming events one at a time, or in batch
+      def batch_mode
+        return @batch_mode unless @batch_mode.nil?
+        @batch_mode = Karafka::App.config.batch_mode
       end
 
       # Checks if topic and group have proper format (acceptable by Kafka)

--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -15,8 +15,8 @@ module Karafka
       # Available settings
       # option name [String] current app name - used to provide default Kafka groups namespaces
       setting :name
-      # If inline is set to true, we won't enqueue jobs, instead we will run them immediately
-      setting :inline, false
+      # If inline_mode is set to true, we won't enqueue jobs, instead we will run them immediately
+      setting :inline_mode, false
       # option logger [Instance] logger that we want to use
       setting :logger, ::Karafka::Logger.instance
       # option monitor [Instance] monitor that we will to use (defaults to Karafka::Monitor)

--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -25,6 +25,8 @@ module Karafka
       # Note that redis could be rewriten using nested options, but it is a sidekiq specific
       # stuff and we don't want to touch it
       setting :redis
+      # If batch_mode is true, incoming messages will be handled in batch, otherwsie one at a time.
+      setting :batch_mode, false
 
       # Connection pool options are used for producer (Waterdrop)
       # They are configured automatically based on Sidekiq concurrency and number of routes

--- a/lib/karafka/templates/app.rb.example
+++ b/lib/karafka/templates/app.rb.example
@@ -13,7 +13,8 @@ class App < Karafka::App
     config.redis = {
       url: 'redis://localhost:6379'
     }
-    config.inline = false
+    config.inline_mode = false
+    config.batch_mode = false
   end
 
   routes.draw do

--- a/spec/lib/karafka/base_controller_spec.rb
+++ b/spec/lib/karafka/base_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Karafka::BaseController do
       context 'and we want to perform inline' do
         before do
           expect(base_controller)
-            .to receive(:inline)
+            .to receive(:inline_mode)
             .and_return(true)
         end
 

--- a/spec/lib/karafka/cli/info_spec.rb
+++ b/spec/lib/karafka/cli/info_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Karafka::Cli::Info do
       [
         "Karafka framework version: #{Karafka::VERSION}",
         "Application name: #{Karafka::App.config.name}",
-        "Inline mode: #{Karafka::App.config.inline}",
+        "Inline mode: #{Karafka::App.config.inline_mode}",
+        "Batch mode: #{Karafka::App.config.batch_mode}",
         "Number of threads: #{Karafka::App.config.concurrency}",
         "Boot file: #{Karafka.boot_file}",
         "Environment: #{Karafka.env}",

--- a/spec/lib/karafka/cli/routes_spec.rb
+++ b/spec/lib/karafka/cli/routes_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Karafka::Cli::Routes do
       parser
       interchanger
       responder
-      inline
+      inline_mode
       batch_mode
     ).freeze
 

--- a/spec/lib/karafka/cli/routes_spec.rb
+++ b/spec/lib/karafka/cli/routes_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Karafka::Cli::Routes do
       interchanger
       responder
       inline
+      batch_mode
     ).freeze
 
     KEYS.each do |key|

--- a/spec/lib/karafka/connection/topic_consumer_spec.rb
+++ b/spec/lib/karafka/connection/topic_consumer_spec.rb
@@ -43,12 +43,14 @@ RSpec.describe Karafka::Connection::TopicConsumer do
 
     before { topic_consumer.instance_variable_set(:'@kafka_consumer', kafka_consumer) }
 
-    it 'expect to use kafka_consumer to get messages and yield' do
-      expect(kafka_consumer).to receive(:each_message).and_yield(incoming_message)
-      expect { |block| topic_consumer.fetch_loop(&block) }.to yield_with_args(incoming_message)
+    context 'single message consumption mode' do
+      it 'expect to use kafka_consumer to get messages and yield' do
+        expect(kafka_consumer).to receive(:each_message).and_yield(incoming_message)
+        expect { |block| topic_consumer.fetch_loop(&block) }.to yield_with_args(incoming_message)
+      end
     end
 
-    context 'batch mode' do
+    context 'message batch consumption mode' do
       let(:batch_mode) { true }
       let(:incoming_batch) { instance_double(Kafka::FetchedBatch) }
       let(:incoming_messages) { [incoming_message, incoming_message] }

--- a/spec/lib/karafka/connection/topic_consumer_spec.rb
+++ b/spec/lib/karafka/connection/topic_consumer_spec.rb
@@ -1,11 +1,13 @@
 RSpec.describe Karafka::Connection::TopicConsumer do
   let(:group) { rand.to_s }
   let(:topic) { rand.to_s }
+  let(:batch_mode) { false }
   let(:route) do
     instance_double(
       Karafka::Routing::Route,
       group: group,
-      topic: topic
+      topic: topic,
+      batch_mode: batch_mode
     )
   end
 
@@ -43,7 +45,21 @@ RSpec.describe Karafka::Connection::TopicConsumer do
 
     it 'expect to use kafka_consumer to get messages and yield' do
       expect(kafka_consumer).to receive(:each_message).and_yield(incoming_message)
-      expect { |block| topic_consumer.fetch_loop(&block) }.to yield_control
+      expect { |block| topic_consumer.fetch_loop(&block) }.to yield_with_args(incoming_message)
+    end
+
+    context 'batch mode' do
+      let(:batch_mode) { true }
+      let(:incoming_batch) { instance_double(Kafka::FetchedBatch) }
+      let(:incoming_messages) { [incoming_message, incoming_message] }
+
+      it 'expect to use kafka_consumer to get messages and yield' do
+        expect(kafka_consumer).to receive(:each_batch).and_yield(incoming_batch)
+        expect(incoming_batch).to receive(:messages).and_return(incoming_messages)
+
+        expect { |block| topic_consumer.fetch_loop(&block) }
+          .to yield_successive_args(*incoming_messages)
+      end
     end
   end
 

--- a/spec/lib/karafka/routing/route_spec.rb
+++ b/spec/lib/karafka/routing/route_spec.rb
@@ -99,39 +99,39 @@ RSpec.describe Karafka::Routing::Route do
     end
   end
 
-  describe '#inline=' do
-    let(:inline) { double }
+  describe '#inline_mode=' do
+    let(:inline_mode) { double }
 
-    it { expect { route.inline = inline }.not_to raise_error }
+    it { expect { route.inline_mode = inline_mode }.not_to raise_error }
   end
 
-  describe '#inline' do
-    before { route.inline = inline }
+  describe '#inline_mode' do
+    before { route.inline_mode = inline_mode }
 
-    context 'when inline is not set' do
+    context 'when inline_mode is not set' do
       let(:default_inline) { rand }
-      let(:inline) { nil }
+      let(:inline_mode) { nil }
 
       before do
-        expect(Karafka::App.config).to receive(:inline)
+        expect(Karafka::App.config).to receive(:inline_mode)
           .and_return(default_inline)
       end
 
       it 'expect to use Karafka::App default' do
-        expect(route.inline).to eq default_inline
+        expect(route.inline_mode).to eq default_inline
       end
     end
 
-    context 'when inline per route is set to false' do
-      let(:inline) { false }
+    context 'when inline_mode per route is set to false' do
+      let(:inline_mode) { false }
 
-      it { expect(route.inline).to eq inline }
+      it { expect(route.inline_mode).to eq inline_mode }
     end
 
-    context 'when inline per route is set to true' do
-      let(:inline) { true }
+    context 'when inline_mode per route is set to true' do
+      let(:inline_mode) { true }
 
-      it { expect(route.inline).to eq inline }
+      it { expect(route.inline_mode).to eq inline_mode }
     end
   end
 

--- a/spec/lib/karafka/routing/router_spec.rb
+++ b/spec/lib/karafka/routing/router_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Karafka::Routing::Router do
     let(:inline) { [true, false].sample }
     let(:group) { rand.to_s }
     let(:controller_instance) { double }
+    let(:batch_mode) { [true, false].sample }
 
     let(:route) do
       Karafka::Routing::Route.new.tap do |route|
@@ -23,6 +24,7 @@ RSpec.describe Karafka::Routing::Router do
         route.interchanger = interchanger
         route.inline = inline
         route.group = group
+        route.batch_mode = batch_mode
       end
     end
 
@@ -62,6 +64,10 @@ RSpec.describe Karafka::Routing::Router do
       expect(controller_instance)
         .to receive(:inline=)
         .with(inline)
+
+      expect(controller_instance)
+        .to receive(:batch_mode=)
+        .with(batch_mode)
     end
 
     it 'expect to build controller with all proper options assigned' do

--- a/spec/lib/karafka/routing/router_spec.rb
+++ b/spec/lib/karafka/routing/router_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Karafka::Routing::Router do
     let(:responder) { double }
     let(:controller) { double }
     let(:interchanger) { double }
-    let(:inline) { [true, false].sample }
+    let(:inline_mode) { [true, false].sample }
     let(:group) { rand.to_s }
     let(:controller_instance) { double }
     let(:batch_mode) { [true, false].sample }
@@ -22,9 +22,9 @@ RSpec.describe Karafka::Routing::Router do
         route.worker = worker
         route.responder = responder
         route.interchanger = interchanger
-        route.inline = inline
         route.group = group
         route.batch_mode = batch_mode
+        route.inline_mode = inline_mode
       end
     end
 
@@ -62,8 +62,8 @@ RSpec.describe Karafka::Routing::Router do
         .with(responder)
 
       expect(controller_instance)
-        .to receive(:inline=)
-        .with(inline)
+        .to receive(:inline_mode=)
+        .with(inline_mode)
 
       expect(controller_instance)
         .to receive(:batch_mode=)


### PR DESCRIPTION
We started using karafka, but we've hit a wall with our throughput. By enabling the batch mode, I was able to increase 10 fold the throughput on a simple 2 partition topic.

I'm pretty sure that in production that throughput increase would significantly be more.

This PR adds the batch message consumption from ruby-kafka, as mentioned here: https://github.com/zendesk/ruby-kafka/blob/e9613b54516ca7d58894fe999ab930ab4b732d00/README.md#consuming-messages-in-batches

To enable the batch mode, you can either specify the system wide setting, or use it per topic, such as:

```
   topic :binary_video_details do
     controller Videos::DetailsController
     batch_mode true
   end
```

@mensfeld 