### PR TITLE
Typo in docstring for Karafka::Patches::RubyKafka

### DIFF
--- a/lib/karafka/patches/ruby_kafka.rb
+++ b/lib/karafka/patches/ruby_kafka.rb
@@ -2,7 +2,7 @@
 
 module Karafka
   module Patches
-    # Batches for Ruby Kafka gem
+    # Patches for Ruby Kafka gem
     module RubyKafka
       # This patch allows us to inject business logic in between fetches and before the consumer
       # stop, so we can perform stop commit or anything else that we need since


### PR DESCRIPTION
Assumedly `Patches` was the intended word here