### PR TITLE
Instrumentation callback hooks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       irb (~> 1.0)
       rdkafka (>= 0.10)
       thor (>= 0.20)
-      waterdrop (>= 2.0.5, < 3.0.0)
+      waterdrop (>= 2.0.6, < 3.0.0)
       zeitwerk (~> 2.3)
 
 GEM

--- a/karafka.gemspec
+++ b/karafka.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'irb', '~> 1.0'
   spec.add_dependency 'rdkafka', '>= 0.10'
   spec.add_dependency 'thor', '>= 0.20'
-  spec.add_dependency 'waterdrop', '>= 2.0.5', '< 3.0.0'
+  spec.add_dependency 'waterdrop', '>= 2.0.6', '< 3.0.0'
   spec.add_dependency 'zeitwerk', '~> 2.3'
 
   spec.required_ruby_version = '>= 2.6.0'

--- a/lib/karafka/instrumentation.rb
+++ b/lib/karafka/instrumentation.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Karafka
+  # @note Since we can only have one statistics callbacks manager and one error callbacks manager
+  # we use WaterDrops one that is already configured.
+  module Instrumentation
+    class << self
+      # Returns a manager for statistics callbacks
+      # @return [::WaterDrop::CallbacksManager]
+      def statistics_callbacks
+        ::WaterDrop::Instrumentation.statistics_callbacks
+      end
+
+      # Returns a manager for error callbacks
+      # @return [::WaterDrop::CallbacksManager]
+      def error_callbacks
+        ::WaterDrop::Instrumentation.error_callbacks
+      end
+    end
+  end
+end

--- a/spec/lib/karafka/instrumentation_spec.rb
+++ b/spec/lib/karafka/instrumentation_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:instrumentation) { described_class }
+
+  let(:waterdrop_instr) { ::WaterDrop::Instrumentation }
+
+  describe '#statistics_callbacks' do
+    it { expect(instrumentation.statistics_callbacks).to be_a(waterdrop_instr::CallbacksManager) }
+    it { expect(instrumentation.statistics_callbacks).to eq(waterdrop_instr.statistics_callbacks) }
+  end
+
+  describe '#error_callbacks' do
+    it { expect(instrumentation.error_callbacks).to be_a(waterdrop_instr::CallbacksManager) }
+    it { expect(instrumentation.error_callbacks).to eq(waterdrop_instr.error_callbacks) }
+  end
+
+  it 'expect to have separate manager for each type of callbacks' do
+    expect(instrumentation.statistics_callbacks).not_to eq(instrumentation.error_callbacks)
+  end
+end


### PR DESCRIPTION
This PR introduces hooks to callbacks managers from WaterDrop for further usage.