### PR TITLE
optimize context switching in the jobs queue

### DIFF
--- a/bin/stress
+++ b/bin/stress
@@ -9,5 +9,5 @@ set -e
 while :
 do
   reset
-  bundle exec bin/integrations
+  bundle exec bin/integrations $1
 done

--- a/lib/karafka/processing/worker.rb
+++ b/lib/karafka/processing/worker.rb
@@ -46,7 +46,6 @@ module Karafka
       ensure
         # job can be nil when the queue is being closed
         @jobs_queue.complete(job) if job
-        Thread.pass
       end
     end
   end

--- a/spec/integrations/consumption/two_consumer_groups_same_topic.rb
+++ b/spec/integrations/consumption/two_consumer_groups_same_topic.rb
@@ -38,5 +38,7 @@ end
 keys = DataCollector.data.keys
 
 assert_equal 2, DataCollector.data.size
+assert_equal 100, DataCollector.data[keys[0]].size
+assert_equal 100, DataCollector.data[keys[1]].size
 assert_equal jsons, DataCollector.data[keys[0]]
 assert_equal jsons, DataCollector.data[keys[1]]

--- a/spec/integrations/consumption/two_consumer_groups_same_topic.rb
+++ b/spec/integrations/consumption/two_consumer_groups_same_topic.rb
@@ -37,6 +37,6 @@ end
 
 keys = DataCollector.data.keys
 
+assert_equal 2, DataCollector.data.size
 assert_equal jsons, DataCollector.data[keys[0]]
 assert_equal jsons, DataCollector.data[keys[1]]
-assert_equal 2, DataCollector.data.size


### PR DESCRIPTION
This PR changes how we skip listener thread execution and pass it to workers. Previous approach would `Thread.pass` effectively running upon each scheduler switch just to pass it. The new approach blocks with a queues (one per group) until it is unblocked when needed. This effectively reduces context switching from 200k switches to listener to just over 200. (99% reduction).

Since we always wait on all the workers work to be done both on polling and shutdown, we can do it that way.

inspired by @ioquatix <3