### PR TITLE
jruby-9.3.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           - '3.0'
           - '2.7'
           - '2.6'
+          - 'jruby-9.3.1.0'
         include:
           - ruby: '3.0'
             coverage: 'true'

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ plugin 'diffend'
 gemspec
 
 group :test do
-  gem 'byebug'
+  gem 'byebug', platform: :ruby
   gem 'factory_bot'
   gem 'rspec'
   gem 'simplecov'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,6 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 # @note HashWithIndifferentAccess is just for testing the optional integration,
 # it is not used by default in the framework
 %w[
-  byebug
   factory_bot
   fiddle
   simplecov
@@ -15,6 +14,8 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 ].each do |lib|
   require lib
 end
+
+require 'byebug' unless defined?(JRUBY_VERSION)
 
 # Don't include unnecessary stuff into rcov
 SimpleCov.start do


### PR DESCRIPTION
Test against JRuby 9.3.x which is compatible with Ruby 2.6.x and stays in sync with C Ruby.