### PR TITLE
Remove unused compose topics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,13 +14,8 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_CREATE_TOPICS:
-        "part1_0:1:1,\
-         part3_0:3:1,\
-         part3_1:3:1,\
-         part10_0:10:1,\
-         part10_1:10:1,\
-         part10_2:10:1,\
-         part10_3:10:1,\
-         part10_4:10:1"
+        "integrations3_1:3:1,\
+         integrations10_0:10:1,\
+         integrations10_1:10:1"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/lib/karafka/server.rb
+++ b/lib/karafka/server.rb
@@ -56,6 +56,10 @@ module Karafka
 
       # Stops Karafka with a supervision (as long as there is a shutdown timeout)
       # If consumers or workers won't stop in a given time frame, it will force them to exit
+      #
+      # @note This method is not async. It should not be executed from the workers as it will
+      #   lock them forever. If you need to run Karafka shutdown from within workers threads,
+      #   please start a separate thread to do so.
       def stop
         Karafka::App.stop!
 

--- a/spec/integrations/consumption/constant_error_should_not_clog_others.rb
+++ b/spec/integrations/consumption/constant_error_should_not_clog_others.rb
@@ -13,7 +13,7 @@ end
 # 300 messages to consume tops from all 3 partitions
 # There can be more if we run this in development several times
 300.times do |i|
-  result = produce('part3_1', SecureRandom.uuid, partition: i % 3)
+  result = produce('integrations3_1', SecureRandom.uuid, partition: i % 3)
   DataCollector.data[:last_offsets][result.partition] = result.offset
 end
 
@@ -37,7 +37,7 @@ end
 Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     # Special topic with 3 partitions available
-    topic 'part3_1' do
+    topic 'integrations3_1' do
       consumer Consumer
     end
   end

--- a/spec/integrations/consumption/of_many_partitions_with_error.rb
+++ b/spec/integrations/consumption/of_many_partitions_with_error.rb
@@ -32,7 +32,7 @@ end
 Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     # Special topic with 10 partitions available
-    topic 'part10_0' do
+    topic 'integrations10_0' do
       consumer Consumer
     end
   end
@@ -44,7 +44,7 @@ Thread.new { Karafka::Server.run }
 # Give it some time to boot and connect before dispatching messages
 sleep(5)
 
-10.times { |i| produce('part10_0', SecureRandom.uuid, partition: i) }
+10.times { |i| produce('integrations10_0', SecureRandom.uuid, partition: i) }
 
 wait_until do
   DataCollector.data.values.flatten.size >= 11

--- a/spec/integrations/consumption/of_many_partitions_with_many_workers.rb
+++ b/spec/integrations/consumption/of_many_partitions_with_many_workers.rb
@@ -26,7 +26,7 @@ end
 Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     # Special topic with 10 partitions available
-    topic 'part10_1' do
+    topic 'integrations10_1' do
       consumer Consumer
     end
   end
@@ -40,7 +40,7 @@ sleep(5)
 
 # We send only one message to each topic partition, so when messages are consumed, it forces them
 # to be in separate worker threads
-10.times { |i| produce('part10_1', SecureRandom.uuid, partition: i) }
+10.times { |i| produce('integrations10_1', SecureRandom.uuid, partition: i) }
 
 wait_until do
   DataCollector.data.values.flatten.size >= 10


### PR DESCRIPTION
This pr removes unused docker compose kafka topics and renames topics to inform that they are of integrations suite nature.