### PR TITLE
Adds time bound integration spec + refactor

### DIFF
--- a/bin/integrations
+++ b/bin/integrations
@@ -4,9 +4,9 @@
 
 require 'open3'
 require 'fileutils'
+require 'pathname'
 
 ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
 
 # Raised from the parent process if any of the integration tests fails
 IntegrationTestError = Class.new(StandardError)
@@ -38,7 +38,9 @@ class Scenario
   # @param path [String] path to the scenarios file
   def initialize(path)
     @path = path
-    @stdin, @stdout, @stderr, @wait_thr = Open3.popen3("bundle exec ruby #{path}")
+    @stdin, @stdout, @stderr, @wait_thr = Open3.popen3(
+      "bundle exec ruby -r ./spec/integrations_helper.rb #{path}"
+    )
     @started_at = current_time
   end
 
@@ -121,11 +123,16 @@ def wait_and_track(active_scenarios, finished_scenarios)
   end
 end
 
-# Run particular spec or all
-specs = ARGV[0] || 'spec/integrations/**/*.rb'
+# Load all the specs
+specs = Dir[ROOT_PATH.join('spec/integrations/**/*.rb')]
+
+# If filter is provided, apply
+specs.delete_if { |name| !name.include?(ARGV[0]) } if ARGV[0]
+
+raise ArgumentError, "No integration specs with filter: #{ARGV[0]}" if specs.empty?
 
 # Randomize order
-Dir[ROOT_PATH.join(specs)].shuffle.each do |integration_test|
+specs.shuffle.each do |integration_test|
   scenario = Scenario.new(integration_test)
 
   active_scenarios << scenario

--- a/spec/integrations/cli_start.rb
+++ b/spec/integrations/cli_start.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 # Karafka CLI should work and should not fail
 
 Karafka::Cli.prepare

--- a/spec/integrations/config_validation.rb
+++ b/spec/integrations/config_validation.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 # Karafka should use rdkafka errors raised when invalid sub-settings after routing is defined
 # We do it after the routing, so any overwrites are also handled
 

--- a/spec/integrations/consumption/constant_error_should_not_clog_others.rb
+++ b/spec/integrations/consumption/constant_error_should_not_clog_others.rb
@@ -4,9 +4,6 @@
 # Workers should not hang when a job within them fails but should be available for other jobs
 # Workers should not be clogged by a failing job
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka do |config|
   config.concurrency = 1
 end

--- a/spec/integrations/consumption/from_earliest.rb
+++ b/spec/integrations/consumption/from_earliest.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 # Karafka should be able to easily consume all the messages from earliest (default)
 
 setup_karafka

--- a/spec/integrations/consumption/from_earliest_simple_routing.rb
+++ b/spec/integrations/consumption/from_earliest_simple_routing.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 # Karafka should be able to easily consume all the messages from earliest (default) when
 # simple routing is in use
 

--- a/spec/integrations/consumption/from_latest.rb
+++ b/spec/integrations/consumption/from_latest.rb
@@ -2,9 +2,6 @@
 
 # Karafka should be able to start consuming from the latest offset
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka do |config|
   config.kafka['auto.offset.reset'] = 'latest'
 end

--- a/spec/integrations/consumption/from_latest_with_non_persistent_error.rb
+++ b/spec/integrations/consumption/from_latest_with_non_persistent_error.rb
@@ -4,9 +4,6 @@
 # from earliest and an error occurs on a first message, we should pause and retry consumption
 # until we can process this message. No messages should be skipped or ignored.
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka do |config|
   config.concurrency = 1
   # We sleep more to check if when sleeping other topic messages are processed

--- a/spec/integrations/consumption/non_constant_error_and_other_topics.rb
+++ b/spec/integrations/consumption/non_constant_error_and_other_topics.rb
@@ -3,9 +3,6 @@
 # When on one partition topic an error occurs, other topics should be processed and given
 # partition should catch up on recovery after the pause timeout
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka do |config|
   config.concurrency = 1
   # We sleep more to check if when sleeping other topic messages are processed

