### PR TITLE
more reliable server stopping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,12 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_CREATE_TOPICS:
-        "integrations3_1:3:1,\
-         integrations10_0:10:1,\
-         integrations10_1:10:1"
+        "integrations_0_03:3:1,\
+         integrations_0_10:10:1,\
+         integrations_1_10:10:1,\
+         benchmarks_0_01:1:1,\
+         benchmarks_0_02:2:1,\
+         benchmarks_0_05:5:1,\
+         benchmarks_0_10:10:1"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/lib/karafka/connection/listener.rb
+++ b/lib/karafka/connection/listener.rb
@@ -127,6 +127,8 @@ module Karafka
       # stops kafka client.
       def shutdown
         @jobs_queue.close
+        # This runs synchronously, making sure we finish all the shutdowns before we stop the
+        # client.
         @executors.shutdown
         @client.commit_offsets!
         @client.stop

--- a/lib/karafka/instrumentation/stdout_listener.rb
+++ b/lib/karafka/instrumentation/stdout_listener.rb
@@ -98,6 +98,14 @@ module Karafka
         Thread.new { info 'Stopping Karafka server' }
       end
 
+      # Logs info that we stopped the Karafka server.
+      #
+      # @param _event [Dry::Events::Event] event details including payload
+      def on_app_stopped(_event)
+        # We use a separate thread as logging can't be called from trap context
+        Thread.new { info 'Stopped Karafka server' }
+      end
+
       # Logs an error that Karafka was unable to stop the server gracefully and it had to do a
       #   forced exit.
       # @param _event [Dry::Events::Event] event details including payload

--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -121,7 +121,9 @@ module Karafka
         # @note At the moment it is only WaterDrop
         def configure_components
           config.producer ||= ::WaterDrop::Producer.new do |producer_config|
-            producer_config.kafka = config.kafka
+            # In some cases WaterDrop updates the config and we don't want our consumer config to
+            # be polluted by those updates, that's why we copy
+            producer_config.kafka = config.kafka.dup
             producer_config.logger = config.logger
           end
         end

--- a/lib/karafka/status.rb
+++ b/lib/karafka/status.rb
@@ -7,7 +7,8 @@ module Karafka
     STATES = {
       initializing: :initialize!,
       running: :run!,
-      stopping: :stop!
+      stopping: :stop!,
+      stopped: :stopped!
     }.freeze
 
     private_constant :STATES

--- a/spec/integrations/consumption/constant_error_should_not_clog_others.rb
+++ b/spec/integrations/consumption/constant_error_should_not_clog_others.rb
@@ -13,7 +13,7 @@ end
 # 300 messages to consume tops from all 3 partitions
 # There can be more if we run this in development several times
 300.times do |i|
-  result = produce('integrations3_1', SecureRandom.uuid, partition: i % 3)
+  result = produce('integrations_0_03', SecureRandom.uuid, partition: i % 3)
   DataCollector.data[:last_offsets][result.partition] = result.offset
 end
 
@@ -37,7 +37,7 @@ end
 Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     # Special topic with 3 partitions available
-    topic 'integrations3_1' do
+    topic 'integrations_0_03' do
       consumer Consumer
     end
   end

--- a/spec/integrations/consumption/of_many_partitions_with_error.rb
+++ b/spec/integrations/consumption/of_many_partitions_with_error.rb
@@ -32,7 +32,7 @@ end
 Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     # Special topic with 10 partitions available
-    topic 'integrations10_0' do
+    topic 'integrations_0_10' do
       consumer Consumer
     end
   end
@@ -44,7 +44,7 @@ Thread.new { Karafka::Server.run }
 # Give it some time to boot and connect before dispatching messages
 sleep(5)
 
-10.times { |i| produce('integrations10_0', SecureRandom.uuid, partition: i) }
+10.times { |i| produce('integrations_0_10', SecureRandom.uuid, partition: i) }
 
 wait_until do
   DataCollector.data.values.flatten.size >= 11

--- a/spec/integrations/consumption/of_many_partitions_with_many_workers.rb
+++ b/spec/integrations/consumption/of_many_partitions_with_many_workers.rb
@@ -26,7 +26,7 @@ end
 Karafka::App.routes.draw do
   consumer_group DataCollector.consumer_group do
     # Special topic with 10 partitions available
-    topic 'integrations10_1' do
+    topic 'integrations_1_10' do
       consumer Consumer
     end
   end
@@ -40,7 +40,7 @@ sleep(5)
 
 # We send only one message to each topic partition, so when messages are consumed, it forces them
 # to be in separate worker threads
-10.times { |i| produce('integrations10_1', SecureRandom.uuid, partition: i) }
+10.times { |i| produce('integrations_1_10', SecureRandom.uuid, partition: i) }
 
 wait_until do
   DataCollector.data.values.flatten.size >= 10

--- a/spec/integrations/consumption/simple_from_earliest.rb
+++ b/spec/integrations/consumption/simple_from_earliest.rb
@@ -24,7 +24,7 @@ end
 
 Thread.new do
   sleep(0.1) while DataCollector.data[0].size < 100
-  Karafka::App.stop!
+  Karafka::Server.stop
 end
 
 elements.each { |data| produce(DataCollector.topic, data) }

--- a/spec/integrations/consumption/time_bound_consumption.rb
+++ b/spec/integrations/consumption/time_bound_consumption.rb
@@ -32,7 +32,7 @@ elements.each { |data| produce(DataCollector.topic, data) }
 # Stop after 10 seconds
 Thread.new do
   sleep(MAX_TIME)
