### PR TITLE
add configuration setting to control Celluloid's shutdown timeout

### DIFF
--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -125,6 +125,13 @@ module Karafka
         setting :sasl_plain_password, nil
       end
 
+      # option celluloid [Hash] - optional - celluloid configuration options
+      setting :celluloid do
+        # options shutdown_timeout [Integer] How many seconds should we wait for actors (listeners)
+        # before forcefully shutting them
+        setting :shutdown_timeout, 30
+      end
+
       # This is configured automatically, don't overwrite it!
       # Each consumer group requires separate thread, so number of threads should be equal to
       # number of consumer groups

--- a/lib/karafka/setup/configurators/celluloid.rb
+++ b/lib/karafka/setup/configurators/celluloid.rb
@@ -5,16 +5,13 @@ module Karafka
     class Configurators
       # Class responsible for setting up Celluloid settings
       class Celluloid < Base
-        # How many seconds should we wait for actors (listeners) before forcefully shutting them
-        SHUTDOWN_TIME = 30
-
         # Sets up a Karafka logger as celluloid logger
         def setup
           ::Celluloid.logger = ::Karafka.logger
           # This is just a precaution - it should automatically close the current
           # connection and shutdown actor - but in case it didn't (hanged, etc)
           # we will kill it after waiting for some time
-          ::Celluloid.shutdown_timeout = SHUTDOWN_TIME
+          ::Celluloid.shutdown_timeout = ::Karafka::App.config.celluloid.shutdown_timeout
         end
       end
     end

--- a/spec/lib/karafka/setup/configurators/celluloid_spec.rb
+++ b/spec/lib/karafka/setup/configurators/celluloid_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Karafka::Setup::Configurators::Celluloid do
   specify { expect(described_class).to be < Karafka::Setup::Configurators::Base }
 
   describe '#setup' do
-    let(:shutdown_timeout) { Karafka::Setup::Configurators::Celluloid::SHUTDOWN_TIME }
+    let(:shutdown_timeout) { ::Karafka::App.config.celluloid.shutdown_timeout }
 
     it 'expect to assign Karafka logger to Celluloid and set a shutdown_timeout' do
       expect(Celluloid).to receive(:logger=).with(Karafka.logger)


### PR DESCRIPTION
At times our consumers take longer than default 30 seconds to process a batch of messages. We'd like to extend the default shutdown period (just like we have extended termination period for docker containers running these consumers).

Not sure if that should to be scoped by `celluloid`, but here goes.