--- a/spec/integrations/consumption/non_critical_error_recovery.rb
+++ b/spec/integrations/consumption/non_critical_error_recovery.rb
@@ -3,9 +3,6 @@
 # Karafka should be able to recover from non-critical error with same consumer instance and it
 # also should emit an event with error details that can be logged
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 class Listener
   def on_consumer_consume_error(event)
     DataCollector.data[:error] << event

--- a/spec/integrations/consumption/of_many_partitions_with_error.rb
+++ b/spec/integrations/consumption/of_many_partitions_with_error.rb
@@ -3,9 +3,6 @@
 # When consuming on multiple workers, when one receives a non-critical exception, others should
 # continue processing and the one should be retried
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka do |config|
   config.concurrency = 10
   config.kafka['auto.offset.reset'] = 'latest'

--- a/spec/integrations/consumption/of_many_partitions_with_many_workers.rb
+++ b/spec/integrations/consumption/of_many_partitions_with_many_workers.rb
@@ -2,9 +2,6 @@
 
 # Karafka should use more than one thread to consume independent topics partitions
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka do |config|
   config.concurrency = 10
   config.kafka['auto.offset.reset'] = 'latest'

--- a/spec/integrations/consumption/of_many_topics_on_many_workers.rb
+++ b/spec/integrations/consumption/of_many_topics_on_many_workers.rb
@@ -2,9 +2,6 @@
 
 # Karafka should use more than one thread to consume independent topics
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka do |config|
   config.concurrency = 10
 end

--- a/spec/integrations/consumption/of_many_topics_with_different_settings.rb
+++ b/spec/integrations/consumption/of_many_topics_with_different_settings.rb
@@ -5,9 +5,6 @@
 # Usually configuration like this may not be optimal with too many subscription groups, nonetheless
 # we should support it
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka do |config|
   config.concurrency = 2
 end

--- a/spec/integrations/consumption/of_messages_with_headers.rb
+++ b/spec/integrations/consumption/of_messages_with_headers.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 # Karafka should be able to work with messages that have headers
 
 setup_karafka

--- a/spec/integrations/consumption/one_consumer_group_two_topics.rb
+++ b/spec/integrations/consumption/one_consumer_group_two_topics.rb
@@ -2,9 +2,6 @@
 
 # Karafka should be able to consume two topics with same consumer group
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka
 
 topic1 = DataCollector.topics[0]

--- a/spec/integrations/consumption/one_worker_many_topics.rb
+++ b/spec/integrations/consumption/one_worker_many_topics.rb
@@ -2,9 +2,6 @@
 
 # Karafka should be able to consume multiple topics with one worker
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka do |config|
   config.concurrency = 1
 end

--- a/spec/integrations/consumption/producer_ping_pong.rb
+++ b/spec/integrations/consumption/producer_ping_pong.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 # Karafka should be able to easily consume and produce messages from consumer
 
 setup_karafka

--- a/spec/integrations/consumption/removing_a_topic_should_still_consume_rest.rb
+++ b/spec/integrations/consumption/removing_a_topic_should_still_consume_rest.rb
@@ -3,9 +3,6 @@
 # Karafka should be able to consume messages after a no-longer used topic has been removed from
 # a given consumer group. It should not cause any problems
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka
 
 elements1 = Array.new(10) { SecureRandom.uuid }

--- a/spec/integrations/consumption/simple_from_earliest.rb
+++ b/spec/integrations/consumption/simple_from_earliest.rb
@@ -2,9 +2,6 @@
 
 # Karafka should be able to consume all the data from beginning
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka
 
 elements = Array.new(100) { SecureRandom.uuid }

--- a/spec/integrations/consumption/time_bound_consumption.rb
+++ b/spec/integrations/consumption/time_bound_consumption.rb
@@ -3,9 +3,6 @@
 # Karafka should be able to consume messages for given amount of time (10 seconds) and then stop
 # While Karafka is designed as a long running process, it can be used as recurring job as well
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka
 
 # How long do we want to process stuff before shutting down Karafka process

