### PR TITLE
#raw_payloads on batches

### DIFF
--- a/lib/karafka/messages/messages.rb
+++ b/lib/karafka/messages/messages.rb
@@ -35,6 +35,11 @@ module Karafka
         map(&:payload)
       end
 
+      # @return [Array<String>] array with raw, not deserialized payloads
+      def raw_payloads
+        map(&:raw_payload)
+      end
+
       # @return [Karafka::Messages::Message] first message
       def first
         @messages_array.first

--- a/spec/integrations/consumption_with_long_living_buffer.rb
+++ b/spec/integrations/consumption_with_long_living_buffer.rb
@@ -13,6 +13,7 @@ elements = Array.new(100) { SecureRandom.uuid }
 
 class Consumer < Karafka::BaseConsumer
   def initialize
+    super
     # Karafka never uses same consumer instance for multiple partitions of the same topic, thus we
     # do not need thread safe structures here
     @buffer = []
@@ -22,7 +23,7 @@ class Consumer < Karafka::BaseConsumer
   def consume
     @batches += 1
 
-    messages.each do |message|
+    messages.each do
       DataCollector.data[0] << true
     end
 
@@ -52,4 +53,4 @@ end
 
 assert_equal 50, DataCollector.data[:batches]
 assert_equal elements, DataCollector.data[:buffer].flatten
-assert_equal true, DataCollector.data[:buffer].all? { |sub| sub.size < 3 }
+assert_equal true, (DataCollector.data[:buffer].all? { |sub| sub.size < 3 })

--- a/spec/integrations/consumption_with_long_living_buffer.rb
+++ b/spec/integrations/consumption_with_long_living_buffer.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../')))
+require ROOT_PATH.join('spec/integrations_helper.rb')
+
+# Karafka should allow to create a long living buffer that we can use and fill as we go, beyond
+# a single batch of data
+
+# This will force several batches, so we won't end up with 1 huge as this is not what we want here
+setup_karafka { |config| config.max_messages = 2 }
+
+elements = Array.new(100) { SecureRandom.uuid }
+
+class Consumer < Karafka::BaseConsumer
+  def initialize
+    # Karafka never uses same consumer instance for multiple partitions of the same topic, thus we
+    # do not need thread safe structures here
+    @buffer = []
+    @batches = 0
+  end
+
+  def consume
+    @batches += 1
+
+    messages.each do |message|
+      DataCollector.data[0] << true
+    end
+
+    @buffer << messages.raw_payloads
+  end
+
+  # Transfer the buffer data outside of the consumer
+  def on_shutdown
+    DataCollector.data[:batches] = @batches
+    DataCollector.data[:buffer] = @buffer
+  end
+end
+
+Karafka::App.routes.draw do
+  consumer_group DataCollector.consumer_group do
+    topic DataCollector.topic do
+      consumer Consumer
+    end
+  end
+end
+
+elements.each { |data| produce(DataCollector.topic, data) }
+
+start_karafka_and_wait_until do
+  DataCollector.data[0].size >= 100
+end
+
+assert_equal 50, DataCollector.data[:batches]
+assert_equal elements, DataCollector.data[:buffer].flatten
+assert_equal true, DataCollector.data[:buffer].all? { |sub| sub.size < 3 }

--- a/spec/lib/karafka/messages/messages_spec.rb
+++ b/spec/lib/karafka/messages/messages_spec.rb
@@ -38,15 +38,29 @@ RSpec.describe_current do
   end
 
   describe '#payloads' do
-    it 'expect to return deserialized payloads from params within params batch' do
+    it 'expect to return deserialized payloads from messages within a batch' do
       expect(messages.payloads).to eq [deserialized_payload, deserialized_payload]
     end
 
     context 'when payloads were used for the first time' do
       before { messages.payloads }
 
-      it 'expect to mark as serialized all the params inside the batch' do
+      it 'expect to mark as serialized all the messages inside the batch' do
         expect(messages.to_a.all?(&:deserialized?)).to eq true
+      end
+    end
+  end
+
+  describe '#raw_payloads' do
+    it 'expect to return raw payloads from messages within a batch' do
+      expect(messages.raw_payloads).to eq [serialized_payload, serialized_payload]
+    end
+
+    context 'when payloads were used for the first time' do
+      before { messages.payloads }
+
+      it 'expect to still keep the raw references' do
+        expect(messages.raw_payloads).to eq [serialized_payload, serialized_payload]
       end
     end
   end


### PR DESCRIPTION
This PR provides a `#raw_payloads` method on the messages batch and adds additional integrations spec.