### PR TITLE
Hot code reload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
       before_install:
         - gem update --system
         - gem install bundler
-      script: \curl -sSL https://api.coditsu.io/run/travis | bash
+      script: \curl -sSL https://api.coditsu.io/run/ci | bash
 
 stages:
   - coditsu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - #502 - Karafka process hangs when sending multiple sigkills
 - #506 - ssl_verify_hostname sync
 - #483 - Upgrade dry-validation before releasing 1.3
+- #492 - Use Zeitwerk for code reload in development
 
 ## 1.2.11
 - [#470](https://github.com/karafka/karafka/issues/470) Karafka not working with dry-configurable 0.8

--- a/config/errors.yml
+++ b/config/errors.yml
@@ -2,8 +2,8 @@ en:
   dry_validation:
     errors:
       invalid_broker_schema: >
-        has an invalid format.
-        Expected schema, host and port number.
+        has an invalid format
+        Expected schema, host and port number
         Example: kafka://127.0.0.1:9092 or kafka+ssl://127.0.0.1:9092
       invalid_certificate: >
         is not a valid certificate
@@ -12,28 +12,28 @@ en:
       invalid_private_key: >
         is not a valid private key
       max_timeout_size_for_exponential: >
-        pause_timeout cannot be more than pause_max_timeout.
+        pause_timeout cannot be more than pause_max_timeout
       max_wait_time_limit:
-        max_wait_time cannot be more than socket_timeout.
+        max_wait_time cannot be more than socket_timeout
       topics_names_not_unique: >
-        all topic names within a single consumer group must be unique.
+        all topic names within a single consumer group must be unique
       ssl_client_cert_with_ssl_client_cert_key: >
-        Both ssl_client_cert and ssl_client_cert_key need to be provided.
+        Both ssl_client_cert and ssl_client_cert_key need to be provided
       ssl_client_cert_key_with_ssl_client_cert: >
-        Both ssl_client_cert_key and ssl_client_cert need to be provided.
+        Both ssl_client_cert_key and ssl_client_cert need to be provided
       ssl_client_cert_chain_with_ssl_client_cert: >
-        Both ssl_client_cert_chain and ssl_client_cert need to be provided.
+        Both ssl_client_cert_chain and ssl_client_cert need to be provided
       ssl_client_cert_chain_with_ssl_client_cert_key: >
-        Both ssl_client_cert_chain and ssl_client_cert_key need to be provided.
+        Both ssl_client_cert_chain and ssl_client_cert_key need to be provided
       ssl_client_cert_key_password_with_ssl_client_cert_key: >
-        Both ssl_client_cert_key_password and ssl_client_cert_key need to be provided.
+        Both ssl_client_cert_key_password and ssl_client_cert_key need to be provided
       does_not_respond_to_token: >
-        needs to respond to a #token method.
+        needs to respond to a #token method
       required_usage_count: >
-        Given topic must be used at least once.
+        Given topic must be used at least once
       pid_already_exists: >
-        Pidfile already exists.
+        Pidfile already exists
       consumer_groups_inclusion: >
-        Unknown consumer group.
+        Unknown consumer group
       does_not_exist:
-        Given file does not exist or cannot be read.
+        Given file does not exist or cannot be read

--- a/lib/karafka.rb
+++ b/lib/karafka.rb
@@ -14,6 +14,7 @@
   dry/events/publisher
   dry/inflector
   dry/monitor/notifications
+  dry/core/constants
   zeitwerk
 ].each(&method(:require))
 

--- a/lib/karafka/app.rb
+++ b/lib/karafka/app.rb
@@ -27,8 +27,8 @@ module Karafka
       # in-development hot code reloading without Karafka process restart
       def reload
         Karafka::Persistence::Consumers.clear
+        Karafka::Persistence::Topics.clear
         Karafka::Routing::Builder.instance.reload
-        Karafka::Persistence::Topic.clear
       end
 
       Status.instance_methods(false).each do |delegated|

--- a/lib/karafka/app.rb
+++ b/lib/karafka/app.rb
@@ -23,6 +23,14 @@ module Karafka
         Routing::Builder.instance
       end
 
