### PR TITLE
make simple routing great again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - `sidekiq-backend` is no longer supported
 - `testing` gem for RSpec has been updated
 - `WaterDrop` `2.0` support
+- Simple routing style (`0.5`) now builds a single consumer group instead of one per topic
 
 ## 1.4.7 (2021-09-04)
 - Update ruby-kafka to `1.4.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Karafka framework changelog
 
 ## 2.0.0-alpha1 (Unreleased)
-- Switch from `ruby-kafka` to `librdkafk` as an underlying driver
+- Switch from `ruby-kafka` to `librdkafka` as an underlying driver
 - Introduce fully automatic integration tests that go through the whole server lifecycle
 - Integrate WaterDrop tightly with autoconfiguration inheritance and an option to redefine it
 - Change license to `LGPL-3.0`
@@ -18,7 +18,7 @@
 - Remove responders in favour of WaterDrop `2.0` producer
 - Remove pidfiles support
 - Remove daemonization support
-- Stop validating `kafka` configuration beyond minimum as it is handled by `librdkafk`
+- Stop validating `kafka` configuration beyond minimum as it is handled by `librdkafka`
 - Remove topics mappers concept
 - Improve environment auto-detection
 - Reorganize monitoring to match new concepts

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 Karafka is a framework used to simplify Apache Kafka based Ruby and Ruby on Rails applications development.
 
 ```ruby
-# Define what topics you want to consume with which consumers
-Karafka::App.consumer_groups.draw do
+# Define what topics you want to consume with which consumers in consumer groups
+Karafka::App.routes.draw do
   topic 'system_events' do
     consumer EventsConsumer
   end

--- a/lib/karafka/app.rb
+++ b/lib/karafka/app.rb
@@ -20,6 +20,9 @@ module Karafka
           .flat_map(&:subscription_groups)
       end
 
+      # Just a nicer name for the consumer groups
+      alias routes consumer_groups
+
       Status.instance_methods(false).each do |delegated|
         define_method(delegated) do
           App.config.internal.status.send(delegated)

--- a/lib/karafka/templates/karafka.rb.erb
+++ b/lib/karafka/templates/karafka.rb.erb
@@ -40,7 +40,7 @@ class KarafkaApp < Karafka::App
   Karafka.monitor.subscribe(Karafka::Instrumentation::StdoutListener.new)
   # Karafka.monitor.subscribe(Karafka::Instrumentation::ProctitleListener.new)
 
-  consumer_groups.draw do
+  routes.draw do
     topic :example do
       consumer ExampleConsumer
     end

--- a/spec/integrations/config_validation.rb
+++ b/spec/integrations/config_validation.rb
@@ -13,7 +13,7 @@ begin
     config.kafka = { 'message.max.bytes' => 0, 'message.copy.max.bytes' => -1 }
   end
 
-  Karafka::App.consumer_groups.draw do
+  Karafka::App.routes.draw do
     consumer_group 'usual' do
       topic 'regular' do
         consumer Class.new

--- a/spec/integrations/consumer_producer_ping_pong.rb
+++ b/spec/integrations/consumer_producer_ping_pong.rb
@@ -24,7 +24,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topic do
       consumer Consumer

--- a/spec/integrations/consumption_constant_error_should_not_clog_others.rb
+++ b/spec/integrations/consumption_constant_error_should_not_clog_others.rb
@@ -47,7 +47,7 @@ Karafka::App.routes.draw do
 end
 
 start_karafka_and_wait_until do
-  # We substract 3 as 3 values are from the offsets
+  # We subtract 3 as 3 values are from the offsets
   (DataCollector.data.values.map(&:size).sum - 3) >= 200
 end
 

--- a/spec/integrations/consumption_constant_error_should_not_clog_others.rb
+++ b/spec/integrations/consumption_constant_error_should_not_clog_others.rb
@@ -37,7 +37,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     # Special topic with 3 partitions available
     topic 'part3_1' do

--- a/spec/integrations/consumption_from_earliest.rb
+++ b/spec/integrations/consumption_from_earliest.rb
@@ -17,7 +17,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topic do
       consumer Consumer

