### PR TITLE
Too shallow ruby-kafka version lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - #341 - Split connection delegator into batch delegator and single_delegator
 - #351 - Rename `#retrieve!` to `#parse!` on params and `#parsed` to `parse!` on params batch.
 - #351 - Adds '#first' for params_batch that returns parsed first element from the params_batch object.
+- #363 - Too shallow ruby-kafka version lock
 
 ## 1.2.4
 - #332 - Fetcher for max queue size

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
       multi_json (>= 1.12)
       rake (>= 11.3)
       require_all (>= 1.4)
-      ruby-kafka (>= 0.5.3)
+      ruby-kafka (>= 0.6.3)
       thor (~> 0.19)
       waterdrop (~> 1.2)
 

--- a/karafka.gemspec
+++ b/karafka.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multi_json', '>= 1.12'
   spec.add_dependency 'rake', '>= 11.3'
   spec.add_dependency 'require_all', '>= 1.4'
-  spec.add_dependency 'ruby-kafka', '>= 0.5.3'
+  spec.add_dependency 'ruby-kafka', '>= 0.6.3'
   spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'waterdrop', '~> 1.2'
 


### PR DESCRIPTION
closes #363 