### PR TITLE
v1.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Karafka framework changelog
 
-## Unreleased
+## 1.4.9 (2021-09-29)
 - fix `dry-configurable` deprecation warnings for default value as positional argument
 
 ## 1.4.8 (2021-09-08)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka (1.4.8)
+    karafka (1.4.9)
       dry-configurable (~> 0.8)
       dry-inflector (~> 0.1)
       dry-monitor (~> 0.3)
@@ -108,7 +108,7 @@ GEM
     thor (1.1.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    waterdrop (1.4.2)
+    waterdrop (1.4.3)
       delivery_boy (>= 0.2, < 2.x)
       dry-configurable (~> 0.8)
       dry-monitor (~> 0.3)

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '1.4.8'
+  VERSION = '1.4.9'
 end


### PR DESCRIPTION
- fix `dry-configurable` deprecation warnings for default value as a positional argument
