### PR TITLE
dry-configurable upgrade

### DIFF
--- a/lib/karafka/attributes_map.rb
+++ b/lib/karafka/attributes_map.rb
@@ -52,14 +52,8 @@ module Karafka
         ignored_settings = api_adapter[:subscribe]
         defined_settings = api_adapter.values.flatten
         karafka_settings = %i[batch_fetching]
-        # This is a dirty and bad hack of dry-configurable to get keys before setting values
-        dynamically_proxied = Karafka::Setup::Config
-                              ._settings
-                              .settings
-                              .find { |s| s.name == :kafka }
-                              .value
-                              .names
-                              .to_a
+
+        dynamically_proxied = Karafka::Setup::Config.config.kafka.to_h.keys
 
         (defined_settings + dynamically_proxied).uniq + karafka_settings - ignored_settings
       end

--- a/lib/karafka/contracts/server_cli_options.rb
+++ b/lib/karafka/contracts/server_cli_options.rb
@@ -6,6 +6,8 @@ module Karafka
     # We validate some basics + the list of consumer_groups on which we want to use, to make
     # sure that all of them are defined, plus that a pidfile does not exist
     class ServerCliOptions < Dry::Validation::Contract
+      config.messages.load_paths << File.join(Karafka.gem_root, 'config', 'errors.yml')
+
       params do
         optional(:pid).filled(:str?)
         optional(:daemon).filled(:bool?)


### PR DESCRIPTION
A couple of small tweaks that make it work with dry-configurable `0.11.0` as well as previous versions.