--- a/spec/integrations/consumption_from_earliest_simple_routing.rb
+++ b/spec/integrations/consumption_from_earliest_simple_routing.rb
@@ -18,7 +18,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   topic DataCollector.topic do
     consumer Consumer
   end

--- a/spec/integrations/consumption_from_latest.rb
+++ b/spec/integrations/consumption_from_latest.rb
@@ -23,7 +23,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topic do
       consumer Consumer

--- a/spec/integrations/consumption_non_critical_error_recovery.rb
+++ b/spec/integrations/consumption_non_critical_error_recovery.rb
@@ -30,7 +30,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topic do
       consumer Consumer

--- a/spec/integrations/consumption_of_many_partitions_with_error.rb
+++ b/spec/integrations/consumption_of_many_partitions_with_error.rb
@@ -32,7 +32,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     # Special topic with 10 partitions available
     topic 'part10_0' do

--- a/spec/integrations/consumption_of_many_partitions_with_many_workers.rb
+++ b/spec/integrations/consumption_of_many_partitions_with_many_workers.rb
@@ -26,7 +26,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     # Special topic with 10 partitions available
     topic 'part10_1' do

--- a/spec/integrations/consumption_of_many_topics_on_many_workers.rb
+++ b/spec/integrations/consumption_of_many_topics_on_many_workers.rb
@@ -21,7 +21,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     DataCollector.topics.first(10).each do |topic_name|
       topic topic_name do

--- a/spec/integrations/consumption_of_many_topics_with_different_settings.rb
+++ b/spec/integrations/consumption_of_many_topics_with_different_settings.rb
@@ -21,7 +21,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     DataCollector.topics.first(10).each_with_index do |topic_name, index|
       topic topic_name do

--- a/spec/integrations/consumption_of_messages_with_headers.rb
+++ b/spec/integrations/consumption_of_messages_with_headers.rb
@@ -17,7 +17,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topic do
       consumer Consumer

--- a/spec/integrations/consumption_with_max_messages.rb
+++ b/spec/integrations/consumption_with_max_messages.rb
@@ -17,7 +17,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topic do
       max_messages 5

--- a/spec/integrations/custom_deserializer_usage.rb
+++ b/spec/integrations/custom_deserializer_usage.rb
@@ -23,7 +23,7 @@ class CustomDeserializer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topic do
       consumer Consumer

--- a/spec/integrations/default_deserializer_usage.rb
+++ b/spec/integrations/default_deserializer_usage.rb
@@ -17,7 +17,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topic do
       consumer Consumer

--- a/spec/integrations/manual_offset_with_error_every_bang.rb
+++ b/spec/integrations/manual_offset_with_error_every_bang.rb
@@ -29,7 +29,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topic do
       consumer Consumer

--- a/spec/integrations/manual_offset_with_error_every_non_bang.rb
+++ b/spec/integrations/manual_offset_with_error_every_non_bang.rb
@@ -29,7 +29,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topic do
       consumer Consumer

--- a/spec/integrations/manual_offset_with_error_interval_bang.rb
+++ b/spec/integrations/manual_offset_with_error_interval_bang.rb
@@ -30,7 +30,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topic do
       consumer Consumer

--- a/spec/integrations/manual_offset_with_error_interval_non_bang.rb
+++ b/spec/integrations/manual_offset_with_error_interval_non_bang.rb
@@ -30,7 +30,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topic do
       consumer Consumer

--- a/spec/integrations/messages_and_metadata_details.rb
+++ b/spec/integrations/messages_and_metadata_details.rb
@@ -17,7 +17,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topic do
       consumer Consumer

--- a/spec/integrations/on_hanging_jobs_and_a_shutdown.rb
+++ b/spec/integrations/on_hanging_jobs_and_a_shutdown.rb
@@ -17,7 +17,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topic do
       consumer Consumer

--- a/spec/integrations/on_hanging_on_shutdown_job_and_a_shutdown.rb
+++ b/spec/integrations/on_hanging_on_shutdown_job_and_a_shutdown.rb
@@ -20,7 +20,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topic do
       consumer Consumer

