### PR TITLE
Link to contributors directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ to check if everything is in order. After that you can submit a pull request.
 ## Contributors
 
 This project exists thanks to all the people who contribute. [[Contribute]](CONTRIBUTING.md).
-<a href="graphs/contributors"><img src="https://opencollective.com/karafka/contributors.svg?width=890" /></a>
+<a href="https://github.com/karafka/karafka/graphs/contributors"><img src="https://opencollective.com/karafka/contributors.svg?width=890" /></a>
 
 
 ## Backers


### PR DESCRIPTION
AS IS: The contributions section is using a relative path and is not properly linked to github's contributors page.

TO BE: The contributors section is using an absolute path and is properly linked to github's contributors page.