### PR TITLE
Allow metadata access without deserialization attempt

### DIFF
--- a/lib/karafka/consumers/single_params.rb
+++ b/lib/karafka/consumers/single_params.rb
@@ -8,7 +8,7 @@ module Karafka
 
       # @return [Karafka::Params::Params] params instance for non batch consumption consumers
       def params
-        params_batch.first
+        params_batch.to_a.first
       end
     end
   end

--- a/lib/karafka/params/params.rb
+++ b/lib/karafka/params/params.rb
@@ -40,6 +40,14 @@ module Karafka
         end
       end
 
+      # override Hash#[] to allow lazy deserialization of payload
+      # @param key [String, Symbol] hash key
+      # @return [any]
+      def [](key)
+        deserialize! if key == 'payload'
+        super
+      end
+
       # @return [Karafka::Params::Params] This method will trigger deserializer execution. If we
       #   decide to retrieve data, deserializer will be executed to get data. Output of that will
       #   be merged to the current object. This object will be also marked as already deserialized,

--- a/spec/lib/karafka/consumers/single_params_spec.rb
+++ b/spec/lib/karafka/consumers/single_params_spec.rb
@@ -4,8 +4,17 @@ RSpec.describe Karafka::Consumers::SingleParams do
   subject(:consumer) { consumer_class.new(topic) }
 
   let(:consumer_class) { Class.new(Karafka::BaseConsumer) }
-  let(:params_batch) { [{ 'value' => {}.to_json }] }
+
+  let(:params_batch) { Karafka::Params::ParamsBatch.new(params_array) }
+  let(:deserialized_payload) { { rand.to_s => rand.to_s } }
+  let(:serialized_payload) { deserialized_payload.to_json }
   let(:topic) { build(:routing_topic) }
+  let(:kafka_message) { build(:kafka_fetched_message, value: serialized_payload) }
+  let(:params_array) do
+    [
+      Karafka::Params::Builders::Params.from_kafka_message(kafka_message, topic)
+    ]
+  end
 
   before do
     consumer.extend(described_class)
@@ -13,7 +22,7 @@ RSpec.describe Karafka::Consumers::SingleParams do
   end
 
   it 'expect to provide #params' do
-    expect(consumer.send(:params)).to eq consumer.send(:params_batch).first
+    expect(consumer.send(:params)).to eq consumer.send(:params_batch).to_a.first
   end
 
   it 'expect not to deserialize the value inside' do

--- a/spec/lib/karafka/params/builders/params_spec.rb
+++ b/spec/lib/karafka/params/builders/params_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Karafka::Params::Builders::Params do
     subject(:result) { described_class.from_kafka_message(fetched_message, routing_topic) }
 
     it { is_expected.to be_a(Karafka::Params::Params) }
-    it { expect(result.payload).to eq fetched_message.value }
+    it { expect(result.payload).to eq fetched_message.value.to_f }
+    it { expect(result['payload']).to eq fetched_message.value.to_f }
     it { expect(result.partition).to eq fetched_message.partition }
     it { expect(result.offset).to eq fetched_message.offset }
     it { expect(result.key).to eq fetched_message.key }

--- a/spec/lib/karafka/params/params_batch_spec.rb
+++ b/spec/lib/karafka/params/params_batch_spec.rb
@@ -3,11 +3,11 @@
 RSpec.describe Karafka::Params::ParamsBatch do
   subject(:params_batch) { described_class.new(params_array) }
 
-  let(:serialized_payload) { { rand.to_s => rand.to_s } }
-  let(:deserialized_payload) { serialized_payload.to_json }
+  let(:deserialized_payload) { { rand.to_s => rand.to_s } }
+  let(:serialized_payload) { deserialized_payload.to_json }
   let(:topic) { build(:routing_topic) }
-  let(:kafka_message1) { build(:kafka_fetched_message, value: deserialized_payload) }
-  let(:kafka_message2) { build(:kafka_fetched_message, value: deserialized_payload) }
+  let(:kafka_message1) { build(:kafka_fetched_message, value: serialized_payload) }
+  let(:kafka_message2) { build(:kafka_fetched_message, value: serialized_payload) }
   let(:params_array) do
     [
       Karafka::Params::Builders::Params.from_kafka_message(kafka_message1, topic),
@@ -41,7 +41,7 @@ RSpec.describe Karafka::Params::ParamsBatch do
 
   describe '#payloads' do
     it 'expect to return deserialized payloads from params within params batch' do
-      expect(params_batch.payloads).to eq [serialized_payload, serialized_payload]
+      expect(params_batch.payloads).to eq [deserialized_payload, deserialized_payload]
     end
 
     context 'when payloads were used for the first time' do


### PR DESCRIPTION
Fixes https://github.com/karafka/karafka/issues/598

~~However, it introduces another inconsistency: now `params['payload']` would return the payload without a deserialization attempt. @mensfeld please take a look, I'm not sure if this approach is valid or there is a better way.
If this **is** the way, probably we should override `Karafka::Params::Params#[]` to remove the inconsistency described above?~~

We decided to override `Hash#[]` method to remove any inconsistencies in payload access.
The small benchmark made shows there is no significant performance penalty in such an approach.