--- a/spec/integrations/on_hanging_poll_and_shutdown.rb
+++ b/spec/integrations/on_hanging_poll_and_shutdown.rb
@@ -16,7 +16,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topic do
       # This will force Karafka to be in a "permanent" poll

--- a/spec/integrations/on_shutdown_when_messages_received.rb
+++ b/spec/integrations/on_shutdown_when_messages_received.rb
@@ -26,7 +26,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     topic topic1 do
       consumer Consumer

--- a/spec/integrations/on_shutdown_when_no_messages_received.rb
+++ b/spec/integrations/on_shutdown_when_no_messages_received.rb
@@ -17,7 +17,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topic do
       consumer Consumer

--- a/spec/integrations/one_consumer_group_two_topics.rb
+++ b/spec/integrations/one_consumer_group_two_topics.rb
@@ -28,7 +28,7 @@ class Consumer2 < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     topic topic1 do
       consumer Consumer1

--- a/spec/integrations/one_worker_many_topics.rb
+++ b/spec/integrations/one_worker_many_topics.rb
@@ -28,7 +28,7 @@ class Consumer2 < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     topic topic1 do
       consumer Consumer1

--- a/spec/integrations/routing_and_cli_validation.rb
+++ b/spec/integrations/routing_and_cli_validation.rb
@@ -11,7 +11,7 @@ setup_karafka
 guarded = []
 
 begin
-  Karafka::App.consumer_groups.draw do
+  Karafka::App.routes.draw do
     consumer_group 'regular' do
       topic '#$%^&*(' do
         consumer Class.new
@@ -23,7 +23,7 @@ rescue Karafka::Errors::InvalidConfigurationError
 end
 
 begin
-  Karafka::App.consumer_groups.draw do
+  Karafka::App.routes.draw do
     consumer_group '#$%^&*(' do
       topic 'regular' do
         consumer Class.new

--- a/spec/integrations/routing_with_the_simple_routes_style.rb
+++ b/spec/integrations/routing_with_the_simple_routes_style.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../')))
+require ROOT_PATH.join('spec/integrations_helper.rb')
+
+# Karafka should allow to use the '.routes' alias for routing builder and it should support a case
+# where there is a single consumer group with multiple topics
+setup_karafka
+
+Karafka::App.routes.draw do
+  topic 'topic1' do
+    consumer Class.new
+  end
+
+  topic 'topic2' do
+    consumer Class.new
+  end
+
+  topic 'topic3' do
+    consumer Class.new
+  end
+end
+
+assert_equal 1, Karafka::App.routes.size
+assert_equal 1, Karafka::App.consumer_groups.size
+assert_equal 1, Karafka::App.subscription_groups.size
+assert_equal 3, Karafka::App.consumer_groups.first.topics.size
+assert_equal 'topic1', Karafka::App.consumer_groups.first.topics.first.name
+assert_equal 'topic2', Karafka::App.consumer_groups.first.topics[1].name
+assert_equal 'topic3', Karafka::App.consumer_groups.first.topics[2].name

--- a/spec/integrations/routing_with_the_simple_routes_style.rb
+++ b/spec/integrations/routing_with_the_simple_routes_style.rb
@@ -28,3 +28,27 @@ assert_equal 3, Karafka::App.consumer_groups.first.topics.size
 assert_equal 'topic1', Karafka::App.consumer_groups.first.topics.first.name
 assert_equal 'topic2', Karafka::App.consumer_groups.first.topics[1].name
 assert_equal 'topic3', Karafka::App.consumer_groups.first.topics[2].name