-  Karafka::App.stop!
+  Karafka::Server.stop
 end
 
 time_before = Process.clock_gettime(Process::CLOCK_MONOTONIC)

--- a/spec/lib/karafka/instrumentation/stdout_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/stdout_listener_spec.rb
@@ -150,6 +150,18 @@ RSpec.describe_current do
     end
   end
 
+  describe '#on_app_stopped' do
+    subject(:trigger) { listener.on_app_stopped(event) }
+
+    let(:payload) { {} }
+    let(:message) { 'Stopped Karafka server' }
+
+    it 'expect logger to log server stopped' do
+      sleep 0.1
+      expect(Karafka.logger).to have_received(:info).with(message).at_least(:once)
+    end
+  end
+
   describe '#on_app_stopping_error' do
     subject(:trigger) { listener.on_app_stopping_error(event) }
 

--- a/spec/lib/karafka/runner_spec.rb
+++ b/spec/lib/karafka/runner_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe_current do
     # We need to set it to 0 as otherwise the listener would always wait for workers threads that
     # would never stop without shutting down whole framework
     before { Karafka::App.config.concurrency = 0 }
+
     after { Karafka::App.config.concurrency = 5 }
 
     context 'when everything is ok' do
@@ -18,8 +19,6 @@ RSpec.describe_current do
         allow(runner)
           .to receive(:listeners)
           .and_return(listeners)
-
-        Karafka::App.stop!
       end
 
       it 'starts asynchronously consumption for each listener' do

--- a/spec/lib/karafka/runner_spec.rb
+++ b/spec/lib/karafka/runner_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe_current do
   subject(:runner) { described_class.new }
 
   describe '#call' do
+    # We need to set it to 0 as otherwise the listener would always wait for workers threads that
+    # would never stop without shutting down whole framework
+    before { Karafka::App.config.concurrency = 0 }
+    after { Karafka::App.config.concurrency = 5 }
+
     context 'when everything is ok' do
       let(:listeners) { [listener] }
       let(:async_scope) { listener }
@@ -13,6 +18,8 @@ RSpec.describe_current do
         allow(runner)
           .to receive(:listeners)
           .and_return(listeners)
+
+        Karafka::App.stop!
       end
 
       it 'starts asynchronously consumption for each listener' do

--- a/spec/lib/karafka/server_spec.rb
+++ b/spec/lib/karafka/server_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe_current do
 
   before do
     allow(Karafka::App).to receive(:run!)
+    allow(Karafka::App).to receive(:stopped?).and_return(true)
     allow(Karafka::Runner).to receive(:new).and_return(runner)
     allow(runner).to receive(:call)
     described_class.consumer_threads = []

--- a/spec/lib/karafka/status_spec.rb
+++ b/spec/lib/karafka/status_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe_current do
   context 'when we start with a default state' do
     it { expect(status_manager.running?).to eq false }
     it { expect(status_manager.stopping?).to eq false }
+    it { expect(status_manager.stopped?).to eq false }
     it { expect(status_manager.initializing?).to eq false }
   end
 
@@ -32,6 +33,7 @@ RSpec.describe_current do
       it { expect(status_manager.running?).to eq true }
       it { expect(status_manager.initializing?).to eq false }
       it { expect(status_manager.stopping?).to eq false }
+      it { expect(status_manager.stopped?).to eq false }
     end
   end
 
@@ -42,6 +44,7 @@ RSpec.describe_current do
       end
 
       it { expect(status_manager.stopping?).to eq false }
+      it { expect(status_manager.stopped?).to eq false }
     end
 
     context 'when status is set to stopping' do
@@ -50,6 +53,7 @@ RSpec.describe_current do
       end
 
       it { expect(status_manager.stopping?).to eq true }
+      it { expect(status_manager.stopped?).to eq false }
     end
   end
 
@@ -63,8 +67,25 @@ RSpec.describe_current do
       it { expect(status_manager.running?).to eq false }
       it { expect(status_manager.initializing?).to eq false }
       it { expect(status_manager.stopping?).to eq true }
+      it { expect(status_manager.stopped?).to eq false }
     end
   end
+
+  describe 'stopped!' do
+    context 'when we set it to stopped' do
+      before do
+        status_manager.run!
+        status_manager.stop!
+        status_manager.stopped!
+      end
+
+      it { expect(status_manager.running?).to eq false }
+      it { expect(status_manager.initializing?).to eq false }
+      it { expect(status_manager.stopping?).to eq false }
+      it { expect(status_manager.stopped?).to eq true }
+    end
+  end
+
 
   describe 'initializing?' do
     context 'when status is not set to initializing' do

--- a/spec/lib/karafka/status_spec.rb
+++ b/spec/lib/karafka/status_spec.rb
@@ -86,7 +86,6 @@ RSpec.describe_current do
     end
   end
 
-
   describe 'initializing?' do
     context 'when status is not set to initializing' do
       it { expect(status_manager.initializing?).to eq false }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,7 @@ SimpleCov.start do
   merge_timeout 600
 end
 
-SimpleCov.minimum_coverage(93)
+SimpleCov.minimum_coverage(94.5)
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"]
   .sort


### PR DESCRIPTION
This PR improves the stopping process by introducing `stopped` status that indicates to the server that all the components were closed and that we can safely stop.