### PR TITLE
Allow karafka root to be specified from ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ There are several env settings you can use:
 |-------------------|-----------------|-------------------------------------------------------------------------------|
 | KARAFKA_ENV       | development     | In what mode this application should boot (production/development/test/etc)   |
 | KARAFKA_BOOT_FILE | app_root/app.rb | Path to a file that contains Karafka app configuration and booting procedures |
+| KARAFKA_ROOT_DIR  | Gemfile location| Path to Karafka's root directory                                              |
 
 ### Kafka brokers auto-discovery
 

--- a/lib/karafka.rb
+++ b/lib/karafka.rb
@@ -49,7 +49,7 @@ module Karafka
 
     # @return [String] Karafka app root path (user application path)
     def root
-      Pathname.new(File.dirname(ENV['BUNDLE_GEMFILE']))
+      Pathname.new(ENV['KARAFKA_ROOT_DIR'] || File.dirname(ENV['BUNDLE_GEMFILE']))
     end
 
     # @return [String] path to Karafka gem root core

--- a/spec/lib/karafka_spec.rb
+++ b/spec/lib/karafka_spec.rb
@@ -22,11 +22,20 @@ RSpec.describe Karafka do
 
   describe '.root' do
     context 'when we want to get app root path' do
-      before do
-        expect(ENV).to receive(:[]).with('BUNDLE_GEMFILE').and_return('/')
+      let(:root_dir_env) { nil }
+
+      before { expect(ENV).to receive(:[]).with('KARAFKA_ROOT_DIR').and_return(root_dir_env) }
+
+      it do
+        expect(ENV).to receive(:[]).with('BUNDLE_GEMFILE').and_return('/Gemfile')
+        expect(karafka.root.to_path).to eq '/'
       end
 
-      it { expect(karafka.root.to_path).to eq '/' }
+      context 'when KARAFKA_ROOT_DIR is specified' do
+        let(:root_dir_env) { './karafka_dir' }
+
+        it { expect(karafka.root.to_path).to eq './karafka_dir' }
+      end
     end
   end
 


### PR DESCRIPTION
Allow using `ENV['KARAFKA_ROOT_DIR']` to specify the root directory for Karafka. We use this so we can have all of our Karafka classes and logic in a subdirectory of a parent Rails app, but still share the same Gemfile. The Rails app can then be loaded without Karafka's classes and dependencies.