### PR TITLE
Add support for parameter sasl_over_ssl in ruby-kafka

### DIFF
--- a/lib/karafka/schemas/consumer_group.rb
+++ b/lib/karafka/schemas/consumer_group.rb
@@ -69,6 +69,7 @@ module Karafka
       end
 
       optional(:ssl_ca_certs_from_system).maybe(:bool?)
+      optional(:sasl_over_ssl).maybe(:bool?)
 
       # It's not with other encryptions as it has some more rules
       optional(:sasl_scram_mechanism)

--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -156,6 +156,8 @@ module Karafka
         setting :sasl_scram_password, nil
         # option sasl_scram_mechanism [String, nil] Scram mechanism, either 'sha256' or 'sha512'
         setting :sasl_scram_mechanism, nil
+        # option sasl_over_ssl [Boolean] whether to enforce SSL with SASL
+        setting :sasl_over_ssl, true
       end
 
       class << self

--- a/spec/lib/karafka/connection/api_adapter_spec.rb
+++ b/spec/lib/karafka/connection/api_adapter_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Karafka::Connection::ApiAdapter do
     it 'expect to have std kafka config keys' do
       expected = %i[
         logger client_id connect_timeout socket_timeout sasl_plain_authzid
-        ssl_ca_certs_from_system
+        ssl_ca_certs_from_system sasl_over_ssl
       ]
       expect(config.last.keys.sort).to eq expected.sort
     end
@@ -44,7 +44,7 @@ RSpec.describe Karafka::Connection::ApiAdapter do
 
     context 'when values of keys are not nil' do
       let(:unsupported_keys) do
-        %i[sasl_over_ssl ssl_client_cert_chain ssl_client_cert_key_password sasl_oauth_token_provider]
+        %i[ssl_client_cert_chain ssl_client_cert_key_password sasl_oauth_token_provider]
       end
       let(:expected_keys) do
         Kafka::Client.instance_method(:initialize).parameters.map(&:last).sort

--- a/spec/lib/karafka/connection/builder_spec.rb
+++ b/spec/lib/karafka/connection/builder_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Karafka::Connection::Builder do
         socket_timeout: 30,
         connect_timeout: 10,
         sasl_plain_authzid: '',
-        ssl_ca_certs_from_system: false
+        ssl_ca_certs_from_system: false,
+        sasl_over_ssl: true
       ]
     end
 


### PR DESCRIPTION
Since 0.7.7 version of ruby-kafka (https://github.com/zendesk/ruby-kafka/commit/21ba7a92f0754d48ada8b410649e7c48a476cb4f) parameter `sasl_over_ssl` is mandatory for connection without ssl.

This parameter would be needed for projects working on karafka 1.2