### PR TITLE
drop support for ruby 2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka framework changelog
 
+## master (Unreleased)
+- Drop support for ruby 2.6
+
 ## 1.4.12 (2022-01-13)
 - Ruby 3.1 support
 - `irb` dependency removal (vbyno)

--- a/karafka.gemspec
+++ b/karafka.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'waterdrop', '~> 1.4'
   spec.add_dependency 'zeitwerk', '~> 2.4'
 
-  spec.required_ruby_version = '>= 2.6.0'
+  spec.required_ruby_version = '>= 2.7'
 
   if $PROGRAM_NAME.end_with?('gem')
     spec.signing_key = File.expand_path('~/.ssh/gem-private_key.pem')


### PR DESCRIPTION
We are officially dropping support for ruby 2.6 because maintenance ends beginning of April 2022. More information in this post https://www.ruby-lang.org/en/news/2021/11/24/ruby-2-6-9-released/. We also can't support JRuby because it is currently based on ruby 2.6.