### PR TITLE
add support for ruby-kafka `ssl_ca_cert_file_path` config

### DIFF
--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -103,6 +103,9 @@ module Karafka
         # waiting for new messages to arrive in a partition, so don't set this value too low
         setting :socket_timeout, 10
         # SSL authentication related settings
+        # option ssl_ca_cert_file_path [String] SSL CA certificate file path
+        setting :ssl_ca_cert_file_path, nil
+        # SSL authentication related settings
         # option ca_cert [String] SSL CA certificate
         setting :ssl_ca_cert, nil
         # option client_cert [String] SSL client certificate


### PR DESCRIPTION
See #186 

The ability to load the ca cert from a file is required to support Heroku Kafka due to a change they are rolling out where multiple ca certs may be present on the brokers. Also see: https://devcenter.heroku.com/articles/ca-cert-rotation-kafka