+
+# Re-running simple routing should just add more topics
+
+Karafka::App.routes.draw do
+  topic 'topic4' do
+    consumer Class.new
+  end
+
+  topic 'topic5' do
+    consumer Class.new
+  end
+
+  topic 'topic6' do
+    consumer Class.new
+  end
+end
+
+assert_equal 1, Karafka::App.routes.size
+assert_equal 1, Karafka::App.consumer_groups.size
+assert_equal 1, Karafka::App.subscription_groups.size
+assert_equal 6, Karafka::App.consumer_groups.first.topics.size
+assert_equal 'topic4', Karafka::App.consumer_groups.first.topics[3].name
+assert_equal 'topic5', Karafka::App.consumer_groups.first.topics[4].name
+assert_equal 'topic6', Karafka::App.consumer_groups.first.topics[5].name

--- a/spec/integrations/seek_backward_from_consumer.rb
+++ b/spec/integrations/seek_backward_from_consumer.rb
@@ -38,7 +38,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topic do
       consumer Consumer

--- a/spec/integrations/seek_to_a_given_offset_from_consumer.rb
+++ b/spec/integrations/seek_to_a_given_offset_from_consumer.rb
@@ -30,7 +30,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topic do
       consumer Consumer

--- a/spec/integrations/simple_consumption_from_earliest.rb
+++ b/spec/integrations/simple_consumption_from_earliest.rb
@@ -17,7 +17,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.topic do
     topic DataCollector.topic do
       consumer Consumer

--- a/spec/integrations/two_consumer_groups_same_topic.rb
+++ b/spec/integrations/two_consumer_groups_same_topic.rb
@@ -18,7 +18,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_groups.first do
     topic DataCollector.topic do
       consumer Consumer

--- a/spec/integrations/worker_critical_error_behaviour.rb
+++ b/spec/integrations/worker_critical_error_behaviour.rb
@@ -31,7 +31,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.consumer_groups.draw do
+Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topic do
       consumer Consumer

--- a/spec/lib/karafka/routing/builder_spec.rb
+++ b/spec/lib/karafka/routing/builder_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe_current do
   after { builder.clear }
 
   describe '#draw' do
-    context 'when we use 0.5 compatible simple topic style' do
+    context 'when we use simple topic style' do
       let(:topic1) { builder.first.topics.first }
-      let(:topic2) { builder.last.topics.first }
-      let(:consumer_group1) do
+      let(:topic2) { builder.last.topics.last }
+      let(:draw1) do
         builder.draw do
           topic :topic_name1 do
             # Here we should have instance doubles, etc but it takes
@@ -22,7 +22,7 @@ RSpec.describe_current do
           end
         end
       end
-      let(:consumer_group2) do
+      let(:draw2) do
         builder.draw do
           topic :topic_name2 do
             consumer Class.new(Karafka::BaseConsumer)
@@ -32,20 +32,19 @@ RSpec.describe_current do
       end
 
       before do
-        consumer_group1
-        consumer_group2
+        draw1
+        draw2
       end
 
       # This needs to have twice same name as for a non grouped in consumer group topics,
-      # we build id based on the consumer group id, here it is virtual and built based on the
-      # topic name
-      it { expect(topic1.id).to eq "#{Karafka::App.config.client_id}_topic_name1_topic_name1" }
-      it { expect(topic2.id).to eq "#{Karafka::App.config.client_id}_topic_name2_topic_name2" }
-      it { expect(builder.size).to eq 2 }
+      # we build id based on the consumer group id, here it is virtual and built with 'app' as a
+      # group name
+      it { expect(topic1.id).to eq "#{Karafka::App.config.client_id}_app_topic_name1" }
+      it { expect(topic2.id).to eq "#{Karafka::App.config.client_id}_app_topic_name2" }
+      it { expect(builder.size).to eq 1 }
       it { expect(topic1.name).to eq 'topic_name1' }
       it { expect(topic2.name).to eq 'topic_name2' }
-      it { expect(builder.first.id).to eq "#{Karafka::App.config.client_id}_topic_name1" }
-      it { expect(builder.last.id).to eq "#{Karafka::App.config.client_id}_topic_name2" }
+      it { expect(builder.first.id).to eq "#{Karafka::App.config.client_id}_app" }
     end
 
     context 'when we use 0.6 simple topic style single topic groups' do


### PR DESCRIPTION
This PR makes the old `0.5` routing style as a default, allowing for consumer group drop but with preservation of a single consumer group