### PR TITLE
#578 - patch for dry-configurable trap context error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka framework changelog
 
+## master
+- #578 - ThreadError: can't be called from trap context patch
+
 ## 1.3.4 (2020-02-17)
 - `dry-configurable` upgrade (solnic)
 - Remove temporary `thor` patches that are no longer needed


### PR DESCRIPTION
close https://github.com/karafka/karafka/issues/578

bypass for: https://github.com/dry-rb/dry-configurable/issues/93

I didn't update specs as I don't have an idea of how to stub a trap context. I consider that worthless as I expect `dry-configurable` to be fixed instead. I've checked with our dummy app.