### PR TITLE
check RUBY_ENGINE constant if RUBY_VERSION is missing

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,7 @@ end
 
 # @return [Boolean] true if we run against jruby
 def jruby?
-  ENV['RUBY_VERSION'].include?('jruby')
+  (ENV['RUBY_VERSION'] || RUBY_ENGINE).include?('jruby')
 end
 
 # Don't include unnecessary stuff into rcov


### PR DESCRIPTION
`spec_helper.rb` checks for `RUBY_VERSION` environment variable.

Perhaps it could fall back to `RUBY_VERSION` constant for `jruby?` check?