### PR TITLE
Partition revoked consumer action spec + fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
       KAFKA_CREATE_TOPICS:
         "integrations_0_03:3:1,\
+         integrations_1_03:3:1,\
          integrations_0_10:10:1,\
          integrations_1_10:10:1,\
          benchmarks_0_01:1:1,\

--- a/lib/karafka/connection/listener.rb
+++ b/lib/karafka/connection/listener.rb
@@ -66,7 +66,7 @@ module Karafka
           # distributing consuming jobs as upon revoking, we might get assigned to the same
           # partitions, thus getting their jobs. The revoking jobs need to finish before
           # appropriate consumers are taken down and re-created
-          wait(@subscription_group) if distribue_revoke_lost_partitions_jobs
+          wait(@subscription_group) if distribute_revoke_lost_partitions_jobs
 
           distribute_partitions_jobs(messages_buffer)
 
@@ -103,7 +103,7 @@ module Karafka
 
       # Enqueues revoking jobs for partitions that were taken away from the running process.
       # @return [Boolean] was there anything to revoke
-      def distribue_revoke_lost_partitions_jobs
+      def distribute_revoke_lost_partitions_jobs
         revoked_partitions = @client.rebalance_manager.revoked_partitions
 
         return false if revoked_partitions.empty?

--- a/lib/karafka/connection/listener.rb
+++ b/lib/karafka/connection/listener.rb
@@ -62,13 +62,16 @@ module Karafka
             messages_buffer: messages_buffer
           )
 
-          # We don't have to wait for the revoke jobs to be done, because since they are revoked,
-          # we should not get any data from them, thus there is no risk of a race-condition.
-          revoke_lost_partitions_consumers
+          # If there were revoked partitions, we need to wait on their jobs to finish before
+          # distributing consuming jobs as upon revoking, we might get assigned to the same
+          # partitions, thus getting their jobs. The revoking jobs need to finish before
+          # appropriate consumers are taken down and re-created
+          wait(@subscription_group) if distribue_revoke_lost_partitions_jobs
+
           distribute_partitions_jobs(messages_buffer)
 
           # We wait only on jobs from our subscription group. Other groups are independent.
-          @jobs_queue.wait(@subscription_group.id)
+          wait(@subscription_group)
 
           # We don't use the `#commit_offsets!` here for performance reasons. This can be achieved
           # if needed by using manual offset management.
@@ -99,10 +102,11 @@ module Karafka
       end
 
       # Enqueues revoking jobs for partitions that were taken away from the running process.
-      def revoke_lost_partitions_consumers
+      # @return [Boolean] was there anything to revoke
+      def distribue_revoke_lost_partitions_jobs
         revoked_partitions = @client.rebalance_manager.revoked_partitions
 
-        return if revoked_partitions.empty?
+        return false if revoked_partitions.empty?
 
         revoked_partitions.each do |topic, partitions|
           partitions.each do |partition|
@@ -111,6 +115,8 @@ module Karafka
             @jobs_queue << Processing::Jobs::Revoked.new(executor)
           end
         end
+
+        true
       end
 
       # Takes the messages per topic partition and enqueues processing jobs in threads.
@@ -126,6 +132,12 @@ module Karafka
 
           @jobs_queue << Processing::Jobs::Consume.new(executor, messages)
         end
+      end
+
+      # Waits for all the jobs from a given subscription group to finish before moving forward
+      # @param subscription_group [Karafka::Routing::SubscriptionGroup]
+      def wait(subscription_group)
+        @jobs_queue.wait(subscription_group.id)
       end
 
       # Stops the jobs queue, triggers shutdown on all the executors (sync), commits offsets and

--- a/spec/integrations/consumption/on_partition_data_revoked.rb
+++ b/spec/integrations/consumption/on_partition_data_revoked.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Karafka should trigger an on_revoked action when a partition is being taken from us
+
+setup_karafka
+
+elements = Array.new(100) { SecureRandom.uuid }
+
+DataCollector.data[:revoked] = Concurrent::Array.new
+DataCollector.data[:pre] = Set.new
+DataCollector.data[:post] = Set.new
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    if DataCollector.data[:revoked].empty?
+      DataCollector.data[:pre] << messages.metadata.partition
+    else
+      DataCollector.data[:post] << messages.metadata.partition
+    end
+  end
+
+  def revoked
+    DataCollector.data[:revoked] << { messages.metadata.partition => Time.now }
+  end
+end
+
+Karafka::App.routes.draw do
+  consumer_group 'integrations_1_03' do
+    topic 'integrations_1_03' do
+      consumer Consumer
+      manual_offset_management true
+    end
+  end
+end
+
+elements.each { |data| produce('integrations_1_03', data, partition: rand(0..2)) }
+
+Thread.new do
+  sleep 5
+
+  config = {
+    :"bootstrap.servers" => "localhost:9092",
+    :"group.id" => Karafka::App.consumer_groups.first.id,
+    'auto.offset.reset' => 'earliest'
+  }
+  consumer = Rdkafka::Config.new(config).consumer
+  consumer.subscribe('integrations_1_03')
+  consumer.each {}
+end
+
+start_karafka_and_wait_until do
+  !DataCollector.data[:post].empty?
+end
+
+p DataCollector.data


### PR DESCRIPTION
This PR:
  - adds a spec for a case when we lose a partition due to rebalance
  - fixes a case where after a rebalance we would receive data for the partition in which we at the moment process data and/or run revoking operations

close https://github.com/karafka/karafka/issues/753