### PR TITLE
sidekiq backend issue 29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - #475 - Disallow subscribing to the same topic with multiple consumers
 - #485 - Setting shutdown_timeout to nil kills the app without waiting for anything
 - #487 - Make listeners as instances
+- #29 (Sidekiq backend) - Consumer class names must have the word "Consumer" in it in order to work
 
 ## 1.2.11
 - [#470](https://github.com/karafka/karafka/issues/470) Karafka not working with dry-configurable 0.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 - #475 - Disallow subscribing to the same topic with multiple consumers
 - #485 - Setting shutdown_timeout to nil kills the app without waiting for anything
 - #487 - Make listeners as instances
-- #29 (Sidekiq backend) - Consumer class names must have the word "Consumer" in it in order to work
+- #29 - Consumer class names must have the word "Consumer" in it in order to work (Sidekiq backend)
 
 ## 1.2.11
 - [#470](https://github.com/karafka/karafka/issues/470) Karafka not working with dry-configurable 0.8

--- a/lib/karafka/helpers/class_matcher.rb
+++ b/lib/karafka/helpers/class_matcher.rb
@@ -45,6 +45,7 @@ module Karafka
       #   matcher.name #=> Super2Responder
       def name
         inflected = @klass.to_s.split('::').last.to_s
+        inflected += @from unless inflected.include?(@from)
         inflected.gsub!(@from, @to)
         inflected.gsub!(CONSTANT_REGEXP, '')
         inflected

--- a/lib/karafka/helpers/class_matcher.rb
+++ b/lib/karafka/helpers/class_matcher.rb
@@ -45,7 +45,13 @@ module Karafka
       #   matcher.name #=> Super2Responder
       def name
         inflected = @klass.to_s.split('::').last.to_s
-        inflected += @from unless inflected.include?(@from)
+        # We inject the from into the name just in case it is missing as in a case like that
+        # it would just sanitize the name without adding the "to" postfix
+        # This could create cases when we want to build for example a responder to a consumer
+        # that does not have the "Consumer" postfix and would actually do nothing returning the
+        # same name. That would be really bad as the matching classes shouldn't be matched to
+        # themselves
+        inflected << @from unless inflected.include?(@from)
         inflected.gsub!(@from, @to)
         inflected.gsub!(CONSTANT_REGEXP, '')
         inflected

--- a/lib/karafka/helpers/class_matcher.rb
+++ b/lib/karafka/helpers/class_matcher.rb
@@ -45,12 +45,11 @@ module Karafka
       #   matcher.name #=> Super2Responder
       def name
         inflected = @klass.to_s.split('::').last.to_s
-        # We inject the from into the name just in case it is missing as in a case like that
-        # it would just sanitize the name without adding the "to" postfix
-        # This could create cases when we want to build for example a responder to a consumer
-        # that does not have the "Consumer" postfix and would actually do nothing returning the
-        # same name. That would be really bad as the matching classes shouldn't be matched to
-        # themselves
+        # We inject the from into the name just in case it is missing as in a situation like
+        # that it would just sanitize the name without adding the "to" postfix.
+        # It could create cases when we want to build for example a responder to a consumer
+        # that does not have the "Consumer" postfix and would do nothing returning the same name.
+        # That would be bad as the matching classes shouldn't be matched to themselves.
         inflected << @from unless inflected.include?(@from)
         inflected.gsub!(@from, @to)
         inflected.gsub!(CONSTANT_REGEXP, '')

--- a/lib/karafka/responders/builder.rb
+++ b/lib/karafka/responders/builder.rb
@@ -3,7 +3,7 @@
 module Karafka
   # Responders namespace encapsulates all the internal responder implementation parts
   module Responders
-    # Responders builder is used to finding (based on the consumer class name) a responder
+    # Responders builder is used for finding (based on the consumer class name) a responder
     # that match the consumer. We use it when user does not provide a responder inside routing,
     # but he still names responder with the same convention (and namespaces) as consumer
     #

--- a/spec/lib/karafka/helpers/class_matcher_spec.rb
+++ b/spec/lib/karafka/helpers/class_matcher_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Karafka::Helpers::ClassMatcher do
 
     context 'when klass is anonymous' do
       let(:klass) { Class.new }
-      let(:expected_name) { klass.to_s.gsub(/[\#<>:]*/, '') }
+      let(:expected_name) { klass.to_s.gsub(/[\#<>:]*/, '') + to }
 
       it { expect(matcher.name).to eq expected_name }
     end


### PR DESCRIPTION
Fixes: https://github.com/karafka/sidekiq-backend/issues/29 by injecting the proper naming from which we remap in case it is missing, so the remapping remaps to a proper worker name.