### PR TITLE
Allow to use headers in the deserializer object

### DIFF
--- a/lib/karafka/params/params.rb
+++ b/lib/karafka/params/params.rb
@@ -55,10 +55,11 @@ module Karafka
       private
 
       # @param payload [String] Raw data that we want to deserialize using consumer deserializer
+      # option headers [Hash] - optional - Kafka message headers
       # @return [Object] deserialized data
       def deserialize(payload)
         Karafka.monitor.instrument('params.params.deserialize', caller: self) do
-          self['deserializer'].call(payload)
+          self['deserializer'].call(payload, self['headers'])
         end
       rescue ::StandardError => e
         Karafka.monitor.instrument('params.params.deserialize.error', caller: self, error: e)

--- a/lib/karafka/serialization/json/deserializer.rb
+++ b/lib/karafka/serialization/json/deserializer.rb
@@ -8,10 +8,11 @@ module Karafka
       # Default Karafka Json deserializer for loading JSON data
       class Deserializer
         # @param content [String] content based on which we want to get our hash
+        # option headers [Hash] - optional - Kafka message headers
         # @return [Hash] hash with deserialized JSON data
         # @example
-        #   Deserializer.call("{\"a\":1}") #=> { 'a' => 1 }
-        def call(content)
+        #   Deserializer.call("{\"a\":1}", message_type: :test) #=> { 'a' => 1 }
+        def call(content, **headers)
           ::MultiJson.load(content)
         rescue ::MultiJson::ParseError => e
           raise ::Karafka::Errors::DeserializationError, e

--- a/spec/lib/karafka/params/params_spec.rb
+++ b/spec/lib/karafka/params/params_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe Karafka::Params::Params do
   let(:base_params_class) { described_class }
+  let(:headers) { { message_type: 'test' } }
 
   describe 'instance methods' do
     subject(:params) { base_params_class.send(:new) }
@@ -23,6 +24,7 @@ RSpec.describe Karafka::Params::Params do
 
         before do
           params['payload'] = payload
+          params['headers'] = headers
 
           allow(params)
             .to receive(:deserialize)
@@ -47,6 +49,7 @@ RSpec.describe Karafka::Params::Params do
 
         before do
           params['payload'] = payload
+          params['headers'] = headers
 
           allow(params)
             .to receive(:deserialize)
@@ -71,6 +74,7 @@ RSpec.describe Karafka::Params::Params do
 
       before do
         params['deserializer'] = deserializer
+        params['headers'] = headers
       end
 
       context 'when we are able to successfully deserialize' do
@@ -79,7 +83,7 @@ RSpec.describe Karafka::Params::Params do
         before do
           allow(deserializer)
             .to receive(:call)
-            .with(payload)
+            .with(payload, headers)
             .and_return(deserialized_payload)
         end
 
@@ -107,7 +111,7 @@ RSpec.describe Karafka::Params::Params do
         before do
           allow(deserializer)
             .to receive(:call)
-            .with(payload)
+            .with(payload, headers)
             .and_raise(::Karafka::Errors::DeserializationError)
         end
 
@@ -123,6 +127,7 @@ RSpec.describe Karafka::Params::Params do
       topic
       partition
       offset
+      headers
       key
       create_time
     ].each do |key|


### PR DESCRIPTION
Hey man!

I played with 1.3 version and found an interesting case for improvement. Now we can use headers. I played with avro and you told me that it's good to put event type and version (for schema-registry) to the headers of kafka message.

And with it I'll be happy to use deserializer like this:

```ruby
module Parsers
  class AvroParser
    REGESTRY_URL = 'http://localhost:8081/'

    attr_reader :avro

    def initialize
      @avro = AvroTurf::Messaging.new(registry_url: REGESTRY_URL)
    end

    def call(content, subject: '', version: 1)
      avro.decode(content, subject: subject, version: version)
    end
  end
end
```

In this case, I can decode the message by subject and version and get decoded payload for in consumer block. Also, it will provide me to use dry-struct for mapping payload to struct object, like this:

```ruby
def call(content, subject: '', version: 1)
  STRUCTS[subject][version].new(
    avro.decode(content, subject: subject, version: version)
  )
end

class ArticlesSnapshotConsumer < ApplicationConsumer
  def consume
    params_batch.each do |message|
      message.payload # => Dry::Struct object
    end
  end
end
```

WDYT about this?