### PR TITLE
Allow exceptions to propagate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Message bus unification
 - Parser available in metadata
 - Cleanup towards moving to a non-global state app management
+- Critical exceptions now will cause consumer to stop instead of retrying without a break
 - #388 - ssl_client_cert_chain sync
 - #300 - Store value in a value key and replace its content with parsed version - without root merge
 - #331 - Disallow building groups without topics

--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -37,6 +37,8 @@ module Karafka
         else
           kafka_consumer.each_message(*settings) { |message| yield(message, :message) }
         end
+      # @note We catch only the processing errors as any other are considered critical (exceptions)
+      #   and should require a client restart with a backoff
       rescue Kafka::ProcessingError => error
         # If there was an error during consumption, we have to log it, pause current partition
         # and process other things
@@ -46,16 +48,6 @@ module Karafka
           error: error.cause
         )
         pause(error.topic, error.partition)
-        retry
-        # This is on purpose - see the notes for this method
-        # rubocop:disable RescueException
-      rescue Exception => error
-        # rubocop:enable RescueException
-        Karafka.monitor.instrument(
-          'connection.client.fetch_loop.error',
-          caller: self,
-          error: error
-        )
         retry
       end
 

--- a/spec/lib/karafka/connection/client_spec.rb
+++ b/spec/lib/karafka/connection/client_spec.rb
@@ -250,9 +250,9 @@ RSpec.describe Karafka::Connection::Client do
           .with(described_class, error)
       end
 
-      it 'notices and not reraise error' do
+      it 'notices and reraises error' do
         expect(kafka_consumer).not_to receive(:pause)
-        expect { client.fetch_loop {} }.not_to raise_error
+        expect { client.fetch_loop {} }.to raise_error(error)
       end
     end
   end


### PR DESCRIPTION
This PR removes catching of the system exceptions (that shouldn't be used) allowing them to propagate to the listener, so it can reinitialize the client upon a critical exception.