### PR TITLE
#582 - Fix for not being able to define seed_brokers on a per consumer_group basis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - #583 - Use Karafka.logger for CLI messages (prikha)
+- #582 - Cannot only define seed brokers in consumer groups
 
 ## 1.3.5 (2020-04-02)
 - #578 - ThreadError: can't be called from trap context patch

--- a/lib/karafka/connection/api_adapter.rb
+++ b/lib/karafka/connection/api_adapter.rb
@@ -14,11 +14,12 @@ module Karafka
     module ApiAdapter
       class << self
         # Builds all the configuration settings for Kafka.new method
+        # @param consumer_group [Karafka::Routing::ConsumerGroup] consumer group details
         # @return [Array<Hash>] Array with all the client arguments including hash with all
         #   the settings required by Kafka.new method
         # @note We return array, so we can inject any arguments we want, in case of changes in the
         #   raw driver
-        def client
+        def client(consumer_group)
           # This one is a default that takes all the settings except special
           # cases defined in the map
           settings = {
@@ -33,7 +34,9 @@ module Karafka
             # from the api_adapter mapping go somewhere else, not to the client directly
             next if AttributesMap.api_adapter.values.flatten.include?(setting_name)
 
-            settings[setting_name] = setting_value
+            # Select the setting from the consumer group or fallback to the app defaults if
+            # something was not configured on a consumer group level
+            settings[setting_name] = consumer_group.to_h.fetch(setting_name) || setting_value
           end
 
           settings_hash = sanitize(settings)

--- a/lib/karafka/connection/api_adapter.rb
+++ b/lib/karafka/connection/api_adapter.rb
@@ -27,16 +27,17 @@ module Karafka
             client_id: ::Karafka::App.config.client_id
           }
 
-          kafka_configs.each do |setting_name, setting_value|
+          kafka_configs.each_key do |setting_name|
             # All options for config adapter should be ignored as we're just interested
             # in what is left, as we want to pass all the options that are "typical"
             # and not listed in the api_adapter special cases mapping. All the values
             # from the api_adapter mapping go somewhere else, not to the client directly
             next if AttributesMap.api_adapter.values.flatten.include?(setting_name)
 
-            # Select the setting from the consumer group or fallback to the app defaults if
-            # something was not configured on a consumer group level
-            settings[setting_name] = consumer_group.to_h.fetch(setting_name) || setting_value
+            # Settings for each consumer group are either defined per consumer group or are
+            # inherited from the global/general settings level, thus we don't have to fetch them
+            # from the kafka settings as they are already on a consumer group level
+            settings[setting_name] = consumer_group.public_send(setting_name)
           end
 
           settings_hash = sanitize(settings)

--- a/lib/karafka/connection/builder.rb
+++ b/lib/karafka/connection/builder.rb
@@ -6,9 +6,11 @@ module Karafka
     module Builder
       class << self
         # Builds a Kafka::Client instance that we use to work with Kafka cluster
+        # @param consumer_group [Karafka::Routing::ConsumerGroup] consumer group for which we want
+        #   to have a new Kafka client
         # @return [::Kafka::Client] returns a Kafka client
-        def call
-          Kafka.new(*ApiAdapter.client)
+        def call(consumer_group)
+          Kafka.new(*ApiAdapter.client(consumer_group))
         end
       end
     end

--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -97,7 +97,7 @@ module Karafka
       def kafka_consumer
         # @note We don't cache the connection internally because we cache kafka_consumer that uses
         #   kafka client object instance
-        @kafka_consumer ||= Builder.call.consumer(
+        @kafka_consumer ||= Builder.call(consumer_group).consumer(
           *ApiAdapter.consumer(consumer_group)
         ).tap do |consumer|
           consumer_group.topics.each do |topic|

--- a/spec/lib/karafka/connection/api_adapter_spec.rb
+++ b/spec/lib/karafka/connection/api_adapter_spec.rb
@@ -58,7 +58,10 @@ RSpec.describe Karafka::Connection::ApiAdapter do
           # or new not supported settings
           next unless Karafka::App.config.kafka.respond_to?(client_key)
 
-          hashed_details[client_key] = rand.to_s
+          key_value = rand.to_s
+
+          consumer_group.public_send(:"#{client_key}=", key_value)
+          hashed_details[client_key] = key_value
         end
       end
 

--- a/spec/lib/karafka/connection/api_adapter_spec.rb
+++ b/spec/lib/karafka/connection/api_adapter_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Karafka::Connection::ApiAdapter do
   end
 
   describe '#client' do
-    subject(:config) { described_class.client }
+    subject(:config) { described_class.client(consumer_group) }
 
     let(:expected_keys) { (attributes_map_values[:consumer] + %i[group_id]).sort }
 
@@ -64,6 +64,16 @@ RSpec.describe Karafka::Connection::ApiAdapter do
 
       it 'expect to have all the keys as kafka requires' do
         expect(config.last.keys.sort).to eq(expected_keys - %i[seed_brokers])
+      end
+    end
+
+    context 'when seed_brokers are defined per consumer group' do
+      let(:seed_brokers) { %w[kafka://not.a.localhost:9091] }
+
+      before { consumer_group.seed_brokers = seed_brokers }
+
+      it 'expect to use them instead of system default' do
+        expect(config.first).to eq seed_brokers
       end
     end
   end

--- a/spec/lib/karafka/connection/builder_spec.rb
+++ b/spec/lib/karafka/connection/builder_spec.rb
@@ -18,10 +18,18 @@ RSpec.describe Karafka::Connection::Builder do
         sasl_over_ssl: true
       ]
     end
+    let(:consumer_group) do
+      Karafka::Routing::ConsumerGroup.new(rand.to_s).tap do |cg|
+        cg.public_send(:topic=, rand.to_s) do
+          consumer Class.new(Karafka::BaseConsumer)
+          backend :inline
+        end
+      end
+    end
 
     it 'expect to build proper instance' do
       expect(Kafka).to receive(:new).with(*kafka_client_args).and_return(kafka_client)
-      expect(builder.call).to eq kafka_client
+      expect(builder.call(consumer_group)).to eq kafka_client
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/karafka/karafka/issues/582

Longer description:

The Kafka client settings were not populated down to the client but taken from the "global" settings. This was an unnoticed bug as it affected only the subset of client settings. Since each consumer group is anyhow built based on per consumer group settings OR (if not defined) based on the defaults, this fetches the proper settings directly from the consumer group object, ensuring, that the settings are always the one "closest" to the consumer group.