--- a/spec/integrations/consumption/time_bound_consumption.rb
+++ b/spec/integrations/consumption/time_bound_consumption.rb
@@ -44,7 +44,6 @@ Karafka::Server.run
 
 time_after = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
-
 assert_equal elements, DataCollector.data[0]
 assert_equal 1, DataCollector.data.size
 # We will give Karafka 2 seconds to stop

--- a/spec/integrations/consumption/time_bound_consumption.rb
+++ b/spec/integrations/consumption/time_bound_consumption.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Karafka should be able to consume messages for given amount of time (10 seconds) and then stop
+# While Karafka is designed as a long running process, it can be used as recurring job as well
+
+ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
+require ROOT_PATH.join('spec/integrations_helper.rb')
+
+setup_karafka
+
+# How long do we want to process stuff before shutting down Karafka process
+MAX_TIME = 10
+
+elements = Array.new(100) { SecureRandom.uuid }
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DataCollector.data[message.metadata.partition] << message.raw_payload
+    end
+  end
+end
+
+Karafka::App.routes.draw do
+  consumer_group DataCollector.consumer_group do
+    topic DataCollector.topic do
+      consumer Consumer
+    end
+  end
+end
+
+# Sends some data so we know all is good
+elements.each { |data| produce(DataCollector.topic, data) }
+
+# Stop after 10 seconds
+Thread.new do
+  sleep(MAX_TIME)
+  Karafka::App.stop!
+end
+
+time_before = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+Karafka::Server.run
+
+time_after = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+
+assert_equal elements, DataCollector.data[0]
+assert_equal 1, DataCollector.data.size
+# We will give Karafka 2 seconds to stop
+assert_equal true, time_after - time_before - MAX_TIME < 2

--- a/spec/integrations/consumption/two_consumer_groups_same_topic.rb
+++ b/spec/integrations/consumption/two_consumer_groups_same_topic.rb
@@ -2,9 +2,6 @@
 
 # Karafka should be able to consume same topic using two consumer groups
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka
 
 jsons = Array.new(100) { { SecureRandom.uuid => rand.to_s } }

--- a/spec/integrations/consumption/with_long_living_buffer.rb
+++ b/spec/integrations/consumption/with_long_living_buffer.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 # Karafka should allow to create a long living buffer that we can use and fill as we go, beyond
 # a single batch of data
 

--- a/spec/integrations/consumption/with_max_messages.rb
+++ b/spec/integrations/consumption/with_max_messages.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 # Karafka should not return more messages than defined with `max_messages`
 
 setup_karafka

--- a/spec/integrations/consumption/worker_critical_error_behaviour.rb
+++ b/spec/integrations/consumption/worker_critical_error_behaviour.rb
@@ -6,9 +6,6 @@
 # @note This test is a bit special as due to how Karafka operates, when unexpected issue happens
 #   in particular moments, it can bubble up and exit 2
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka do |config|
   config.concurrency = 1
 end

--- a/spec/integrations/deserialization/custom_deserializer_usage.rb
+++ b/spec/integrations/deserialization/custom_deserializer_usage.rb
@@ -2,9 +2,6 @@
 
 # Karafka should be able to use custom deserializers on messages after they are declared
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka
 
 messages = Array.new(100) { |i| "message#{i}" }

--- a/spec/integrations/deserialization/default_deserializer_usage.rb
+++ b/spec/integrations/deserialization/default_deserializer_usage.rb
@@ -2,9 +2,6 @@
 
 # Karafka should be able to deserialize JSON messages
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka
 
 jsons = Array.new(100) { { SecureRandom.uuid => rand.to_s } }

--- a/spec/integrations/instrumentation/error_callback_multiple_subscription_groups.rb
+++ b/spec/integrations/instrumentation/error_callback_multiple_subscription_groups.rb
@@ -4,9 +4,6 @@
 # and they should not collide with each other.
 # If they would, events would be published twice.
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka do |config|
   # Bad port on purpose to trigger the error
   config.kafka = { 'bootstrap.servers' => '127.0.0.1:9090' }

