### PR TITLE
Fixup logger checks for non-writeable logfile

### DIFF
--- a/lib/karafka/instrumentation/logger.rb
+++ b/lib/karafka/instrumentation/logger.rb
@@ -20,7 +20,6 @@ module Karafka
       # @param _args Any arguments that we don't care about but that are needed in order to
       #   make this logger compatible with the default Ruby one
       def initialize(*_args)
-        ensure_dir_exists
         super(target)
         self.level = ENV_MAP[Karafka.env] || ENV_MAP['default']
       end
@@ -33,14 +32,7 @@ module Karafka
       def target
         Karafka::Helpers::MultiDelegator
           .delegate(:write, :close)
-          .to($stdout, file)
-      end
-
-      # Makes sure the log directory exists as long as we can write to it
-      def ensure_dir_exists
-        FileUtils.mkdir_p(File.dirname(log_path))
-      rescue Errno::EACCES, Errno::EROFS
-        nil
+          .to(*[$stdout, file].compact)
       end
 
       # @return [Pathname] Path to a file to which we should log
@@ -51,7 +43,11 @@ module Karafka
       # @return [File] file to which we want to write our logs
       # @note File is being opened in append mode ('a')
       def file
+        FileUtils.mkdir_p(File.dirname(log_path))
+
         @file ||= File.open(log_path, 'a')
+      rescue Errno::EACCES, Errno::EROFS
+        nil
       end
     end
   end

--- a/spec/lib/karafka/instrumentation/logger_spec.rb
+++ b/spec/lib/karafka/instrumentation/logger_spec.rb
@@ -3,54 +3,94 @@
 RSpec.describe Karafka::Instrumentation::Logger do
   subject(:logger) { described_class.new }
 
+  let(:delegate_scope) { class_double(Karafka::Helpers::MultiDelegator) }
+
   # We use a singleton logger that could be already initialized in other specs, so
   # in order to check all the behaviours we need to "reset" it to the initial state
-  before { logger.instance_variable_set('@file', nil) }
+  before do
+    allow(Karafka::Helpers::MultiDelegator).to receive(:delegate)
+      .with(:write, :close)
+      .and_return(delegate_scope)
+    allow(delegate_scope).to receive(:to)
+  end
 
   specify { expect(described_class).to be < ::Logger }
 
   describe '#new' do
-    let(:target) { double }
-    let(:log_file) { Karafka::App.root.join('log', "#{Karafka.env}.log") }
-    # A Pathname, because this is what is returned by File.join
-    let(:log_dir) { File.dirname(log_file) }
-    let(:parent_dir) { File.dirname(log_dir) }
+    let(:karafka_test_root) { Pathname(Dir::Tmpname.create('karafka') { |_| }) }
+    let(:log_path) { karafka_test_root.join("log/#{Karafka.env}.log") }
+    let(:file_matcher) { having_attributes(closed?: false, path: log_path.to_path, class: File) }
+
+    before { allow(Karafka::App).to receive(:root).and_return(karafka_test_root) }
+
+    after { FileUtils.rm_rf(karafka_test_root) }
 
     it 'expect to be of a proper level' do
       expect(logger.level).to eq ::Logger::ERROR
     end
 
     context 'when the dir does not exist' do
-      before do
-        logger.instance_variable_set(:'@log_path', log_path)
-        logger.send(:ensure_dir_exists)
+      context 'when parent dir is not writable' do
+        before { Dir.mkdir(karafka_test_root, 0o500) }
+
+        specify do
+          described_class.new
+          expect(delegate_scope).to have_received(:to).with($stdout)
+        end
       end
 
-      context 'when it is not writable' do
-        let(:log_path) { '/non-existing/test.log' }
+      context 'when parent dir is writable' do
+        before { Dir.mkdir(karafka_test_root, 0o700) }
 
-        it { expect(File.exist?('/non-existing/')).to eq(false) }
-      end
-
-      context 'when it is writable' do
-        let(:log_path) { '/tmp/non-existing/test.log' }
-
-        it { expect(File.exist?(File.dirname(log_path))).to eq(true) }
+        specify do
+          described_class.new
+          expect(delegate_scope).to have_received(:to).with($stdout, file_matcher)
+        end
       end
     end
-  end
 
-  describe '#target' do
-    let(:delegate_scope) { double }
+    context 'when the dir exists and file does not exists' do
+      before { Dir.mkdir(karafka_test_root, 0o700) }
 
-    it 'delegates write and close to $stdout and file' do
-      expect(Karafka::Helpers::MultiDelegator).to receive(:delegate)
-        .with(:write, :close)
-        .and_return(delegate_scope)
+      context 'when dir is not writable' do
+        before { Dir.mkdir(File.dirname(log_path), 0o500) }
 
-      expect(delegate_scope).to receive(:to).with($stdout, logger.send(:file))
+        specify do
+          described_class.new
+          expect(delegate_scope).to have_received(:to).with($stdout)
+        end
+      end
 
-      logger.send(:target)
+      context 'when dir is writable' do
+        before { Dir.mkdir(File.dirname(log_path), 0o700) }
+
+        specify do
+          described_class.new
+          expect(delegate_scope).to have_received(:to).with($stdout, file_matcher)
+        end
+      end
+    end
+
+    context 'when file exists' do
+      before { FileUtils.mkdir_p(File.dirname(log_path), mode: 0o700) }
+
+      context 'when file is writable' do
+        before { FileUtils.install('/dev/null', log_path, mode: 0o700) }
+
+        specify do
+          described_class.new
+          expect(delegate_scope).to have_received(:to).with($stdout, file_matcher)
+        end
+      end
+
+      context 'when file is not writable' do
+        before { FileUtils.install('/dev/null', log_path, mode: 0o400) }
+
+        specify do
+          described_class.new
+          expect(delegate_scope).to have_received(:to).with($stdout)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This was partially fixed in #651, but we're still raising if log directory is writable/exists, but logfile is not.

Consolidate file-creation stuff and handle errors in the single place.