+      # Triggers reload of all cached Karafka app components, so we can use in-process
+      # in-development hot code reloading without Karafka process restart
+      def reload
+        Karafka::Persistence::Consumers.clear
+        Karafka::Routing::Builder.instance.reload
+        Karafka::Persistence::Topic.clear
+      end
+
       Status.instance_methods(false).each do |delegated|
         define_method(delegated) do
           Status.instance.send(delegated)

--- a/lib/karafka/connection/batch_delegator.rb
+++ b/lib/karafka/connection/batch_delegator.rb
@@ -12,7 +12,7 @@ module Karafka
         # @param group_id [String] group_id of a group from which a given message came
         # @param kafka_batch [<Kafka::FetchedBatch>] raw messages fetched batch
         def call(group_id, kafka_batch)
-          topic = Persistence::Topic.fetch(group_id, kafka_batch.topic)
+          topic = Persistence::Topics.fetch(group_id, kafka_batch.topic)
           consumer = Persistence::Consumers.fetch(topic, kafka_batch.partition)
 
           Karafka.monitor.instrument(

--- a/lib/karafka/connection/batch_delegator.rb
+++ b/lib/karafka/connection/batch_delegator.rb
@@ -13,7 +13,7 @@ module Karafka
         # @param kafka_batch [<Kafka::FetchedBatch>] raw messages fetched batch
         def call(group_id, kafka_batch)
           topic = Persistence::Topic.fetch(group_id, kafka_batch.topic)
-          consumer = Persistence::Consumer.fetch(topic, kafka_batch.partition)
+          consumer = Persistence::Consumers.fetch(topic, kafka_batch.partition)
 
           Karafka.monitor.instrument(
             'connection.batch_delegator.call',

--- a/lib/karafka/connection/listener.rb
+++ b/lib/karafka/connection/listener.rb
@@ -37,7 +37,7 @@ module Karafka
         # @note What happens here is a delegation of processing to a proper processor based
         #   on the incoming messages characteristics
         client.fetch_loop do |raw_data, type|
-          Karafka.monitor.instrument('connection.listener.fetch_loop', {})
+          Karafka.monitor.instrument('connection.listener.fetch_loop')
 
           case type
           when :message

--- a/lib/karafka/connection/listener.rb
+++ b/lib/karafka/connection/listener.rb
@@ -34,12 +34,15 @@ module Karafka
       #   Kafka connections / Internet connection issues / Etc. Business logic problems should not
       #   propagate this far
       def fetch_loop
-        delegators = { message: MessageDelegator, batch: BatchDelegator }
-
         # @note What happens here is a delegation of processing to a proper processor based
         #   on the incoming messages characteristics
         client.fetch_loop do |raw_data, type|
-          delegators[type].call(@consumer_group.id, raw_data)
+          case type
+          when :message
+            MessageDelegator.call(@consumer_group.id, raw_data)
+          when :batch
+            BatchDelegator.call(@consumer_group.id, raw_data)
+          end
         end
         # This is on purpose - see the notes for this method
         # rubocop:disable RescueException

--- a/lib/karafka/connection/listener.rb
+++ b/lib/karafka/connection/listener.rb
@@ -37,6 +37,8 @@ module Karafka
         # @note What happens here is a delegation of processing to a proper processor based
         #   on the incoming messages characteristics
         client.fetch_loop do |raw_data, type|
+          Karafka.monitor.instrument('connection.listener.fetch_loop', {})
+
           case type
           when :message
             MessageDelegator.call(@consumer_group.id, raw_data)

--- a/lib/karafka/connection/message_delegator.rb
+++ b/lib/karafka/connection/message_delegator.rb
@@ -12,7 +12,7 @@ module Karafka
         # @param group_id [String] group_id of a group from which a given message came
         # @param kafka_message [<Kafka::FetchedMessage>] raw message from kafka
         def call(group_id, kafka_message)
-          topic = Persistence::Topic.fetch(group_id, kafka_message.topic)
+          topic = Persistence::Topics.fetch(group_id, kafka_message.topic)
           consumer = Persistence::Consumers.fetch(topic, kafka_message.partition)
 
           Karafka.monitor.instrument(

--- a/lib/karafka/connection/message_delegator.rb
+++ b/lib/karafka/connection/message_delegator.rb
@@ -13,7 +13,7 @@ module Karafka
         # @param kafka_message [<Kafka::FetchedMessage>] raw message from kafka
         def call(group_id, kafka_message)
           topic = Persistence::Topic.fetch(group_id, kafka_message.topic)
-          consumer = Persistence::Consumer.fetch(topic, kafka_message.partition)
+          consumer = Persistence::Consumers.fetch(topic, kafka_message.partition)
 
           Karafka.monitor.instrument(
             'connection.message_delegator.call',

--- a/lib/karafka/instrumentation/monitor.rb
+++ b/lib/karafka/instrumentation/monitor.rb
@@ -24,6 +24,7 @@ module Karafka
         params.params.deserialize
         params.params.deserialize.error
         connection.listener.before_fetch_loop
+        connection.listener.fetch_loop
         connection.listener.fetch_loop.error
         connection.client.fetch_loop.error
         connection.batch_delegator.call

--- a/lib/karafka/patches/ruby_kafka.rb
+++ b/lib/karafka/patches/ruby_kafka.rb
@@ -13,8 +13,8 @@ module Karafka
       # thread)
       def consumer_loop
         super do
-          consumers = Karafka::Persistence::Consumer
-                      .all
+          consumers = Karafka::Persistence::Consumers
+                      .current
                       .values
                       .flat_map(&:values)
                       .select { |consumer| consumer.class.respond_to?(:after_fetch) }

--- a/lib/karafka/persistence/consumers.rb
+++ b/lib/karafka/persistence/consumers.rb
@@ -7,7 +7,7 @@ module Karafka
     # Module used to provide a persistent cache across batch requests for a given
     # topic and partition to store some additional details when the persistent mode
     # for a given topic is turned on
-    class Consumer
+    class Consumers
       # Thread.current scope under which we store consumers data
       PERSISTENCE_SCOPE = :consumers
 
@@ -15,10 +15,10 @@ module Karafka
 
       class << self
         # @return [Hash] current thread's persistence scope hash with all the consumers
-        def all
-          # @note This does not need to be thread safe (Hash) as it is always executed in a
-          # current thread context
-          Thread.current[PERSISTENCE_SCOPE] ||= Hash.new { |hash, key| hash[key] = {} }
+        def current
+          Thread.current[PERSISTENCE_SCOPE] ||= Concurrent::Hash.new do |hash, key|
+            hash[key] = Concurrent::Hash.new
+          end
         end
 
         # Used to build (if block given) and/or fetch a current consumer instance that will be
@@ -27,7 +27,17 @@ module Karafka
         # @param topic [Karafka::Routing::Topic] topic instance for which we might cache
         # @param partition [Integer] number of partition for which we want to cache
         def fetch(topic, partition)
-          all[topic][partition] ||= topic.consumer.new(topic)
+          current[topic][partition] ||= topic.consumer.new(topic)
+        end
+
+        # Removes all persisted instances of consumers from the consumer cache
+        # @note This is used to reload consumers instances when code reloading in development mode
+        #   is present. This should not be used in production.
+        def clear
+          Thread
+            .list
+            .select { |thread| !thread[PERSISTENCE_SCOPE].nil? }
+            .each { |thread| thread[PERSISTENCE_SCOPE].clear }
         end
       end
     end

--- a/lib/karafka/persistence/consumers.rb
+++ b/lib/karafka/persistence/consumers.rb
@@ -36,7 +36,7 @@ module Karafka
         def clear
           Thread
             .list
-            .select { |thread| !thread[PERSISTENCE_SCOPE].nil? }
+            .select { |thread| thread[PERSISTENCE_SCOPE] }
             .each { |thread| thread[PERSISTENCE_SCOPE].clear }
         end
       end

--- a/lib/karafka/persistence/topic.rb
+++ b/lib/karafka/persistence/topic.rb
@@ -18,7 +18,9 @@ module Karafka
         # @return [Karafka::Routing::Topic] remapped topic representation that can be used further
         #   on when working with given parameters
         def fetch(group_id, raw_topic_name)
-          Thread.current[PERSISTENCE_SCOPE] ||= Hash.new { |hash, key| hash[key] = {} }
+          Thread.current[PERSISTENCE_SCOPE] ||= Concurrent::Hash.new do |hash, key|
+            hash[key] = Concurrent::Hash.new
+          end
 
           Thread.current[PERSISTENCE_SCOPE][group_id][raw_topic_name] ||= begin
             # We map from incoming topic name, as it might be namespaced, etc.
@@ -26,6 +28,16 @@ module Karafka
             mapped_topic_name = Karafka::App.config.topic_mapper.incoming(raw_topic_name)
             Routing::Router.find("#{group_id}_#{mapped_topic_name}")
           end
+        end
+
+        # Clears the whole topics cache for all the threads
+        # This is used for in-development code reloading as we need to get rid of all the
+        # preloaded and cached instances of objects to make it work
+        def clear
+          Thread
+            .list
+            .select { |thread| !thread[PERSISTENCE_SCOPE].nil? }
+            .each { |thread| thread[PERSISTENCE_SCOPE].clear }
         end
       end
     end

--- a/lib/karafka/persistence/topic.rb
+++ b/lib/karafka/persistence/topic.rb
@@ -36,7 +36,7 @@ module Karafka
         def clear
           Thread
             .list
-            .select { |thread| !thread[PERSISTENCE_SCOPE].nil? }
+            .select { |thread| thread[PERSISTENCE_SCOPE] }
             .each { |thread| thread[PERSISTENCE_SCOPE].clear }
         end
       end

--- a/lib/karafka/persistence/topics.rb
+++ b/lib/karafka/persistence/topics.rb
@@ -5,24 +5,27 @@ module Karafka
     # Local cache for routing topics
     # We use it in order not to build string instances and remap incoming topic upon each
     # message / message batches received
-    class Topic
+    class Topics
       # Thread.current scope under which we store topics data
       PERSISTENCE_SCOPE = :topics
 
       private_constant :PERSISTENCE_SCOPE
 
       class << self
-        # @param group_id [String] group id for which we fetch a topic representation
-        # @param raw_topic_name [String] raw topic name (before remapping) for which we fetch a
-        #   topic representation
-        # @return [Karafka::Routing::Topic] remapped topic representation that can be used further
-        #   on when working with given parameters
-        def fetch(group_id, raw_topic_name)
+        # @return [Concurrent::Hash] hash with all the topics from given groups
+        def current
           Thread.current[PERSISTENCE_SCOPE] ||= Concurrent::Hash.new do |hash, key|
             hash[key] = Concurrent::Hash.new
           end
+        end
 
-          Thread.current[PERSISTENCE_SCOPE][group_id][raw_topic_name] ||= begin
+        # @param group_id [String] group id for which we fetch a topic representation
+        # @param raw_topic_name [String] raw topic name (before remapping) for which we fetch a
+        #   topic representation
+        # @return [Karafka::Routing::Topics] remapped topic representation that can be used further
+        #   on when working with given parameters
+        def fetch(group_id, raw_topic_name)
+          current[group_id][raw_topic_name] ||= begin
             # We map from incoming topic name, as it might be namespaced, etc.
             # @see topic_mapper internal docs
             mapped_topic_name = Karafka::App.config.topic_mapper.incoming(raw_topic_name)

--- a/lib/karafka/routing/builder.rb
+++ b/lib/karafka/routing/builder.rb
@@ -9,13 +9,17 @@ module Karafka
     #       consumer NewVideosConsumer
     #     end
     #   end
-    class Builder < Array
+    class Builder < Concurrent::Array
       include Singleton
 
       # Consumer group consistency checking schema
       SCHEMA = Karafka::Schemas::ConsumerGroup.new.freeze
 
       private_constant :SCHEMA
+
+      def initialize
+        @draws = Concurrent::Array.new
+      end
 
       # Used to draw routes for Karafka
       # @note After it is done drawing it will store and validate all the routes to make sure that
@@ -30,6 +34,8 @@ module Karafka
       #     end
       #   end
       def draw(&block)
+        @draws << block
+
         instance_eval(&block)
 
         each do |consumer_group|
@@ -46,6 +52,21 @@ module Karafka
       #   to pick only those consumer groups that should be active in our given process context
       def active
         select(&:active?)
+      end
+
+      # Clears the builder and the draws memory
+      def clear
+        @draws.clear
+        super
+      end
+
+      # Redraws all the routes for the in-process code reloading.
+      # @note This won't allow registration of new topics without process restart but will trigger
+      #   cache invalidation so all the classes, etc are refetched after code reload
+      def reload
+        draws = @draws.dup
+        clear
+        draws.each { |block| draw(&block) }
       end
 
       private

--- a/lib/karafka/routing/builder.rb
+++ b/lib/karafka/routing/builder.rb
@@ -62,7 +62,7 @@ module Karafka
 
       # Redraws all the routes for the in-process code reloading.
       # @note This won't allow registration of new topics without process restart but will trigger
-      #   cache invalidation so all the classes, etc are refetched after code reload
+      #   cache invalidation so all the classes, etc are re-fetched after code reload
       def reload
         draws = @draws.dup
         clear

--- a/lib/karafka/schemas.rb
+++ b/lib/karafka/schemas.rb
@@ -6,8 +6,5 @@ module Karafka
     # Regexp for validating format of groups and topics
     # @note It is not nested inside of the schema, as it is used by couple schemas
     TOPIC_REGEXP = /\A(\w|\-|\.)+\z/.freeze
-
-    # Frozen array for internal usage
-    EMPTY_ARRAY = [].freeze
   end
 end

--- a/lib/karafka/schemas/responder_usage.rb
+++ b/lib/karafka/schemas/responder_usage.rb
@@ -22,6 +22,8 @@ module Karafka
 
     # Validator to check that everything in a responder flow matches responder rules
     class ResponderUsage < Dry::Validation::Contract
+      include Dry::Core::Constants
+
       # Schema for verifying the topic usage details
       TOPIC_SCHEMA = ResponderUsageTopic.new.freeze
 

--- a/lib/karafka/schemas/responder_usage.rb
+++ b/lib/karafka/schemas/responder_usage.rb
@@ -35,7 +35,7 @@ module Karafka
       end
 
       rule(:used_topics) do
-        (value || Schemas::EMPTY_ARRAY).each do |used_topic|
+        (value || EMPTY_ARRAY).each do |used_topic|
           TOPIC_SCHEMA.call(used_topic).errors.each do |error|
             key([:used_topics, used_topic, error.path[0]]).failure(error.text)
           end
@@ -43,7 +43,7 @@ module Karafka
       end
 
       rule(:registered_topics) do
-        (value || Schemas::EMPTY_ARRAY).each do |used_topic|
+        (value || EMPTY_ARRAY).each do |used_topic|
           TOPIC_SCHEMA.call(used_topic).errors.each do |error|
             key([:registered_topics, used_topic, error.path[0]]).failure(error.text)
           end

--- a/spec/lib/karafka/app_spec.rb
+++ b/spec/lib/karafka/app_spec.rb
@@ -49,15 +49,15 @@ RSpec.describe Karafka::App do
 
     context 'when we trigger reload' do
       it 'expect to invalidate the consumers cache' do
-        expect { Karafka::App.reload }.to change(Karafka::Persistence::Consumers, :current)
+        expect { app_class.reload }.to change(Karafka::Persistence::Consumers, :current)
       end
 
       it 'expect to invalidate the topics cache' do
-        expect { Karafka::App.reload }.to change(Karafka::Persistence::Topics, :current)
+        expect { app_class.reload }.to change(Karafka::Persistence::Topics, :current)
       end
 
       it 'expect to redraw routes' do
-        expect { Karafka::App.reload }.to change(Karafka::Routing::Builder, :instance)
+        expect { app_class.reload }.to change(Karafka::Routing::Builder, :instance)
       end
     end
   end

--- a/spec/lib/karafka/app_spec.rb
+++ b/spec/lib/karafka/app_spec.rb
@@ -30,6 +30,38 @@ RSpec.describe Karafka::App do
     end
   end
 
+  describe '#reload' do
+    let(:topic) { build(:routing_topic) }
+    let(:consumers_persistence) { Karafka::Persistence::Consumers }
+    let(:topics_persistence) { Karafka::Persistence::Topics }
+
+    before do
+      Karafka::Routing::Builder.instance.draw do
+        topic :topic do
+          consumer Class.new(Karafka::BaseConsumer)
+        end
+      end
+
+      allow(Karafka::Routing::Router).to receive(:find).and_return(topic)
+      consumers_persistence.fetch(topic, 0)
+      topics_persistence.fetch(topic.consumer_group.id, topic.name)
+    end
+
+    context 'when we trigger reload' do
+      it 'expect to invalidate the consumers cache' do
+        expect { Karafka::App.reload }.to change(Karafka::Persistence::Consumers, :current)
+      end
+
+      it 'expect to invalidate the topics cache' do
+        expect { Karafka::App.reload }.to change(Karafka::Persistence::Topics, :current)
+      end
+
+      it 'expect to redraw routes' do
+        expect { Karafka::App.reload }.to change(Karafka::Routing::Builder, :instance)
+      end
+    end
+  end
+
   describe 'Karafka delegations' do
     %i[
       root

--- a/spec/lib/karafka/connection/batch_delegator_spec.rb
+++ b/spec/lib/karafka/connection/batch_delegator_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Karafka::Connection::BatchDelegator do
   let(:kafka_batch) { build(:kafka_fetched_batch) }
 
   before do
-    allow(Karafka::Persistence::Topic).to receive(:fetch).and_return(consumer_group.topics[0])
+    allow(Karafka::Persistence::Topics).to receive(:fetch).and_return(consumer_group.topics[0])
     allow(Karafka::Persistence::Consumers).to receive(:fetch).and_return(consumer_instance)
   end
 

--- a/spec/lib/karafka/connection/batch_delegator_spec.rb
+++ b/spec/lib/karafka/connection/batch_delegator_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Karafka::Connection::BatchDelegator do
 
   before do
     allow(Karafka::Persistence::Topic).to receive(:fetch).and_return(consumer_group.topics[0])
-    allow(Karafka::Persistence::Consumer).to receive(:fetch).and_return(consumer_instance)
+    allow(Karafka::Persistence::Consumers).to receive(:fetch).and_return(consumer_instance)
   end
 
   context 'when batch_consuming true' do

--- a/spec/lib/karafka/connection/message_delegator_spec.rb
+++ b/spec/lib/karafka/connection/message_delegator_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Karafka::Connection::MessageDelegator do
   end
 
   before do
-    allow(Karafka::Persistence::Topic).to receive(:fetch).and_return(consumer_group.topics[0])
+    allow(Karafka::Persistence::Topics).to receive(:fetch).and_return(consumer_group.topics[0])
     allow(Karafka::Persistence::Consumers).to receive(:fetch).and_return(consumer_instance)
     allow(consumer_instance).to receive(:call)
   end

--- a/spec/lib/karafka/connection/message_delegator_spec.rb
+++ b/spec/lib/karafka/connection/message_delegator_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Karafka::Connection::MessageDelegator do
 
   before do
     allow(Karafka::Persistence::Topic).to receive(:fetch).and_return(consumer_group.topics[0])
-    allow(Karafka::Persistence::Consumer).to receive(:fetch).and_return(consumer_instance)
+    allow(Karafka::Persistence::Consumers).to receive(:fetch).and_return(consumer_instance)
     allow(consumer_instance).to receive(:call)
   end
 

--- a/spec/lib/karafka/patches/ruby_kafka_spec.rb
+++ b/spec/lib/karafka/patches/ruby_kafka_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Karafka::Patches::RubyKafka do
   describe '#consumer_loop' do
     let(:client) { instance_double(Karafka::Connection::Client, stop: true) }
     let(:consumer_class) { Class.new(Karafka::BaseConsumer) }
-    let(:consumer_instance) { Karafka::Persistence::Consumer.fetch(topic, 0) }
+    let(:consumer_instance) { Karafka::Persistence::Consumers.fetch(topic, 0) }
     let(:topic) { build(:routing_topic, consumer: consumer_class) }
 
     before do

--- a/spec/lib/karafka/persistence/consumers_spec.rb
+++ b/spec/lib/karafka/persistence/consumers_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Karafka::Persistence::Consumer do
+RSpec.describe Karafka::Persistence::Consumers do
   subject(:persistence) { described_class }
 
   describe '#fetch' do

--- a/spec/lib/karafka/persistence/topics_spec.rb
+++ b/spec/lib/karafka/persistence/topics_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Karafka::Persistence::Topic do
+RSpec.describe Karafka::Persistence::Topics do
   subject(:persistence) { described_class }
 
   let(:group_id) { rand.to_s }

--- a/spec/lib/karafka/routing/builder_spec.rb
+++ b/spec/lib/karafka/routing/builder_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Karafka::Routing::Builder do
       let(:topic1) { builder.first.topics.first }
       let(:topic2) { builder.last.topics.first }
       let(:consumer_group1) do
-        described_class.instance.draw do
+        builder.draw do
           topic :topic_name1 do
             # Here we should have instance doubles, etc but it takes
             # shitload of time to setup instance evaluation from instance variables,
@@ -32,7 +32,7 @@ RSpec.describe Karafka::Routing::Builder do
         end
       end
       let(:consumer_group2) do
-        described_class.instance.draw do
+        builder.draw do
           topic :topic_name2 do
             consumer Class.new(Karafka::BaseConsumer)
             backend :inline
@@ -66,7 +66,7 @@ RSpec.describe Karafka::Routing::Builder do
       let(:topic1) { builder.first.topics.first }
       let(:topic2) { builder.last.topics.first }
       let(:consumer_group1) do
-        described_class.instance.draw do
+        builder.draw do
           consumer_group :group_name1 do
             seed_brokers ['kafka://localhost:9092']
 
@@ -81,7 +81,7 @@ RSpec.describe Karafka::Routing::Builder do
         end
       end
       let(:consumer_group2) do
-        described_class.instance.draw do
+        builder.draw do
           consumer_group :group_name2 do
             seed_brokers ['kafka://localhost:9093']
 
@@ -113,7 +113,7 @@ RSpec.describe Karafka::Routing::Builder do
       let(:topic2) { builder.first.topics.last }
 
       before do
-        described_class.instance.draw do
+        builder.draw do
           consumer_group :group_name1 do
             seed_brokers ['kafka://localhost:9092']
 
@@ -144,7 +144,7 @@ RSpec.describe Karafka::Routing::Builder do
 
     context 'when we define invalid route' do
       let(:invalid_route) do
-        described_class.instance.draw do
+        builder.draw do
           consumer_group '$%^&*(' do
             topic :topic_name1 do
               backend :inline
@@ -158,7 +158,7 @@ RSpec.describe Karafka::Routing::Builder do
 
     context 'when we define multiple consumer groups and one is without topics' do
       subject(:drawing) do
-        described_class.instance.draw do
+        builder.draw do
           consumer_group :group_name1 do
             topic(:topic_name1) { consumer Class.new(Karafka::BaseConsumer) }
           end
@@ -183,5 +183,27 @@ RSpec.describe Karafka::Routing::Builder do
     it 'expect to select only active consumer groups' do
       expect(builder.active).to eq [active_group]
     end
+  end
+
+  describe '#reload' do
+    let(:consumer_group) do
+      builder.draw do
+        consumer_group :group_name1 do
+          topic :topic_name1 do
+            consumer Class.new(Karafka::BaseConsumer)
+            backend :inline
+            name 'name1'
+          end
+        end
+      end
+    end
+
+    before do
+      builder.clear
+      consumer_group
+    end
+
+    it { expect { builder.reload }.to change { builder.to_a } }
+    it { expect { builder.reload }.to change { builder[0].topics[0].consumer } }
   end
 end

--- a/spec/lib/karafka/routing/builder_spec.rb
+++ b/spec/lib/karafka/routing/builder_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe Karafka::Routing::Builder do
       consumer_group
     end
 
-    it { expect { builder.reload }.to(change { builder.to_a }) }
+    it { expect { builder.reload }.to change(builder, :to_a) }
     it { expect { builder.reload }.to(change { builder[0].topics[0].consumer }) }
   end
 end

--- a/spec/lib/karafka/routing/builder_spec.rb
+++ b/spec/lib/karafka/routing/builder_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe Karafka::Routing::Builder do
       consumer_group
     end
 
-    it { expect { builder.reload }.to change { builder.to_a } }
-    it { expect { builder.reload }.to change { builder[0].topics[0].consumer } }
+    it { expect { builder.reload }.to(change { builder.to_a }) }
+    it { expect { builder.reload }.to(change { builder[0].topics[0].consumer }) }
   end
 end


### PR DESCRIPTION
close https://github.com/karafka/karafka/issues/492

This PR adds option to reload and redraw all the cached mappings and objects to support hot code reload in development.

It should work both with Zeitwerk and Rails as it does not reload framework code, just the invalidates caches so things are recreated.

Limitations:

-  During the redraw, if new topics are present, they won't be included.
- All the multi batch long running operations will be invalidated when the code is reloaded (to be expected but still worth mentioning).