### PR TITLE
Override generator (parser) for responder

### DIFF
--- a/lib/karafka/responders/topic.rb
+++ b/lib/karafka/responders/topic.rb
@@ -29,6 +29,11 @@ module Karafka
         @options[:registered] == true
       end
 
+      # @return [Class] Class to use to serialize messages for this topic
+      def serializer
+        @options[:serializer]
+      end
+
       # @return [Boolean] do we want to use async producer. Defaults to false as the sync producer
       #   is safer and introduces less problems
       def async?
@@ -41,6 +46,7 @@ module Karafka
           name: name,
           required: required?,
           registered: registered?,
+          serializer: serializer,
           async: async?
         }
       end

--- a/spec/lib/karafka/base_responder_spec.rb
+++ b/spec/lib/karafka/base_responder_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe Karafka::BaseResponder do
       let(:instance) { working_class.new }
       subject(:responder) { instance.serializer(topic_name) }
 
-      let(:default_parser_class) { Karafka::Parsers::Json }
+      let(:default_parser) { Karafka::Parsers::Json }
 
-      it { expect(responder).to eq default_parser }
+      it { expect(responder).to be_a default_parser }
 
       context 'when a class is assigned to the constructor' do
         let(:parser_class) { Class.new(default_parser) }


### PR DESCRIPTION
This addresses the two cases listed on https://github.com/karafka/karafka/issues/460

Case 1:

```
Class MyResponder < BaseResponder
  # Takes precedence over the consumer's parser
  def default_generator_class
    MyCustomParser
  end
end
```

Case 2:

```
Class MyResponder < BaseResponder

  def respond(data)
    if some_condition
      # Override each time you call respond_to()...
      respond_to :topic1, data, generator: MyCustomParser
    else
      respond_to :topic2, data, generator: MyOtherCustomerParser
    end

    respond_to :topic3, data, generator: YetAnotherCustomerParser
  end
end

```

I struggled with naming, feedback welcome. "Parser" is Karafka's term
for what's known in Kafka as a deserializer. It seems confusing to
call the serializer a parser too. Since the method called on it is
`generate()` I chose "generator".