### PR TITLE
Remove persistence in favor of persisting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - #356 - Provide a `#values` for params_batch to extract only values of objects from the params_batch
 - #363 - Too shallow ruby-kafka version lock
 - #354 - Expose consumer heartbeat
+- #377 - Remove the persistent setup in favor of persistence
 
 ## 1.2.5
 - #354 - Expose consumer heartbeat

--- a/lib/karafka/attributes_map.rb
+++ b/lib/karafka/attributes_map.rb
@@ -38,7 +38,6 @@ module Karafka
           parser
           responder
           batch_consuming
-          persistent
         ]).uniq
       end
 

--- a/lib/karafka/persistence/consumer.rb
+++ b/lib/karafka/persistence/consumer.rb
@@ -25,12 +25,7 @@ module Karafka
         # @param topic [Karafka::Routing::Topic] topic instance for which we might cache
         # @param partition [Integer] number of partition for which we want to cache
         def fetch(topic, partition)
-          # We always store a current instance for callback reasons
-          if topic.persistent
-            all[topic][partition] ||= topic.consumer.new
-          else
-            all[topic][partition] = topic.consumer.new
-          end
+          all[topic][partition] ||= topic.consumer.new
         end
       end
     end

--- a/lib/karafka/schemas/consumer_group_topic.rb
+++ b/lib/karafka/schemas/consumer_group_topic.rb
@@ -12,7 +12,6 @@ module Karafka
       required(:max_bytes_per_partition).filled(:int?, gteq?: 0)
       required(:start_from_beginning).filled(:bool?)
       required(:batch_consuming).filled(:bool?)
-      required(:persistent).filled(:bool?)
     end
   end
 end

--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -43,12 +43,6 @@ module Karafka
       # #params_batch will contain params received from Kafka (may be more than 1) so we can
       # process them in batches
       setting :batch_consuming, false
-      # Should we operate in a single consumer instance across multiple batches of messages,
-      # from the same partition or should we build a new one for each incoming batch.
-      # Disabling that can be useful when you want to create a new consumer instance for each
-      # incoming batch. It's disabled by default, not to create more objects that needed
-      # on each batch
-      setting :persistent, true
       # option shutdown_timeout [Integer, nil] the number of seconds after which Karafka no
       #   longer wait for the consumers to stop gracefully but instead we force
       #   terminate everything.

--- a/spec/lib/karafka/connection/batch_delegator_spec.rb
+++ b/spec/lib/karafka/connection/batch_delegator_spec.rb
@@ -60,7 +60,6 @@ RSpec.describe Karafka::Connection::BatchDelegator do
       Karafka::Routing::Builder.instance.draw do
         topic :topic_name1 do
           consumer Class.new(Karafka::BaseConsumer)
-          persistent false
           batch_consuming true
         end
       end
@@ -84,7 +83,6 @@ RSpec.describe Karafka::Connection::BatchDelegator do
       Karafka::Routing::Builder.instance.draw do
         topic :topic_name1 do
           consumer Class.new(Karafka::BaseConsumer)
-          persistent false
           batch_consuming false
         end
       end

--- a/spec/lib/karafka/connection/message_delegator_spec.rb
+++ b/spec/lib/karafka/connection/message_delegator_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe Karafka::Connection::MessageDelegator do
     Karafka::Routing::Builder.instance.draw do
       topic :topic_name1 do
         consumer Class.new(Karafka::BaseConsumer)
-        persistent false
       end
     end
 

--- a/spec/lib/karafka/patches/ruby_kafka_spec.rb
+++ b/spec/lib/karafka/patches/ruby_kafka_spec.rb
@@ -18,11 +18,11 @@ RSpec.describe Karafka::Patches::RubyKafka do
 
   describe '#consumer_loop' do
     let(:client) { instance_double(Karafka::Connection::Client, stop: true) }
-    let(:topic) { instance_double(Karafka::Routing::Topic, id: rand.to_s, persistent: false) }
+    let(:topic) { instance_double(Karafka::Routing::Topic, id: rand.to_s) }
 
     let(:consumer_instance) do
       Karafka::Persistence::Consumer.fetch(
-        instance_double(Karafka::Routing::Topic, consumer: consumer, persistent: true),
+        instance_double(Karafka::Routing::Topic, consumer: consumer),
         0
       )
     end

--- a/spec/lib/karafka/persistence/consumer_spec.rb
+++ b/spec/lib/karafka/persistence/consumer_spec.rb
@@ -9,28 +9,14 @@ RSpec.describe Karafka::Persistence::Consumer do
     let(:topic) do
       instance_double(
         Karafka::Routing::Topic,
-        persistent: persistent,
         id: topic_id,
         consumer: Karafka::BaseConsumer
       )
     end
 
-    context 'when persistence is disabled' do
-      let(:persistent) { false }
-
-      it 'expect not to cache it' do
-        r1 = persistence.fetch(topic, partition)
-        expect(r1).not_to eq persistence.fetch(topic, partition)
-      end
-    end
-
-    context 'when persistence is enabled' do
-      let(:persistent) { true }
-
-      it 'expect to cache it' do
-        r1 = persistence.fetch(topic, partition)
-        expect(r1).to eq persistence.fetch(topic, partition)
-      end
+    it 'expect to cache it' do
+      r1 = persistence.fetch(topic, partition)
+      expect(r1).to eq persistence.fetch(topic, partition)
     end
   end
 end

--- a/spec/lib/karafka/routing/router_spec.rb
+++ b/spec/lib/karafka/routing/router_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Karafka::Routing::Router do
     Karafka::Routing::Builder.instance.draw do
       topic :topic_name1 do
         consumer Class.new(Karafka::BaseConsumer)
-        persistent false
         batch_consuming true
       end
     end


### PR DESCRIPTION
This will allow us to optimize how consumers are being built and pre heat everything.

It will also simplify a bit the codebase and allow further steps towards Ruby 3.0 support.