### PR TITLE
Make waterdrop send_messages and raise_on_failure configurable

### DIFF
--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -47,6 +47,10 @@ module Karafka
       # incoming batch. It's disabled by default, not to create more objects that needed on
       # each batch
       setting :persistent, true
+      # Boolean value to define whether messages should be sent
+      setting :send_messages, true
+      # Boolean value to define if it should raise error when failed to deliver a message
+      setting :raise_on_failure, true
       # This is configured automatically, don't overwrite it!
       # Each consumer group requires separate thread, so number of threads should be equal to
       # number of consumer groups

--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -47,10 +47,6 @@ module Karafka
       # incoming batch. It's disabled by default, not to create more objects that needed on
       # each batch
       setting :persistent, true
-      # Boolean value to define whether messages should be sent
-      setting :send_messages, true
-      # Boolean value to define if it should raise error when failed to deliver a message
-      setting :raise_on_failure, true
       # This is configured automatically, don't overwrite it!
       # Each consumer group requires separate thread, so number of threads should be equal to
       # number of consumer groups
@@ -73,6 +69,14 @@ module Karafka
         # How long should we wait for a working resource from the pool before rising timeout
         # With a proper connection pool size, this should never happen
         setting :timeout, 5
+      end
+
+      # option producer [Hash] - optional - WaterDrop configuration options
+      setting :producer do
+        # Boolean value to define whether messages should be sent
+        setting :send_messages, true
+        # Boolean value to define if it should raise error when failed to deliver a message
+        setting :raise_on_failure, true
       end
 
       # option kafka [Hash] - optional - kafka configuration options

--- a/lib/karafka/setup/configurators/water_drop.rb
+++ b/lib/karafka/setup/configurators/water_drop.rb
@@ -10,8 +10,8 @@ module Karafka
           dynamic_params = Connection::ConfigAdapter.client(nil)
 
           ::WaterDrop.setup do |water_config|
-            water_config.send_messages = true
-            water_config.raise_on_failure = true
+            water_config.send_messages = config.send_messages
+            water_config.raise_on_failure = config.raise_on_failure
             water_config.connection_pool = config.connection_pool
 
             # Automigration of all the attributes that should be accepted by waterdrop

--- a/lib/karafka/setup/configurators/water_drop.rb
+++ b/lib/karafka/setup/configurators/water_drop.rb
@@ -10,8 +10,8 @@ module Karafka
           dynamic_params = Connection::ConfigAdapter.client(nil)
 
           ::WaterDrop.setup do |water_config|
-            water_config.send_messages = config.send_messages
-            water_config.raise_on_failure = config.raise_on_failure
+            water_config.send_messages = config.producer.send_messages
+            water_config.raise_on_failure = config.producer.raise_on_failure
             water_config.connection_pool = config.connection_pool
 
             # Automigration of all the attributes that should be accepted by waterdrop

--- a/spec/lib/karafka/setup/configurators/water_drop_spec.rb
+++ b/spec/lib/karafka/setup/configurators/water_drop_spec.rb
@@ -10,8 +10,10 @@ RSpec.describe Karafka::Setup::Configurators::WaterDrop do
       kafka: OpenStruct.new(
         seed_brokers: ::Karafka::App.config.kafka.seed_brokers
       ),
-      send_messages: ::Karafka::App.config.send_messages,
-      raise_on_failure: ::Karafka::App.config.raise_on_failure,
+      producer: OpenStruct.new(
+        send_messages: ::Karafka::App.config.producer.send_messages,
+        raise_on_failure: ::Karafka::App.config.producer.raise_on_failure
+      ),
       # Instance double has a private method called timeout, that's why we use
       # openstruct here
       connection_pool: OpenStruct.new(
@@ -26,11 +28,11 @@ RSpec.describe Karafka::Setup::Configurators::WaterDrop do
   describe '#setup' do
     before { water_drop_configurator.setup }
 
-    it { expect(WaterDrop.config.send_messages).to eq config.send_messages }
+    it { expect(WaterDrop.config.send_messages).to eq config.producer.send_messages }
     it { expect(WaterDrop.config.connection_pool.size).to eq config.connection_pool.size }
     it { expect(WaterDrop.config.connection_pool.timeout).to eq config.connection_pool.timeout }
     it { expect(WaterDrop.config.kafka.seed_brokers).to eq config.kafka.seed_brokers }
     it { expect(WaterDrop.config.logger).to eq Karafka::App.logger }
-    it { expect(WaterDrop.config.raise_on_failure).to eq config.raise_on_failure }
+    it { expect(WaterDrop.config.raise_on_failure).to eq config.producer.raise_on_failure }
   end
 end

--- a/spec/lib/karafka/setup/configurators/water_drop_spec.rb
+++ b/spec/lib/karafka/setup/configurators/water_drop_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Karafka::Setup::Configurators::WaterDrop do
       kafka: OpenStruct.new(
         seed_brokers: ::Karafka::App.config.kafka.seed_brokers
       ),
+      send_messages: ::Karafka::App.config.send_messages,
+      raise_on_failure: ::Karafka::App.config.raise_on_failure,
       # Instance double has a private method called timeout, that's why we use
       # openstruct here
       connection_pool: OpenStruct.new(
@@ -24,11 +26,11 @@ RSpec.describe Karafka::Setup::Configurators::WaterDrop do
   describe '#setup' do
     before { water_drop_configurator.setup }
 
-    it { expect(WaterDrop.config.send_messages).to eq true }
+    it { expect(WaterDrop.config.send_messages).to eq config.send_messages }
     it { expect(WaterDrop.config.connection_pool.size).to eq config.connection_pool.size }
     it { expect(WaterDrop.config.connection_pool.timeout).to eq config.connection_pool.timeout }
     it { expect(WaterDrop.config.kafka.seed_brokers).to eq config.kafka.seed_brokers }
     it { expect(WaterDrop.config.logger).to eq Karafka::App.logger }
-    it { expect(WaterDrop.config.raise_on_failure).to eq true }
+    it { expect(WaterDrop.config.raise_on_failure).to eq config.raise_on_failure }
   end
 end


### PR DESCRIPTION
### Issue
- https://github.com/karafka/karafka/issues/225

### Fix
- Define new settings inside `Karafka::Setup::Config`
- Use the settings from `config` object inside `Karafka::Setup::Configurators`