### PR TITLE
Rescue Errno::EROFS in ensure_dir_exists

### DIFF
--- a/lib/karafka/instrumentation/logger.rb
+++ b/lib/karafka/instrumentation/logger.rb
@@ -39,7 +39,7 @@ module Karafka
       # Makes sure the log directory exists as long as we can write to it
       def ensure_dir_exists
         FileUtils.mkdir_p(File.dirname(log_path))
-      rescue Errno::EACCES
+      rescue Errno::EACCES, Errno::EROFS
         nil
       end
 


### PR DESCRIPTION
In case of passed read-only path as log_pass, `FileUtils.mkdir_p` raises `Errno::EROFS`.

That's a not target of the rescue clause, so cause unexpected behavior.

In my environment (macOS Big Sur 11.2.1), `bundle exec rspec` failed below error.

[![Image from Gyazo](https://i.gyazo.com/77ad7b9d80f35c34f3e5d025d8dea4dd.png)](https://gyazo.com/77ad7b9d80f35c34f3e5d025d8dea4dd)

## additional information
https://developer.apple.com/forums/thread/650016
> The system volume is now read-only so you should seek to avoid modifying system files.