### PR TITLE
Direct CLI output to the logger

### DIFF
--- a/lib/karafka/cli.rb
+++ b/lib/karafka/cli.rb
@@ -47,7 +47,7 @@ end
 if ENV['KARAFKA_CONSOLE']
   # Reloads Karafka irb console session
   def reload!
-    puts "Reloading...\n"
+    Karafka.logger.info "Reloading...\n"
     Kernel.exec Karafka::Cli::Console.command
   end
 end

--- a/lib/karafka/cli/flow.rb
+++ b/lib/karafka/cli/flow.rb
@@ -11,19 +11,22 @@ module Karafka
       def call
         topics.each do |topic|
           any_topics = !topic.responder&.topics.nil?
+          log_messages = []
 
           if any_topics
-            puts "#{topic.name} =>"
+            log_messages << "#{topic.name} =>"
 
             topic.responder.topics.each_value do |responder_topic|
               features = []
               features << (responder_topic.required? ? 'always' : 'conditionally')
 
-              print responder_topic.name, "(#{features.join(', ')})"
+              log_messages << format(responder_topic.name, "(#{features.join(', ')})")
             end
           else
-            puts "#{topic.name} => (nothing)"
+            log_messages << "#{topic.name} => (nothing)"
           end
+
+          Karafka.logger.info(log_messages.join("\n"))
         end
       end
 
@@ -34,15 +37,11 @@ module Karafka
         Karafka::App.consumer_groups.map(&:topics).flatten.sort_by(&:name)
       end
 
-      # Prints a given value with label in a nice way
+      # Formats a given value with label in a nice way
       # @param label [String] label describing value
       # @param value [String] value that should be printed
-      def print(label, value)
-        printf(
-          "%<label>-25s %<value>s\n",
-          label: "  - #{label}:",
-          value: value
-        )
+      def format(label, value)
+        "  - #{label}:                #{value}"
       end
     end
   end

--- a/lib/karafka/cli/info.rb
+++ b/lib/karafka/cli/info.rb
@@ -24,7 +24,7 @@ module Karafka
           "Kafka seed brokers: #{config.kafka.seed_brokers}"
         ]
 
-        puts(info.join("\n"))
+        Karafka.logger.info(info.join("\n"))
       end
     end
   end

--- a/spec/lib/karafka/cli/flow_spec.rb
+++ b/spec/lib/karafka/cli/flow_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Karafka::Cli::Flow do
         let(:topics) { [] }
 
         it 'expect to print that the flow is terminated' do
-          expect(flow_cli).to receive(:puts).with("#{topic} => (nothing)")
+          expect(Karafka.logger).to receive(:info).with("#{topic} => (nothing)")
           flow_cli.call
         end
       end
@@ -54,25 +54,20 @@ RSpec.describe Karafka::Cli::Flow do
       context 'when they are with outgoing topics' do
         let(:topics) { { topic => Karafka::Responders::Topic.new(topic, {}) } }
 
-        it 'expect to print flow details' do
-          expect(flow_cli).to receive(:puts)
-          expect(flow_cli).to receive(:print)
+        it 'expect to log flow details' do
+          expect(Karafka.logger).to receive(:info).once
+          expect(flow_cli).to receive(:format)
           expect { flow_cli.call }.not_to raise_error
         end
       end
     end
   end
 
-  describe '#print' do
-    let(:label) { rand.to_s }
-    let(:value) { rand.to_s }
-
-    it 'expect to printf nicely' do
-      expect(flow_cli)
-        .to receive(:printf)
-        .with("%<label>-25s %<value>s\n", label: "  - #{label}:", value: value)
-
-      flow_cli.send(:print, label, value)
+  describe '#format' do
+    subject(:formatted) { flow_cli.send(:format, 'label', 'value') }
+    
+    it 'expect to format nicely' do
+      expect(formatted).to eq('  - label:                value')
     end
   end
 end

--- a/spec/lib/karafka/cli/info_spec.rb
+++ b/spec/lib/karafka/cli/info_spec.rb
@@ -20,11 +20,12 @@ RSpec.describe Karafka::Cli::Info do
         "Boot file: #{Karafka.boot_file}",
         "Environment: #{Karafka.env}",
         "Kafka seed brokers: #{Karafka::App.config.kafka.seed_brokers}"
-      ]
+      ].join("\n")
     end
 
     it 'expect to print details of this Karafka app instance' do
-      expect { info_cli.call }.to output(info.join("\n") + "\n").to_stdout
+      expect(Karafka.logger).to receive(:info).with(info)
+      info_cli.call
     end
   end
 end


### PR DESCRIPTION
Swap `puts` with `Karafka.logger`. Fixes https://github.com/karafka/karafka/issues/583

Plain logging still look nice:

```log
2020-04-17 12:05:31.985611 I [14392:70280042062320] KarafkaApp -- Initializing Karafka server 14392
2020-04-17 12:05:32.010163 I [14392:70280341057040] KarafkaApp -- Karafka version: 1.3.5
Ruby version: 2.5.5
Ruby-kafka version: 0.7.10
Application client id: giorgio
Backend: inline
Batch fetching: false
Batch consuming: false
Boot file: /Users/serj/Projects/toptal/giorgio/karafka.rb
Environment: development
Kafka seed brokers: ["kafka://localhost:9092"]
```

And with JSON logging:

```
 bundle exec karafka server | jq
```

```json
{
  "host": "cube.local",
  "application": "App",
  "environment": "development",
  "timestamp": "2020-04-17T09:08:56.131481Z",
  "level": "info",
  "level_index": 2,
  "pid": 20797,
  "thread": "70321537510960",
  "name": "KarafkaApp",
  "message": "Karafka version: 1.3.5\nRuby version: 2.5.5\nRuby-kafka version: 0.7.10\nApplication client id: app\nBackend: inline\nBatch fetching: false\nBatch consuming: false\nBoot file: .../karafka.rb\nEnvironment: development\nKafka seed brokers: [\"kafka://localhost:9092\"]"
}
```