### PR TITLE
Support exactly once delivery and transactional messaging

### DIFF
--- a/lib/karafka/connection/api_adapter.rb
+++ b/lib/karafka/connection/api_adapter.rb
@@ -12,6 +12,10 @@ module Karafka
     #   do nothing. So we don't have to worry about injecting our internal settings
     #   into the client and breaking stuff
     module ApiAdapter
+      # Settings that are not accepted by `ruby-kafka` for consumer, but allowed for producer
+      PRODUCER_ONLY_SETTINGS = %i[idempotent transactional transactional_timeout].freeze
+      private_constant :PRODUCER_ONLY_SETTINGS
+
       class << self
         # Builds all the configuration settings for Kafka.new method
         # @param consumer_group [Karafka::Routing::ConsumerGroup] consumer group details
@@ -41,6 +45,7 @@ module Karafka
           end
 
           settings_hash = sanitize(settings)
+          PRODUCER_ONLY_SETTINGS.each { |x| settings_hash.delete(x) }
 
           # Normalization for the way Kafka::Client accepts arguments from  0.5.3
           [settings_hash.delete(:seed_brokers), settings_hash]

--- a/lib/karafka/contracts/consumer_group.rb
+++ b/lib/karafka/contracts/consumer_group.rb
@@ -67,6 +67,10 @@ module Karafka
         # It's not with other encryptions as it has some more rules
         optional(:sasl_scram_mechanism)
           .maybe(:str?, included_in?: SASL_SCRAM_MECHANISMS)
+
+        optional(:idempotent).maybe(:bool?)
+        optional(:transactional).maybe(:bool?)
+        optional(:transactional_timeout).filled { (int? | float?) & gteq?(0) }
       end
 
       # Uri rule to check if uri is in a Karafka acceptable format

--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -173,6 +173,12 @@ module Karafka
         # @param sasl_oauth_token_provider [Object, nil] OAuthBearer Token Provider instance that
         #   implements method token.
         setting :sasl_oauth_token_provider, nil
+        # option [Boolean]
+        setting :idempotent, false
+        # option [Boolean]
+        setting :transactional, false
+        # option [Integer]
+        setting :transactional_timeout, 60
       end
 
       # Namespace for internal settings that should not be modified

--- a/spec/lib/karafka/contracts/consumer_group_spec.rb
+++ b/spec/lib/karafka/contracts/consumer_group_spec.rb
@@ -805,4 +805,46 @@ RSpec.describe Karafka::Contracts::ConsumerGroup do
       it { expect(check).to be_success }
     end
   end
+
+  context 'when we validate idempotent' do
+    context 'when it is not a bool' do
+      before { config[:idempotent] = 2 }
+
+      it { expect(check).not_to be_success }
+    end
+  end
+
+  context 'when we validate transactional' do
+    context 'when it is not a bool' do
+      before { config[:transactional] = 2 }
+
+      it { expect(check).not_to be_success }
+    end
+  end
+
+  context 'when we validate transactional_timeout' do
+    context 'when transactional_timeout is nil' do
+      before { config[:transactional_timeout] = nil }
+
+      it { expect(check).not_to be_success }
+    end
+
+    context 'when min_bytes is not integer' do
+      before { config[:transactional_timeout] = 's' }
+
+      it { expect(check).not_to be_success }
+    end
+
+    context 'when min_bytes is less than 0' do
+      before { config[:transactional_timeout] = -1 }
+
+      it { expect(check).not_to be_success }
+    end
+
+    context 'when min_bytes is a float' do
+      before { config[:transactional_timeout] = rand(100) + 0.1 }
+
+      it { expect(check).to be_success }
+    end
+  end
 end

--- a/spec/lib/karafka/setup/configurators/water_drop_spec.rb
+++ b/spec/lib/karafka/setup/configurators/water_drop_spec.rb
@@ -6,10 +6,18 @@ RSpec.describe Karafka::Setup::Configurators::WaterDrop do
   let(:config) { Karafka::App.config }
 
   describe '.call' do
-    before { water_drop_configurator.call(config) }
+    before do
+      config.kafka.idempotent = true
+      config.kafka.transactional = true
+      config.kafka.transactional_timeout = 1337
+      water_drop_configurator.call(config)
+    end
 
     it { expect(WaterDrop.config.deliver).to eq true }
     it { expect(WaterDrop.config.kafka.seed_brokers).to eq config.kafka.seed_brokers }
     it { expect(WaterDrop.config.logger).to eq Karafka::App.logger }
+    it { expect(WaterDrop.config.kafka.idempotent).to eq(true) }
+    it { expect(WaterDrop.config.kafka.transactional).to eq(true) }
+    it { expect(WaterDrop.config.kafka.transactional_timeout).to eq(1337) }
   end
 end


### PR DESCRIPTION
karafka config doesn't allow it, so additional `WaterDrop` configuration is needed and it needs to be done carefully, because karafka will overwrite it to `false` with it's own config on initialization.