### PR TITLE
Allow 'rails' in Gemfile to enable rails-aware generator

### DIFF
--- a/lib/karafka/cli/install.rb
+++ b/lib/karafka/cli/install.rb
@@ -30,11 +30,12 @@ module Karafka
       # @param args [Array] all the things that Thor CLI accepts
       def initialize(*args)
         super
-        @rails = Bundler::LockfileParser.new(
+        dependencies = Bundler::LockfileParser.new(
           Bundler.read_file(
             Bundler.default_lockfile
           )
-        ).dependencies.key?('railties')
+        ).dependencies
+        @rails = dependencies.key?('railties') || dependencies.key?('rails')
       end
 
       # Install all required things for Karafka application in current directory


### PR DESCRIPTION
The current generator does not recognize having just 'rails' in Gemfile, and generates the non-rails app class.

With this change, it supports either 'railties' (for piecemeal dependency) or 'rails' (for all-in).