### PR TITLE
introduce consumer and client name

### DIFF
--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -10,6 +10,10 @@ module Karafka
     class Client
       attr_reader :rebalance_manager
 
+      # @return [String] underlying consumer name
+      # @note Consumer name may change in case we regenerate it
+      attr_reader :name
+
       # How many times should we retry polling in case of a failure
       MAX_POLL_RETRIES = 10
 
@@ -30,6 +34,7 @@ module Karafka
         # Marks if we need to offset. If we did not store offsets, we should not commit the offset
         # position as it will crash rdkafka
         @offsetting = false
+        @name
       end
 
       # Fetches messages within boundaries defined by the settings (time, size, topics, etc).
@@ -264,6 +269,7 @@ module Karafka
         config.consumer_rebalance_listener = @rebalance_manager
         consumer = config.consumer
         consumer.subscribe(*@subscription_group.topics.map(&:name))
+        @name = consumer.name
         consumer
       end
     end

--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -27,6 +27,8 @@ module Karafka
       def initialize(subscription_group)
         @mutex = Mutex.new
         @closed = false
+        # Name is set when we build consumer
+        @name = ''
         @subscription_group = subscription_group
         @buffer = MessagesBuffer.new
         @rebalance_manager = RebalanceManager.new
@@ -34,7 +36,6 @@ module Karafka
         # Marks if we need to offset. If we did not store offsets, we should not commit the offset
         # position as it will crash rdkafka
         @offsetting = false
-        @name
       end
 
       # Fetches messages within boundaries defined by the settings (time, size, topics, etc).

--- a/lib/karafka/patches/rdkafka/consumer.rb
+++ b/lib/karafka/patches/rdkafka/consumer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Karafka
+  # Patches to external components
+  module Patches
+    # Rdkafka related patches
+    module Rdkafka
+      # Rdkafka::Consumer patches
+      module Consumer
+        # A method that allows us to get the native kafka producer name
+        # @return [String] producer instance name
+        # @note We need this to make sure that we allocate proper dispatched events only to
+        #   callback listeners that should publish them
+        def name
+          ::Rdkafka::Bindings.rd_kafka_name(@native_kafka)
+        end
+      end
+    end
+  end
+end
+
+::Rdkafka::Consumer.include ::Karafka::Patches::Rdkafka::Consumer

--- a/spec/lib/karafka/connection/client_spec.rb
+++ b/spec/lib/karafka/connection/client_spec.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
 
 RSpec.describe_current do
-  pending
+  subject(:client) { described_class.new(subscription_group) }
+
+  let(:subscription_group) { build(:routing_subscription_group) }
+
+  describe '#name' do
+    let(:client_id) { SecureRandom.uuid }
+    let(:start_nr) { client.name.split('-').last.to_i }
+
+    before { Karafka::App.config.client_id = client_id }
+
+    # Kafka counts all the consumers one after another, that is why we need to check it in one
+    # spec
+    it 'expect to give it proper names within the lifecycle' do
+      expect(client.name).to eq("#{Karafka::App.config.client_id}#consumer-#{start_nr}")
+      client.reset
+      expect(client.name).to eq("#{Karafka::App.config.client_id}#consumer-#{start_nr + 1}")
+      client.stop
+      expect(client.name).to eq("#{Karafka::App.config.client_id}#consumer-#{start_nr + 1}")
+    end
+  end
 end


### PR DESCRIPTION
This PR matches the waterdrop `producer#name` with `consumer#name` patch as well as aliases that to the consumer client instance.