### PR TITLE
Change `rails?` check to  `railties` gem

### DIFF
--- a/lib/karafka/cli/install.rb
+++ b/lib/karafka/cli/install.rb
@@ -34,7 +34,7 @@ module Karafka
           Bundler.read_file(
             Bundler.default_lockfile
           )
-        ).dependencies.key?('rails')
+        ).dependencies.key?('railties')
       end
 
       # Install all required things for Karafka application in current directory

--- a/spec/lib/karafka/cli/install_spec.rb
+++ b/spec/lib/karafka/cli/install_spec.rb
@@ -36,14 +36,14 @@ RSpec.describe Karafka::Cli::Install do
 
     before { allow(Bundler).to receive(:read_file).and_return(gemfile) }
 
-    context 'when rails is not in the gemfile' do
+    context 'when railties is not in the gemfile' do
       let(:gemfile) { '' }
 
       it { expect(is_rails).to eq false }
     end
 
-    context 'when rails is in the gemfile' do
-      let(:gemfile) { "DEPENDENCIES\n  rails" }
+    context 'when railties is in the gemfile' do
+      let(:gemfile) { "DEPENDENCIES\n  railties" }
 
       it { expect(is_rails).to eq true }
     end


### PR DESCRIPTION
`rails` is just a meta-gem with a bunch of dependencies, all the Rails stuff can be installed without it and depends on `railties`.