### PR TITLE
Divide mark_as_consumed into mark_as_consumed and mark_as_consumed!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - #341 - Split connection delegator into batch delegator and single_delegator
 - #351 - Rename `#retrieve!` to `#parse!` on params and `#parsed` to `parse!` on params batch.
 - #351 - Adds '#first' for params_batch that returns parsed first element from the params_batch object.
-- #359 - Divide mark_as_consumed into mark_and_consumed and mark_as_consumed!
+- #359 - Divide mark_as_consumed into mark_as_consumed and mark_as_consumed!
 
 ## 1.2.4
 - #332 - Fetcher for max queue size

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - #341 - Split connection delegator into batch delegator and single_delegator
 - #351 - Rename `#retrieve!` to `#parse!` on params and `#parsed` to `parse!` on params batch.
 - #351 - Adds '#first' for params_batch that returns parsed first element from the params_batch object.
+- #359 - Divide mark_as_consumed into mark_and_consumed and mark_as_consumed!
 
 ## 1.2.4
 - #332 - Fetcher for max queue size

--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -10,9 +10,14 @@ module Karafka
     # Allows us to mark messages as consumed for non-automatic mode without having
     # to use consumer client directly. We do this that way, because most of the people should not
     # mess with the client instance directly (just in case)
-    def_delegator :client, :mark_as_consumed
+    %i[
+      mark_as_consumed
+      mark_as_consumed!
+    ].each do |delegated_method_name|
+      def_delegator :client, delegated_method_name
 
-    private :mark_as_consumed
+      private delegated_method_name
+    end
 
     class << self
       attr_reader :topic

--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -69,14 +69,22 @@ module Karafka
         kafka_consumer.pause(*ApiAdapter.pause(topic, partition, consumer_group))
       end
 
-      # Marks a given message as consumed and commit the offsets
-      # @note In opposite to ruby-kafka, we commit the offset for each manual marking to be sure
-      #   that offset commit happen asap in case of a crash
+      # Marks given message as consumed
+      # @note This method won't trigger automatic offsets commits, rather relying on the ruby-kafka
+      #   offsets time-interval based committing
       # @param [Karafka::Params::Params] params message that we want to mark as processed
       def mark_as_consumed(params)
         kafka_consumer.mark_message_as_processed(
           *ApiAdapter.mark_message_as_processed(params)
         )
+      end
+
+      # Marks a given message as consumed and commit the offsets in a blocking way
+      # @note This method commits the offset for each manual marking to be sure
+      #   that offset commit happen asap in case of a crash
+      # @param [Karafka::Params::Params] params message that we want to mark as processed
+      def mark_as_consumed!(params)
+        mark_as_consumed(params)
         # Trigger an immediate, blocking offset commit in order to minimize the risk of crashing
         # before the automatic triggers have kicked in.
         kafka_consumer.commit_offsets

--- a/spec/lib/karafka/base_consumer_spec.rb
+++ b/spec/lib/karafka/base_consumer_spec.rb
@@ -105,4 +105,16 @@ RSpec.describe Karafka::BaseConsumer do
       base_consumer.send(:mark_as_consumed, params)
     end
   end
+
+  describe '#mark_as_consumed!' do
+    let(:client) { instance_double(Karafka::Connection::Client) }
+    let(:params) { instance_double(Karafka::Params::Params) }
+
+    before { Karafka::Persistence::Client.write(client) }
+
+    it 'expect to proxy pass to client' do
+      expect(client).to receive(:mark_as_consumed!).with(params)
+      base_consumer.send(:mark_as_consumed!, params)
+    end
+  end
 end

--- a/spec/lib/karafka/connection/client_spec.rb
+++ b/spec/lib/karafka/connection/client_spec.rb
@@ -141,10 +141,22 @@ RSpec.describe Karafka::Connection::Client do
 
     before { client.instance_variable_set(:'@kafka_consumer', kafka_consumer) }
 
+    it 'expect to forward to mark_message_as_processed and not to commit offsets' do
+      expect(kafka_consumer).to receive(:mark_message_as_processed).with(params)
+      expect(kafka_consumer).not_to receive(:commit_offsets)
+      client.mark_as_consumed(params)
+    end
+  end
+
+  describe '#mark_as_consumed!' do
+    let(:params) { instance_double(Karafka::Params::Params) }
+
+    before { client.instance_variable_set(:'@kafka_consumer', kafka_consumer) }
+
     it 'expect to forward to mark_message_as_processed and commit offsets' do
       expect(kafka_consumer).to receive(:mark_message_as_processed).with(params)
       expect(kafka_consumer).to receive(:commit_offsets)
-      client.mark_as_consumed(params)
+      client.mark_as_consumed!(params)
     end
   end
 


### PR DESCRIPTION
closes #359 

Allows to mark as consumed faster without triggering the blocking call to kafka for offset commits.