### PR TITLE
fix [#196] incorrect subscriptions are created when topic mapper is used

### DIFF
--- a/lib/karafka/connection/config_adapter.rb
+++ b/lib/karafka/connection/config_adapter.rb
@@ -80,7 +80,7 @@ module Karafka
             settings[setting_name] = setting_value
           end
 
-          [topic.name, sanitize(settings)]
+          [Karafka::App.config.topic_mapper.outgoing(topic.name), sanitize(settings)]
         end
 
         private

--- a/lib/karafka/connection/messages_processor.rb
+++ b/lib/karafka/connection/messages_processor.rb
@@ -24,7 +24,7 @@ module Karafka
           controller = Karafka::Routing::Router.build("#{group_id}_#{mapped_topic}")
           handler = controller.topic.batch_processing ? :process_batch : :process_each
 
-          send(handler, controller, mapped_topic, kafka_messages)
+          send(handler, controller, kafka_messages)
           # This is on purpose - see the notes for this method
           # rubocop:disable RescueException
         rescue Exception => e
@@ -38,21 +38,9 @@ module Karafka
         # @param controller [Karafka::BaseController] base controller descendant
         # @param mapped_topic [String] mapped topic name
         # @param kafka_messages [Array<Kafka::FetchedMessage>] raw messages from kafka
-        def process_batch(controller, mapped_topic, kafka_messages)
-          messages_batch = kafka_messages.map do |kafka_message|
-            # Since we support topic mapping (for Kafka providers that require namespaces)
-            # we have to overwrite topic with our mapped topic version
-            # @note For the default mapper, it will be the same as topic
-            # @note We have to use instance_variable_set, as the Kafka::FetchedMessage does not
-            #   provide attribute writers
-            kafka_message.instance_variable_set(:'@topic', mapped_topic)
-            kafka_message
-          end
-
-          controller.params_batch = messages_batch
-
-          Karafka.monitor.notice(self, messages_batch)
-
+        def process_batch(controller, kafka_messages)
+          controller.params_batch = kafka_messages
+          Karafka.monitor.notice(self, kafka_messages)
           controller.schedule
         end
 
@@ -60,12 +48,12 @@ module Karafka
         # @param controller [Karafka::BaseController] base controller descendant
         # @param mapped_topic [String] mapped topic name
         # @param kafka_messages [Array<Kafka::FetchedMessage>] raw messages from kafka
-        def process_each(controller, mapped_topic, kafka_messages)
+        def process_each(controller, kafka_messages)
           kafka_messages.each do |kafka_message|
             # @note This is a simple trick - we just process one after another, but in order
             # not to handle everywhere both cases (single vs batch), we just "fake" batching with
             # a single message for each
-            process_batch(controller, mapped_topic, [kafka_message])
+            process_batch(controller, [kafka_message])
           end
         end
       end

--- a/spec/lib/karafka/connection/config_adapter_spec.rb
+++ b/spec/lib/karafka/connection/config_adapter_spec.rb
@@ -82,5 +82,23 @@ RSpec.describe Karafka::Connection::ConfigAdapter do
     end
 
     it { expect(config.first).to eq consumer_group.topics.first.name }
+
+    context 'with a custom topic mapper' do
+      let(:custom_mapper) do
+        ClassBuilder.build do
+          def self.outgoing(topic)
+            "prefix.#{topic}"
+          end
+        end
+      end
+
+      before do
+        expect(Karafka::App.config)
+          .to receive(:topic_mapper)
+                .and_return(custom_mapper)
+      end
+
+      it { expect(config.first).to eq custom_mapper.outgoing(consumer_group.topics.first.name) }
+    end
   end
 end

--- a/spec/lib/karafka/connection/messages_processor_spec.rb
+++ b/spec/lib/karafka/connection/messages_processor_spec.rb
@@ -64,15 +64,15 @@ RSpec.describe Karafka::Connection::MessagesProcessor do
         before do
           expect(Karafka::App.config)
             .to receive(:topic_mapper)
-            .and_return(custom_mapper)
+                  .and_return(custom_mapper)
 
           expect(Karafka::Routing::Router)
             .to receive(:build)
-            .and_return(controller_instance)
+                  .and_return(controller_instance)
 
           expect(controller_instance)
             .to receive(:params_batch=)
-            .with([raw_message1, raw_message2])
+                  .with([raw_message1, raw_message2])
 
           expect(controller_instance)
             .to receive(:schedule)
@@ -80,12 +80,6 @@ RSpec.describe Karafka::Connection::MessagesProcessor do
 
         it 'routes to a proper controller and schedule task' do
           expect { processor.process(group_id, messages_batch) }.not_to raise_error
-        end
-
-        it 'expect to replace topic with mapped one on kafka fetched messages' do
-          processor.process(group_id, messages_batch)
-          expect(raw_message1.topic).to eq mapped_topic
-          expect(raw_message2.topic).to eq mapped_topic
         end
       end
 


### PR DESCRIPTION
fixes [#196]

In the below situation, karafka will now correctly subscribe to `staging_my_topic`. Also fixes an issue where when a topic mapper is in place the `@topic` instance variable on the message would get replaced, leading to the message to be processed over and over as it would never be committed as read.

```
# topic_mapper.rb
module StagingTopicMapper
    PREFIX = 'staging_'

    def self.incoming(topic)
      topic.to_s.gsub(PREFIX, '')
    end

    def self.outgoing(topic)
      "#{PREFIX}#{topic}"
    end
  end
```

```
  # app.rb
  consumer_groups.draw do
      topic :my_topic
    end
```