### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -863,6 +863,8 @@ ENV['RACK_ENV'] ||= 'development'
 ENV['KARAFKA_ENV'] = ENV['RACK_ENV']
 
 Bundler.require(:default, ENV['KARAFKA_ENV'])
+
+Karafka::Loader.new.load(Karafka::App.root)
 ```
 
 with


### PR DESCRIPTION
When integrating with a rails app the Karafka::Loader must be
removed since the loading of rails env does the same thing and
the first one interferes with the other.

This was producing a runtime error while loading the Rails env.

```
bundler: failed to load command: karafka (/usr/local/bundle/bin/karafka)
 RuntimeError: can't modify frozen Array
   /usr/local/bundle/gems/actionpack-5.0.2/lib/action_dispatch/middleware/stack.rb:74:in `insert'
   /usr/local/bundle/gems/actionpack-5.0.2/lib/action_dispatch/middleware/stack.rb:74:in `insert'
   /app/config/initializers/cors.rb:8:in `<top (required)>'
   /usr/local/bundle/gems/activesupport-5.0.2/lib/active_support/dependencies.rb:293:in `require'
   /usr/local/bundle/gems/activesupport-5.0.2/lib/active_support/dependencies.rb:293:in `block in require'
   /usr/local/bundle/gems/activesupport-5.0.2/lib/active_support/dependencies.rb:259:in `load_dependency'
   /usr/local/bundle/gems/activesupport-5.0.2/lib/active_support/dependencies.rb:293:in `require'
   /usr/local/bundle/gems/karafka-0.5.0.2/lib/karafka/loader.rb:65:in `each'
   /usr/local/bundle/gems/karafka-0.5.0.2/lib/karafka/loader.rb:65:in `files_load!'
   /usr/local/bundle/gems/karafka-0.5.0.2/lib/karafka/loader.rb:39:in `load!'
   /usr/local/bundle/gems/karafka-0.5.0.2/lib/karafka/loader.rb:30:in `block in load'
   /usr/local/bundle/gems/karafka-0.5.0.2/lib/karafka/loader.rb:28:in `each'
   /usr/local/bundle/gems/karafka-0.5.0.2/lib/karafka/loader.rb:28:in `load'
   /app/app.rb:4:in `<top (required)>'
   /usr/local/bundle/gems/karafka-0.5.0.2/bin/karafka:4:in `require'
   /usr/local/bundle/gems/karafka-0.5.0.2/bin/karafka:4:in `<top (required)>'
   /usr/local/bundle/bin/karafka:17:in `load'
   /usr/local/bundle/bin/karafka:17:in `<top (required)>'
```