--- a/spec/integrations/instrumentation/error_callback_subscription.rb
+++ b/spec/integrations/instrumentation/error_callback_subscription.rb
@@ -2,9 +2,6 @@
 
 # Karafka should publish async errors from the client via a dedicated instrumentation hook
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka do |config|
   # Bad port on purpose to trigger the error
   config.kafka = { 'bootstrap.servers' => '127.0.0.1:9090' }

--- a/spec/integrations/instrumentation/statistics_callback_multiple_subscription_groups.rb
+++ b/spec/integrations/instrumentation/statistics_callback_multiple_subscription_groups.rb
@@ -4,9 +4,6 @@
 # hooks and they should not collide with each other.
 # If they would, events would be published twice.
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka
 
 Karafka::App.routes.draw do

--- a/spec/integrations/instrumentation/statistics_callback_on_client_change.rb
+++ b/spec/integrations/instrumentation/statistics_callback_on_client_change.rb
@@ -3,9 +3,6 @@
 # Karafka should not only recover from critical errors that happened but it also should reload
 # the underlying client and keep publishing statistics from the new librdkafka client
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka
 
 Karafka::App.routes.draw do

--- a/spec/integrations/instrumentation/statistics_callback_subscription.rb
+++ b/spec/integrations/instrumentation/statistics_callback_subscription.rb
@@ -2,9 +2,6 @@
 
 # Karafka should publish async errors from the client via a dedicated instrumentation hook
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka
 
 Karafka::App.routes.draw do

--- a/spec/integrations/offset_management/manual_offset_with_error_every_bang.rb
+++ b/spec/integrations/offset_management/manual_offset_with_error_every_bang.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 # When manual offset management is on, upon error Karafka should start again from the place
 # it had in the checkpoint. If we checkpoint after each message is processed (here adding to array)
 # it should not have any duplicates as the error happens befor checkpointing

--- a/spec/integrations/offset_management/manual_offset_with_error_every_non_bang.rb
+++ b/spec/integrations/offset_management/manual_offset_with_error_every_non_bang.rb
@@ -2,7 +2,7 @@
 
 # When manual offset management is on, upon error Karafka should start again from the place
 # it had in the checkpoint. If we checkpoint after each message is processed (here adding to array)
-# it should not have any duplicates as the error happens befor checkpointing
+# it should not have any duplicates as the error happens before checkpointing
 
 setup_karafka do |config|
   config.manual_offset_management = true

--- a/spec/integrations/offset_management/manual_offset_with_error_every_non_bang.rb
+++ b/spec/integrations/offset_management/manual_offset_with_error_every_non_bang.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 # When manual offset management is on, upon error Karafka should start again from the place
 # it had in the checkpoint. If we checkpoint after each message is processed (here adding to array)
 # it should not have any duplicates as the error happens befor checkpointing

--- a/spec/integrations/offset_management/manual_offset_with_error_interval_bang.rb
+++ b/spec/integrations/offset_management/manual_offset_with_error_interval_bang.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 # When manual offset management is on, upon error Karafka should start again from the place
 # it had in the checkpoint, not from the beginning. We check here that this works well when we
 # commit "from time to time", not every message

--- a/spec/integrations/offset_management/manual_offset_with_error_interval_non_bang.rb
+++ b/spec/integrations/offset_management/manual_offset_with_error_interval_non_bang.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 # When manual offset management is on, upon error Karafka should start again from the place
 # it had in the checkpoint, not from the beginning. We check here that this works well when we
 # commit "from time to time", not every message

--- a/spec/integrations/offset_management/messages_and_metadata_details.rb
+++ b/spec/integrations/offset_management/messages_and_metadata_details.rb
@@ -2,9 +2,6 @@
 
 # Karafka messages data should be as defined here
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka
 
 elements = Array.new(10) { SecureRandom.uuid }

--- a/spec/integrations/routing/routing_and_cli_validation.rb
+++ b/spec/integrations/routing/routing_and_cli_validation.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 # Karafka should fail when defined routing is invalid
 # Karafka should fail if we want to listen on a topic that was not defined
 

