### PR TITLE
#689 - update initialization message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka framework changelog
 
+## Unreleased
+- #689 - Update the stdout initialization message for framework initialization
+
 ## 1.4.4 (2021-04-19)
 - Remove Ruby 2.5 support and update minimum Ruby requirement to 2.6
 - Remove rake dependency

--- a/lib/karafka/instrumentation/stdout_listener.rb
+++ b/lib/karafka/instrumentation/stdout_listener.rb
@@ -103,10 +103,10 @@ module Karafka
         info "Responded from #{calling.class} using #{responder} with following data #{data}"
       end
 
-      # Logs info that we're initializing Karafka app
+      # Logs info that we're initializing Karafka framework components
       # @param _event [Dry::Events::Event] event details including payload
       def on_app_initializing(_event)
-        info "Initializing Karafka server #{::Process.pid}"
+        info "Initializing Karafka framework #{::Process.pid}"
       end
 
       # Logs info that we're running Karafka app

--- a/spec/lib/karafka/instrumentation/stdout_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/stdout_listener_spec.rb
@@ -173,9 +173,9 @@ RSpec.describe Karafka::Instrumentation::StdoutListener do
     subject(:trigger) { listener.on_app_initializing(event) }
 
     let(:payload) { {} }
-    let(:message) { "Initializing Karafka server #{::Process.pid}" }
+    let(:message) { "Initializing Karafka framework #{::Process.pid}" }
 
-    it 'expect logger to log server initializing' do
+    it 'expect logger to log framework initializing' do
       # We had to add at least once as it runs in a separate thread and can interact
       # with other specs - this is a cheap workaround
       expect(Karafka.logger).to receive(:info).with(message).at_least(:once)


### PR DESCRIPTION
This PR updates the message that is printed with stdout logger when booting the framework.

The previous message was misleading for Ruby on Rails users. Users would think that when booting the framework a karafka process starts, while it was not true. Booting just bootstraps the framework components when executed outside of the server process.

close: https://github.com/karafka/karafka/issues/689