### PR TITLE
Allow to use headers in the deserializer object

### DIFF
--- a/lib/karafka/params/params.rb
+++ b/lib/karafka/params/params.rb
@@ -55,10 +55,11 @@ module Karafka
       private
 
       # @param payload [String] Raw data that we want to deserialize using consumer deserializer
+      # option headers [Hash] - optional - Kafka message headers
       # @return [Object] deserialized data
       def deserialize(payload)
         Karafka.monitor.instrument('params.params.deserialize', caller: self) do
-          self['deserializer'].call(payload)
+          self['deserializer'].call(payload, self['headers'])
         end
       rescue ::StandardError => e
         Karafka.monitor.instrument('params.params.deserialize.error', caller: self, error: e)

--- a/lib/karafka/params/params.rb
+++ b/lib/karafka/params/params.rb
@@ -48,21 +48,19 @@ module Karafka
         return self if self['deserialized']
 
         self['deserialized'] = true
-        self['payload'] = deserialize(self)
+        self['payload'] = deserialize
         self
       end
 
       private
 
-      # @param params [Karafka::Params::Params] Full params object that we want to
-      # deserialize using consumer deserializer
       # @return [Object] deserialized data
-      def deserialize(params)
-        Karafka.monitor.instrument('params.params.deserialize', caller: params) do
-          params['deserializer'].call(params)
+      def deserialize
+        Karafka.monitor.instrument('params.params.deserialize', caller: self) do
+          self['deserializer'].call(self)
         end
       rescue ::StandardError => e
-        Karafka.monitor.instrument('params.params.deserialize.error', caller: params, error: e)
+        Karafka.monitor.instrument('params.params.deserialize.error', caller: self, error: e)
         raise e
       end
     end

--- a/lib/karafka/params/params.rb
+++ b/lib/karafka/params/params.rb
@@ -48,21 +48,21 @@ module Karafka
         return self if self['deserialized']
 
         self['deserialized'] = true
-        self['payload'] = deserialize(self['payload'])
+        self['payload'] = deserialize(self)
         self
       end
 
       private
 
-      # @param payload [String] Raw data that we want to deserialize using consumer deserializer
-      # option headers [Hash] - optional - Kafka message headers
+      # @param params [Karafka::Params::Params] Full params object that we want to
+      # deserialize using consumer deserializer
       # @return [Object] deserialized data
-      def deserialize(payload)
-        Karafka.monitor.instrument('params.params.deserialize', caller: self) do
-          self['deserializer'].call(payload, self['headers'])
+      def deserialize(params)
+        Karafka.monitor.instrument('params.params.deserialize', caller: params) do
+          params['deserializer'].call(params)
         end
       rescue ::StandardError => e
-        Karafka.monitor.instrument('params.params.deserialize.error', caller: self, error: e)
+        Karafka.monitor.instrument('params.params.deserialize.error', caller: params, error: e)
         raise e
       end
     end

--- a/lib/karafka/serialization/json/deserializer.rb
+++ b/lib/karafka/serialization/json/deserializer.rb
@@ -8,10 +8,11 @@ module Karafka
       # Default Karafka Json deserializer for loading JSON data
       class Deserializer
         # @param content [String] content based on which we want to get our hash
+        # option headers [Hash] - optional - Kafka message headers
         # @return [Hash] hash with deserialized JSON data
         # @example
-        #   Deserializer.call("{\"a\":1}") #=> { 'a' => 1 }
-        def call(content)
+        #   Deserializer.call("{\"a\":1}", message_type: :test) #=> { 'a' => 1 }
+        def call(content, **headers)
           ::MultiJson.load(content)
         rescue ::MultiJson::ParseError => e
           raise ::Karafka::Errors::DeserializationError, e

--- a/lib/karafka/serialization/json/deserializer.rb
+++ b/lib/karafka/serialization/json/deserializer.rb
@@ -7,13 +7,17 @@ module Karafka
     module Json
       # Default Karafka Json deserializer for loading JSON data
       class Deserializer
-        # @param content [String] content based on which we want to get our hash
-        # option headers [Hash] - optional - Kafka message headers
+        # @param params [Karafka::Params::Params] Full params object that we want to deserialize
         # @return [Hash] hash with deserialized JSON data
         # @example
-        #   Deserializer.call("{\"a\":1}", message_type: :test) #=> { 'a' => 1 }
-        def call(content, **headers)
-          ::MultiJson.load(content)
+        #   params = {
+        #     'payload' => "{\"a\":1}",
+        #     'topic' => 'my-topic',
+        #     'headers' => { 'message_type' => :test }
+        #   }
+        #   Deserializer.call(params) #=> { 'a' => 1 }
+        def call(params)
+          ::MultiJson.load(params['payload'])
         rescue ::MultiJson::ParseError => e
           raise ::Karafka::Errors::DeserializationError, e
         end

--- a/spec/lib/karafka/params/params_spec.rb
+++ b/spec/lib/karafka/params/params_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe Karafka::Params::Params do
 
           allow(params)
             .to receive(:deserialize)
-            .with(params)
             .and_return(deserialized_payload)
 
           params.deserialize!
@@ -88,7 +87,7 @@ RSpec.describe Karafka::Params::Params do
         end
 
         it 'expect to return payload in a message key' do
-          expect(params.send(:deserialize, params)).to eq deserialized_payload
+          expect(params.send(:deserialize)).to eq deserialized_payload
         end
       end
 