--- a/spec/integrations/routing/routing_with_the_simple_routes_style.rb
+++ b/spec/integrations/routing/routing_with_the_simple_routes_style.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 # Karafka should allow to use the '.routes' alias for routing builder and it should support a case
 # where there is a single consumer group with multiple topics
+
 setup_karafka
 
 Karafka::App.routes.draw do

--- a/spec/integrations/seek/seek_backward_from_consumer.rb
+++ b/spec/integrations/seek/seek_backward_from_consumer.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 # This spec aims to test seeking process. We use seek to process first message out of all and then
 # we move backwards till 0
 

--- a/spec/integrations/seek/seek_to_a_given_offset_from_consumer.rb
+++ b/spec/integrations/seek/seek_to_a_given_offset_from_consumer.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 # Karafka should be able to easily consume from a given offset, instead of starting from 0.
 # Karafka makes sure, we do not process in parallel incoming data from the same partition
 # ahead, so we can easily rewind the offset and then the client queue will be cleared. What that

--- a/spec/integrations/shutdown/on_hanging_jobs_and_a_shutdown.rb
+++ b/spec/integrations/shutdown/on_hanging_jobs_and_a_shutdown.rb
@@ -2,9 +2,6 @@
 
 # When Karafka is being shutdown and the consumer is hanging, it should force a shutdown
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka { |config| config.shutdown_timeout = 1_000 }
 
 produce(DataCollector.topic, '1')

--- a/spec/integrations/shutdown/on_hanging_on_shutdown_job_and_a_shutdown.rb
+++ b/spec/integrations/shutdown/on_hanging_on_shutdown_job_and_a_shutdown.rb
@@ -2,9 +2,6 @@
 
 # When Karafka is being shutdown and the consumer is hanging, it should force a shutdown
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka { |config| config.shutdown_timeout = 1_000 }
 
 produce(DataCollector.topic, '1')

--- a/spec/integrations/shutdown/on_hanging_poll_and_shutdown.rb
+++ b/spec/integrations/shutdown/on_hanging_poll_and_shutdown.rb
@@ -3,9 +3,6 @@
 # When Karafka is being shutdown and the consumer thread is hanging for too long, it should force
 # a shutdown despite having active connections to Kafka
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka { |config| config.shutdown_timeout = 1_000 }
 
 produce(DataCollector.topic, '1')

--- a/spec/integrations/shutdown/on_shutdown_when_messages_received.rb
+++ b/spec/integrations/shutdown/on_shutdown_when_messages_received.rb
@@ -2,9 +2,6 @@
 
 # When we received messages, on_shutdown should kick in for every consumer that did any work
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka
 
 topic1 = DataCollector.topics[0]

--- a/spec/integrations/shutdown/on_shutdown_when_no_messages_received.rb
+++ b/spec/integrations/shutdown/on_shutdown_when_no_messages_received.rb
@@ -2,9 +2,6 @@
 
 # When we received no messages, on_shutdown should not happen
 
-ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../../../')))
-require ROOT_PATH.join('spec/integrations_helper.rb')
-
 setup_karafka
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations_helper.rb
+++ b/spec/integrations_helper.rb
@@ -4,14 +4,14 @@
 
 ENV['KARAFKA_ENV'] = 'test'
 
-$LOAD_PATH.unshift(File.dirname(__FILE__))
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..'))
+require 'bundler'
+Bundler.setup(:default, :test)
 
 require 'singleton'
 require 'securerandom'
 require 'byebug'
-require 'lib/karafka'
-require 'spec/support/data_collector'
+require_relative '../lib/karafka'
+require_relative './support/data_collector'
 
 Thread.abort_on_exception = true
 


### PR DESCRIPTION
This PR:
- adds time bound integration spec
- removes redundant helper requirements as now those are auto-injected when running a given spec process
- adds a code that will fail when no integration specs would run when specifying filter
- improves filtering allowing for easier specs definition when running partial
