### PR TITLE
Config hash must respect symbols as a strings

### DIFF
--- a/lib/karafka/routing/subscription_group.rb
+++ b/lib/karafka/routing/subscription_group.rb
@@ -37,7 +37,7 @@ module Karafka
       #   topics but they lack the group.id (unless explicitly) provided. To make it compatible
       #   with our routing engine, we inject it before it will go to the consumer
       def kafka
-        kafka = @topics.first.kafka.dup
+        kafka = @topics.first.kafka.dup.stringify_keys
 
         kafka['client.id'] ||= Karafka::App.config.client_id
         kafka['group.id'] ||= @topics.first.consumer_group.id

--- a/spec/lib/karafka/routing/subscription_group_spec.rb
+++ b/spec/lib/karafka/routing/subscription_group_spec.rb
@@ -26,6 +26,18 @@ RSpec.describe_current do
     it { expect(group.kafka['group.id']).to eq(topic.consumer_group.id) }
     it { expect(group.kafka['auto.offset.reset']).to eq('earliest') }
     it { expect(group.kafka['enable.auto.offset.store']).to eq('false') }
-    it { expect(group.kafka['bootstrap.servers']).to eq(topic.kafka['bootstrap.servers']) }
+    it { expect(group.kafka['bootstrap.servers']).to eq(topic.kafka[:'bootstrap.servers']) }
+  end
+
+  context "with string keys" do
+    let(:topic) { build(:routing_topic, kafka: { 'bootstrap.servers' => 'kafka://kafka:9092' }) }
+
+    describe '#kafka' do
+      it { expect(group.kafka['client.id']).to eq(Karafka::App.config.client_id) }
+      it { expect(group.kafka['group.id']).to eq(topic.consumer_group.id) }
+      it { expect(group.kafka['auto.offset.reset']).to eq('earliest') }
+      it { expect(group.kafka['enable.auto.offset.store']).to eq('false') }
+      it { expect(group.kafka['bootstrap.servers']).to eq(topic.kafka['bootstrap.servers']) }
+    end
   end
 end

--- a/spec/lib/karafka/routing/subscription_group_spec.rb
+++ b/spec/lib/karafka/routing/subscription_group_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe_current do
     it { expect(group.kafka['auto.offset.reset']).to eq('earliest') }
     it { expect(group.kafka['enable.auto.offset.store']).to eq('false') }
     it { expect(group.kafka['bootstrap.servers']).to eq(topic.kafka[:'bootstrap.servers']) }
+    it { expect(group.kafka['bootstrap.servers']).not_to be_nil }
   end
 
   context "with string keys" do
@@ -38,6 +39,7 @@ RSpec.describe_current do
       it { expect(group.kafka['auto.offset.reset']).to eq('earliest') }
       it { expect(group.kafka['enable.auto.offset.store']).to eq('false') }
       it { expect(group.kafka['bootstrap.servers']).to eq(topic.kafka['bootstrap.servers']) }
+      it { expect(group.kafka['bootstrap.servers']).not_to be_nil }
     end
   end
 end


### PR DESCRIPTION
```
it { expect(group.kafka['bootstrap.servers']).to eq(topic.kafka[:'bootstrap.servers']) }
```
This test passed but because both are nil 😭 You need to add the next line for it
```
it { expect(group.kafka['bootstrap.servers']).not_to be_nil }
```

I think we need to stringify keys for this hash.
