### PR TITLE
rate limited integration spec + validator fix

### DIFF
--- a/bin/integrations
+++ b/bin/integrations
@@ -64,7 +64,7 @@ class Scenario
     buffer = ''
     @stdout.read_nonblock(10_240, buffer, exception: false)
     @stdout_tail << buffer
-    @stdout_tail = @stdout_tail[-1_024..-1] || @stdout_tail
+    @stdout_tail = @stdout_tail[-10_024..-1] || @stdout_tail
 
     !@wait_thr.alive?
   end

--- a/bin/integrations
+++ b/bin/integrations
@@ -42,6 +42,8 @@ class Scenario
       "bundle exec ruby -r ./spec/integrations_helper.rb #{path}"
     )
     @started_at = current_time
+    # Last 1024 characters from stdout
+    @stdout_tail = ''
   end
 
   # @return [String] integration spec name
@@ -51,15 +53,18 @@ class Scenario
 
   # @return [Boolean] did this scenario finished or is it still running
   def finished?
-    # We read it so it won't grow as we use our default logger that prints to both test.log and
-    # to stdout. Otherwise after reaching the buffer size, it would hang
-    @stdout.read_nonblock(10_240, exception: false)
-
     # If the thread is running too long, kill it
     if current_time - @started_at > MAX_RUN_TIME
       @wait_thr.kill
       Process.kill('TERM', pid)
     end
+
+    # We read it so it won't grow as we use our default logger that prints to both test.log and
+    # to stdout. Otherwise after reaching the buffer size, it would hang
+    buffer = ''
+    @stdout.read_nonblock(10_240, buffer, exception: false)
+    @stdout_tail << buffer
+    @stdout_tail = @stdout_tail[-1_024..-1] || @stdout_tail
 
     !@wait_thr.alive?
   end
@@ -90,6 +95,7 @@ class Scenario
 
     unless success?
       puts "Exit code: #{exit_code}"
+      puts @stdout_tail
       puts @stderr.read
     end
   end

--- a/config/errors.yml
+++ b/config/errors.yml
@@ -1,11 +1,7 @@
 en:
   dry_validation:
     errors:
-      max_timeout_size_for_exponential: >
-        pause_timeout cannot be more than pause_max_timeout
-      topics_names_not_unique: >
-        all topic names within a single consumer group must be unique
-      required_usage_count: >
-        Given topic must be used at least once
-      consumer_groups_inclusion: >
-        Unknown consumer group
+      max_timeout_vs_pause_max_timeout: pause_timeout must be less or equal to pause_max_timeout
+      topics_names_not_unique: all topic names within a single consumer group must be unique
+      required_usage_count: Given topic must be used at least once
+      consumer_groups_inclusion: Unknown consumer group

--- a/lib/karafka/connection/pauses_manager.rb
+++ b/lib/karafka/connection/pauses_manager.rb
@@ -35,9 +35,9 @@ module Karafka
             next unless pause.paused?
             next unless pause.expired?
 
-            yield(topic, partition)
-
             pause.resume
+
+            yield(topic, partition)
           end
         end
       end

--- a/lib/karafka/contracts/config.rb
+++ b/lib/karafka/contracts/config.rb
@@ -22,10 +22,9 @@ module Karafka
         required(:shutdown_timeout) { int? & gt?(0) }
       end
 
-      rule(:pause_timeout, :pause_max_timeout, :pause_with_exponential_backoff) do
-        if values[:pause_with_exponential_backoff] &&
-           values[:pause_timeout].to_i > values[:pause_max_timeout].to_i
-          key(:pause_max_timeout).failure(:max_timeout_size_for_exponential)
+      rule(:pause_timeout, :pause_max_timeout) do
+        if values[:pause_timeout].to_i > values[:pause_max_timeout].to_i
+          key(:pause_timeout).failure(:max_timeout_vs_pause_max_timeout)
         end
       end
     end

--- a/spec/integrations/consumption/rate_limited.rb
+++ b/spec/integrations/consumption/rate_limited.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Karafka should be able to use pause to rate limit when consumption is tracked
-# We can do it by using the pausing capabilites.
+# We can do it by using the pausing capabilities.
 # While it is rather not recommended, but for the sake of demo and making sure things work as
 # expected, we us it
 
@@ -34,7 +34,8 @@ class Consumer < Karafka::BaseConsumer
       @seconds_available = 5
       client.pause(topic.name, message.partition, message.offset + 1)
       pause.pause
-      return
+
+      break
     end
   end
 end
@@ -58,7 +59,7 @@ end
 # Since we have 5 messages and we sleep 1, for 50 messages it would mean at least 9 seconds
 # assuming, that all the other things take 0 time (since the pause after last is irrelevant as
 # we shutdown)
