### PR TITLE
add additional post stop events

### DIFF
--- a/lib/karafka/instrumentation/monitor.rb
+++ b/lib/karafka/instrumentation/monitor.rb
@@ -41,6 +41,7 @@ module Karafka
         app.running
         app.stopping
         app.stopping.error
+        app.stopped
       ].freeze
 
       private_constant :BASE_EVENTS


### PR DESCRIPTION
This PR adds additional post stop events for hooking up cleanup or anything else that needs to run after everything is stopped.