### PR TITLE
Remove rake dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Remove Ruby 2.5 support and update minimum Ruby requirement to 2.6
+- Remove rake dependency
 
 ## 1.4.3 (2021-03-24)
 - Fixes for Ruby 3.0 compatibility

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,6 @@ PATH
       dry-validation (~> 1.2)
       envlogic (~> 1.1)
       irb (~> 1.0)
-      rake (>= 11.3)
       ruby-kafka (>= 1.0.0)
       thor (>= 0.20)
       waterdrop (~> 1.4.0)
@@ -123,6 +122,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/karafka.gemspec
+++ b/karafka.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dry-validation', '~> 1.2'
   spec.add_dependency 'envlogic', '~> 1.1'
   spec.add_dependency 'irb', '~> 1.0'
-  spec.add_dependency 'rake', '>= 11.3'
   spec.add_dependency 'ruby-kafka', '>= 1.0.0'
   spec.add_dependency 'thor', '>= 0.20'
   spec.add_dependency 'waterdrop', '~> 1.4.0'


### PR DESCRIPTION
We are trying to use Karafka with an application that uses an old version of rake. After analyzing the commits, I realized that rake is no longer used by this project but the dependency is still present in the gemspec. 

This pull request removes the dependency. 