-assert_equal true, (Time.now.to_f - started_at) > 9
+assert_equal true, (Time.now.to_f - started_at) >= 9
 assert_equal elements, DataCollector.data[0]
 # We should pause 10 times, once every 5 messages
 assert_equal 10, DataCollector.data[:pauses].count
@@ -70,8 +71,10 @@ DataCollector.data[:pauses].each do |pause_time|
   if previous_pause_time
     distance = pause_time - previous_pause_time
 
-    assert_equal true, distance > 1
-    assert_equal true, distance < 2
+    p distance
+
+    assert_equal true, distance >= 1
+    assert_equal true, distance <= 2
   end
 
   previous_pause_time = pause_time

--- a/spec/integrations/consumption/rate_limited.rb
+++ b/spec/integrations/consumption/rate_limited.rb
@@ -58,6 +58,9 @@ start_karafka_and_wait_until do
   DataCollector.data[0].size >= 50
 end
 
+# Distance in between pauses should be more or less 1 second
+previous_pause_time = nil
+
 # Since we have 5 messages and we sleep 1, for 50 messages it would mean at least 9 seconds
 # assuming, that all the other things take 0 time (since the pause after last is irrelevant as
 # we shutdown)
@@ -81,6 +84,3 @@ assert_equal true, (Time.now.to_f - started_at) >= 9
 assert_equal elements, DataCollector.data[0]
 # We should pause 10 times, once every 5 messages
 assert_equal 10, DataCollector.data[:pauses].count
-
-# Distance in between pauses should be more or less 1 second
-previous_pause_time = nil

--- a/spec/integrations/consumption/rate_limited.rb
+++ b/spec/integrations/consumption/rate_limited.rb
@@ -59,6 +59,9 @@ end
 # Since we have 5 messages and we sleep 1, for 50 messages it would mean at least 9 seconds
 # assuming, that all the other things take 0 time (since the pause after last is irrelevant as
 # we shutdown)
+
+p (Time.now.to_f - started_at)
+
 assert_equal true, (Time.now.to_f - started_at) >= 9
 assert_equal elements, DataCollector.data[0]
 # We should pause 10 times, once every 5 messages

--- a/spec/integrations/consumption/rate_limited.rb
+++ b/spec/integrations/consumption/rate_limited.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# Karafka should be able to use pause to rate limit when consumption is tracked
+# We can do it by using the pausing capabilites.
+# While it is rather not recommended, but for the sake of demo and making sure things work as
+# expected, we us it
+
+setup_karafka do |config|
+  # Throttle for a second
+  config.pause_timeout = 1_000
+  config.max_wait_time = 500
+  config.max_messages = 1
+end
+
+elements = Array.new(50) { SecureRandom.uuid }
+
+class Consumer < Karafka::BaseConsumer
+  def initialize
+    super
+    @seconds_available = 5
+  end
+
+  def consume
+    # Lets say we want to process at most 5 messages per second and that processing one takes 0.2s
+    # which means we can process at most 5 messages before pausing for a second
+    messages.each do |message|
+      DataCollector.data[0] << message.raw_payload
+
+      @seconds_available -= 1
+
+      next unless @seconds_available.zero?
+
+      DataCollector.data[:pauses] << Time.now.to_f
+      @seconds_available = 5
+      client.pause(topic.name, message.partition, message.offset + 1)
+      pause.pause
+      return
+    end
+  end
+end
+
+Karafka::App.routes.draw do
+  consumer_group DataCollector.consumer_group do
+    topic DataCollector.topic do
+      consumer Consumer
+    end
+  end
+end
+
+elements.each { |data| produce(DataCollector.topic, data) }
+
+started_at = Time.now.to_f
+
+start_karafka_and_wait_until do
+  DataCollector.data[0].size >= 50
+end
+
+# Since we have 5 messages and we sleep 1, for 50 messages it would mean at least 9 seconds
+# assuming, that all the other things take 0 time (since the pause after last is irrelevant as
+# we shutdown)
+assert_equal true, (Time.now.to_f - started_at) > 9
+assert_equal elements, DataCollector.data[0]
+# We should pause 10 times, once every 5 messages
+assert_equal 10, DataCollector.data[:pauses].count
+
+# Distance in between pauses should be more or less 1 second
+previous_pause_time = nil
+
+DataCollector.data[:pauses].each do |pause_time|
+  if previous_pause_time
+    distance = pause_time - previous_pause_time
+
+    assert_equal true, distance > 1
+    assert_equal true, distance < 2
+  end
+
+  previous_pause_time = pause_time
+end


### PR DESCRIPTION
A PR to demonstrate and check, that rate-limiting using pause time could be implemented.

This PR includes also:
- a fix for config validator. We will always validate pause_max_timeout to make sure, we don't end up with invalid smaller max than the pause timeout (did this and didn't know what is happening)
- improvement in the integration suite runner: when spec fails, part of stdout is printed alongside stderr

You probably don't want to use this in production ;) but worth having as a POC on how to achieve it.