### PR TITLE
Handle SIGTERM as a shutdown command for kafka server to support Heroku deployment

### DIFF
--- a/lib/karafka/process.rb
+++ b/lib/karafka/process.rb
@@ -6,7 +6,7 @@ module Karafka
 
     # Signal types that we handle
     HANDLED_SIGNALS = %i(
-      SIGINT SIGQUIT
+      SIGINT SIGQUIT SIGTERM
     ).freeze
 
     HANDLED_SIGNALS.each do |signal|

--- a/lib/karafka/server.rb
+++ b/lib/karafka/server.rb
@@ -11,6 +11,7 @@ module Karafka
         @consumers = Concurrent::Array.new
         bind_on_sigint
         bind_on_sigquit
+        bind_on_sigterm
         start_supervised
       end
 
@@ -33,6 +34,15 @@ module Karafka
       # What should happen when we decide to quit with sigquit
       def bind_on_sigquit
         process.on_sigquit do
+          Karafka::App.stop!
+          consumers.map(&:stop)
+          exit
+        end
+      end
+
+      # What should happen when we decide to quit with sigterm
+      def bind_on_sigterm
+        process.on_sigterm do
           Karafka::App.stop!
           consumers.map(&:stop)
           exit

--- a/spec/lib/karafka/server_spec.rb
+++ b/spec/lib/karafka/server_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Karafka::Server do
       expect(Karafka::Process.instance).to receive(:supervise).and_yield
       expect(Karafka::Process.instance).to receive(:on_sigint)
       expect(Karafka::Process.instance).to receive(:on_sigquit)
+      expect(Karafka::Process.instance).to receive(:on_sigterm)
 
       server_class.run
     end
@@ -19,6 +20,7 @@ RSpec.describe Karafka::Server do
       expect(Karafka::Process.instance).to receive(:supervise)
       expect(Karafka::Process.instance).to receive(:on_sigint).and_yield
       expect(Karafka::Process.instance).to receive(:on_sigquit)
+      expect(Karafka::Process.instance).to receive(:on_sigterm)
       expect(Karafka::App).to receive(:stop!)
       expect(server_class).to receive(:exit)
 
@@ -29,6 +31,18 @@ RSpec.describe Karafka::Server do
       expect(Karafka::Process.instance).to receive(:supervise)
       expect(Karafka::Process.instance).to receive(:on_sigint)
       expect(Karafka::Process.instance).to receive(:on_sigquit).and_yield
+      expect(Karafka::Process.instance).to receive(:on_sigterm)
+      expect(Karafka::App).to receive(:stop!)
+      expect(server_class).to receive(:exit)
+
+      server_class.run
+    end
+
+    it 'defines a proper action for sigterm' do
+      expect(Karafka::Process.instance).to receive(:supervise)
+      expect(Karafka::Process.instance).to receive(:on_sigint)
+      expect(Karafka::Process.instance).to receive(:on_sigquit)
+      expect(Karafka::Process.instance).to receive(:on_sigterm).and_yield
       expect(Karafka::App).to receive(:stop!)
       expect(server_class).to receive(:exit)
 


### PR DESCRIPTION
We use Karafka with Heroku Kafka and noticed that Kafka Server does not properly shut down on Heroku because SIGTERM is used instead of SIGQUIT or SIGINT. This PR simply adds support for SIGTERM as well.