@@ -118,7 +117,7 @@ RSpec.describe Karafka::Params::Params do
         it 'expect to monitor and reraise' do
           expect(Karafka.monitor).to receive(:instrument).with(*instrument_args).and_yield
           expect(Karafka.monitor).to receive(:instrument).with(*instrument_error_args)
-          expect { params.send(:deserialize, params) }.to raise_error(expected_error)
+          expect { params.send(:deserialize) }.to raise_error(expected_error)
         end
       end
     end

--- a/spec/lib/karafka/params/params_spec.rb
+++ b/spec/lib/karafka/params/params_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe Karafka::Params::Params do
   let(:base_params_class) { described_class }
+  let(:headers) { { message_type: 'test' } }
 
   describe 'instance methods' do
     subject(:params) { base_params_class.send(:new) }
@@ -23,6 +24,7 @@ RSpec.describe Karafka::Params::Params do
 
         before do
           params['payload'] = payload
+          params['headers'] = headers
 
           allow(params)
             .to receive(:deserialize)
@@ -47,6 +49,7 @@ RSpec.describe Karafka::Params::Params do
 
         before do
           params['payload'] = payload
+          params['headers'] = headers
 
           allow(params)
             .to receive(:deserialize)
@@ -71,6 +74,7 @@ RSpec.describe Karafka::Params::Params do
 
       before do
         params['deserializer'] = deserializer
+        params['headers'] = headers
       end
 
       context 'when we are able to successfully deserialize' do
@@ -79,7 +83,7 @@ RSpec.describe Karafka::Params::Params do
         before do
           allow(deserializer)
             .to receive(:call)
-            .with(payload)
+            .with(payload, headers)
             .and_return(deserialized_payload)
         end
 
@@ -107,7 +111,7 @@ RSpec.describe Karafka::Params::Params do
         before do
           allow(deserializer)
             .to receive(:call)
-            .with(payload)
+            .with(payload, headers)
             .and_raise(::Karafka::Errors::DeserializationError)
         end
 
@@ -123,6 +127,7 @@ RSpec.describe Karafka::Params::Params do
       topic
       partition
       offset
+      headers
       key
       create_time
     ].each do |key|

--- a/spec/lib/karafka/params/params_spec.rb
+++ b/spec/lib/karafka/params/params_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Karafka::Params::Params do
 
           allow(params)
             .to receive(:deserialize)
-            .with(payload)
+            .with(params)
             .and_return(deserialized_payload)
 
           params.deserialize!
@@ -83,12 +83,12 @@ RSpec.describe Karafka::Params::Params do
         before do
           allow(deserializer)
             .to receive(:call)
-            .with(payload, headers)
+            .with(params)
             .and_return(deserialized_payload)
         end
 
         it 'expect to return payload in a message key' do
-          expect(params.send(:deserialize, payload)).to eq deserialized_payload
+          expect(params.send(:deserialize, params)).to eq deserialized_payload
         end
       end
 
@@ -111,14 +111,14 @@ RSpec.describe Karafka::Params::Params do
         before do
           allow(deserializer)
             .to receive(:call)
-            .with(payload, headers)
+            .with(params)
             .and_raise(::Karafka::Errors::DeserializationError)
         end
 
         it 'expect to monitor and reraise' do
           expect(Karafka.monitor).to receive(:instrument).with(*instrument_args).and_yield
           expect(Karafka.monitor).to receive(:instrument).with(*instrument_error_args)
-          expect { params.send(:deserialize, payload) }.to raise_error(expected_error)
+          expect { params.send(:deserialize, params) }.to raise_error(expected_error)
         end
       end
     end

--- a/spec/lib/karafka/serialization/json/deserializer_spec.rb
+++ b/spec/lib/karafka/serialization/json/deserializer_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe Karafka::Serialization::Json::Deserializer do
   describe '.call' do
     context 'when we can deserialize given content' do
       let(:content_source) { { rand.to_s => rand.to_s } }
-      let(:content) { content_source.to_json }
+      let(:params) { { 'payload' => content_source.to_json } }
 
       it 'expect to deserialize' do
-        expect(deserializer.call(content)).to eq content_source
+        expect(deserializer.call(params)).to eq content_source
       end
     end
 


### PR DESCRIPTION
I played with 1.3 version and found an interesting case for improvement. Now we can use headers. I played with avro and you told me that it's good to put event type and version (for schema-registry) to the headers of kafka message.

And with it I'll be happy to use deserializer like this:

```ruby
module Parsers
  class AvroParser
    REGESTRY_URL = 'http://localhost:8081/'

    attr_reader :avro

    def initialize
      @avro = AvroTurf::Messaging.new(registry_url: REGESTRY_URL)
    end

    def call(content, subject: '', version: 1)
      avro.decode(content, subject: subject, version: version)
    end
  end
end
```

In this case, I can decode the message by subject and version and get decoded payload for in consumer block. Also, it will provide me to use dry-struct for mapping payload to struct object, like this:

```ruby
def call(content, subject: '', version: 1)
  STRUCTS[subject][version].new(
    avro.decode(content, subject: subject, version: version)
  )
end

class ArticlesSnapshotConsumer < ApplicationConsumer
  def consume
    params_batch.each do |message|
      message.payload # => Dry::Struct object
    end
  end
end
```

--------

This PR is copy of https://github.com/karafka/karafka/pull/533. I just use karafka repository branch now for better maintainability.