### PR TITLE
expose lag information in the batch headers

### DIFF
--- a/lib/karafka/messages/batch_metadata.rb
+++ b/lib/karafka/messages/batch_metadata.rb
@@ -14,6 +14,8 @@ module Karafka
       :partition,
       :topic,
       :scheduled_at,
+      :consumption_lag,
+      :processing_lag,
       keyword_init: true
     )
   end

--- a/lib/karafka/messages/builders/batch_metadata.rb
+++ b/lib/karafka/messages/builders/batch_metadata.rb
@@ -12,7 +12,12 @@ module Karafka
           # @param topic [Karafka::Routing::Topic] topic for which we've fetched the batch
           # @param scheduled_at [Time] moment when the batch was scheduled for processing
           # @return [Karafka::Messages::BatchMetadata] batch metadata object
+          # @note In regards to the time lags: we can use current time here, as creation of
+          #   batch metadata happens in worker. So whenever this is being built, it means that the
+          #   processing of this batch started.
           def call(kafka_batch, topic, scheduled_at)
+            now = Time.now
+
             Karafka::Messages::BatchMetadata.new(
               size: kafka_batch.count,
               first_offset: kafka_batch.first.offset,
@@ -20,8 +25,25 @@ module Karafka
               deserializer: topic.deserializer,
               partition: kafka_batch[0].partition,
               topic: topic.name,
-              scheduled_at: scheduled_at
+              scheduled_at: scheduled_at,
+              # This lag describes how long did it take for a message to be consumed from the
+              # moment it was created
+              consumption_lag: time_distance_in_ms(now, kafka_batch.last.timestamp),
+              # This lag describes how long did a batch have to wait before it was picked up by
+              # one of the workers
+              processing_lag: time_distance_in_ms(now, scheduled_at)
             ).freeze
+          end
+
+          private
+
+          # Computes time distance in between two times in ms
+          #
+          # @param time1 [Time]
+          # @param time2 [Time]
+          # @return [Integer] distance in between two times in ms
+          def time_distance_in_ms(time1, time2)
+            ((time1 - time2) * 1_000).round
           end
         end
       end

--- a/spec/integrations/active_job/async_job_processing.rb
+++ b/spec/integrations/active_job/async_job_processing.rb
@@ -5,7 +5,7 @@
 setup_karafka
 setup_active_job
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_group do
     active_job_topic DataCollector.topic
   end

--- a/spec/integrations/active_job/backoff_and_retry_on_error.rb
+++ b/spec/integrations/active_job/backoff_and_retry_on_error.rb
@@ -5,7 +5,7 @@
 setup_karafka
 setup_active_job
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_group do
     active_job_topic DataCollector.topic
   end

--- a/spec/integrations/active_job/multiple_jobs_same_topic.rb
+++ b/spec/integrations/active_job/multiple_jobs_same_topic.rb
@@ -5,7 +5,7 @@
 setup_karafka
 setup_active_job
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_group do
     active_job_topic DataCollector.topic
   end

--- a/spec/integrations/active_job/sync_job_processing.rb
+++ b/spec/integrations/active_job/sync_job_processing.rb
@@ -5,7 +5,7 @@
 setup_karafka
 setup_active_job
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_group do
     active_job_topic DataCollector.topic
   end

--- a/spec/integrations/config_validation.rb
+++ b/spec/integrations/config_validation.rb
@@ -10,7 +10,7 @@ begin
     config.kafka = { 'message.max.bytes' => 0, 'message.copy.max.bytes' => -1 }
   end
 
-  Karafka::App.routes.draw do
+  draw_routes do
     consumer_group 'usual' do
       topic 'regular' do
         consumer Class.new

--- a/spec/integrations/consumption/constant_error_should_not_clog_others.rb
+++ b/spec/integrations/consumption/constant_error_should_not_clog_others.rb
@@ -34,7 +34,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_group do
     # Special topic with 3 partitions available
     topic 'integrations_0_03' do

--- a/spec/integrations/consumption/from_earliest.rb
+++ b/spec/integrations/consumption/from_earliest.rb
@@ -14,13 +14,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_group do
-    topic DataCollector.topic do
-      consumer Consumer
-    end
-  end
-end
+draw_routes(Consumer)
 
 elements.each { |data| produce(DataCollector.topic, data) }
 

--- a/spec/integrations/consumption/from_earliest_simple_routing.rb
+++ b/spec/integrations/consumption/from_earliest_simple_routing.rb
@@ -15,7 +15,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
+draw_routes do
   topic DataCollector.topic do
     consumer Consumer
   end

--- a/spec/integrations/consumption/from_latest.rb
+++ b/spec/integrations/consumption/from_latest.rb
@@ -20,13 +20,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_group do
-    topic DataCollector.topic do
-      consumer Consumer
-    end
-  end
-end
+draw_routes(Consumer)
 
 # Start Karafka
 Thread.new { Karafka::Server.run }

--- a/spec/integrations/consumption/from_latest_with_non_persistent_error.rb
+++ b/spec/integrations/consumption/from_latest_with_non_persistent_error.rb
@@ -32,13 +32,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_group do
-    topic DataCollector.topic do
-      consumer Consumer
-    end
-  end
-end
+draw_routes(Consumer)
 
 # Start Karafka
 Thread.new { Karafka::Server.run }

--- a/spec/integrations/consumption/non_constant_error_and_other_topics.rb
+++ b/spec/integrations/consumption/non_constant_error_and_other_topics.rb
@@ -49,7 +49,7 @@ class Consumer2 < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topics.first do
       consumer Consumer1

--- a/spec/integrations/consumption/non_critical_error_recovery.rb
+++ b/spec/integrations/consumption/non_critical_error_recovery.rb
@@ -27,7 +27,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topic do
       consumer Consumer

--- a/spec/integrations/consumption/of_many_partitions_with_error.rb
+++ b/spec/integrations/consumption/of_many_partitions_with_error.rb
@@ -29,7 +29,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_group do
     # Special topic with 10 partitions available
     topic 'integrations_0_10' do

--- a/spec/integrations/consumption/of_many_partitions_with_many_workers.rb
+++ b/spec/integrations/consumption/of_many_partitions_with_many_workers.rb
@@ -23,7 +23,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_group do
     # Special topic with 10 partitions available
     topic 'integrations_1_10' do

--- a/spec/integrations/consumption/of_many_topics_on_many_workers.rb
+++ b/spec/integrations/consumption/of_many_topics_on_many_workers.rb
@@ -18,7 +18,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_group do
     DataCollector.topics.first(10).each do |topic_name|
       topic topic_name do

--- a/spec/integrations/consumption/of_many_topics_with_different_settings.rb
+++ b/spec/integrations/consumption/of_many_topics_with_different_settings.rb
@@ -18,7 +18,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_group do
     DataCollector.topics.first(10).each_with_index do |topic_name, index|
       topic topic_name do

--- a/spec/integrations/consumption/of_many_with_error_and_long_pause.rb
+++ b/spec/integrations/consumption/of_many_with_error_and_long_pause.rb
@@ -27,7 +27,7 @@ class Consumer2 < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topics.first do
       consumer Consumer1

--- a/spec/integrations/consumption/of_messages_with_headers.rb
+++ b/spec/integrations/consumption/of_messages_with_headers.rb
@@ -14,13 +14,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_group do
-    topic DataCollector.topic do
-      consumer Consumer
-    end
-  end
-end
+draw_routes(Consumer)
 
 elements.each { |data| produce(DataCollector.topic, data, headers: { 'value' => data }) }
 

--- a/spec/integrations/consumption/on_partition_data_revoked.rb
+++ b/spec/integrations/consumption/on_partition_data_revoked.rb
@@ -24,7 +24,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group 'integrations_1_03' do
     topic 'integrations_1_03' do
       consumer Consumer

--- a/spec/integrations/consumption/one_consumer_group_two_topics.rb
+++ b/spec/integrations/consumption/one_consumer_group_two_topics.rb
@@ -25,7 +25,7 @@ class Consumer2 < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_group do
     topic topic1 do
       consumer Consumer1

--- a/spec/integrations/consumption/one_worker_many_topics.rb
+++ b/spec/integrations/consumption/one_worker_many_topics.rb
@@ -25,7 +25,7 @@ class Consumer2 < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_group do
     topic topic1 do
       consumer Consumer1

--- a/spec/integrations/consumption/producer_ping_pong.rb
+++ b/spec/integrations/consumption/producer_ping_pong.rb
@@ -21,13 +21,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_group do
-    topic DataCollector.topic do
-      consumer Consumer
-    end
-  end
-end
+draw_routes(Consumer)
 
 start_karafka_and_wait_until do
   DataCollector.data[0].size > 10

--- a/spec/integrations/consumption/rate_limited.rb
+++ b/spec/integrations/consumption/rate_limited.rb
@@ -42,13 +42,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_group do
-    topic DataCollector.topic do
-      consumer Consumer
-    end
-  end
-end
+draw_routes(Consumer)
 
 elements.each { |data| produce(DataCollector.topic, data) }
 

--- a/spec/integrations/consumption/removing_a_topic_should_still_consume_rest.rb
+++ b/spec/integrations/consumption/removing_a_topic_should_still_consume_rest.rb
@@ -24,7 +24,7 @@ class Consumer2 < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topics.first do
       consumer Consumer1
@@ -47,7 +47,7 @@ end
 # Clear all the routes so later we can subscribe to only one topic
 Karafka::App.routes.clear
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topics.last do
       consumer Consumer2

--- a/spec/integrations/consumption/simple_from_earliest.rb
+++ b/spec/integrations/consumption/simple_from_earliest.rb
@@ -14,13 +14,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_group do
-    topic DataCollector.topic do
-      consumer Consumer
-    end
-  end
-end
+draw_routes(Consumer)
 
 Thread.new do
   sleep(0.1) while DataCollector.data[0].size < 100

--- a/spec/integrations/consumption/time_bound_consumption.rb
+++ b/spec/integrations/consumption/time_bound_consumption.rb
@@ -18,13 +18,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_group do
-    topic DataCollector.topic do
-      consumer Consumer
-    end
-  end
-end
+draw_routes(Consumer)
 
 # Sends some data so we know all is good
 elements.each { |data| produce(DataCollector.topic, data) }

--- a/spec/integrations/consumption/two_consumer_groups_one_active.rb
+++ b/spec/integrations/consumption/two_consumer_groups_one_active.rb
@@ -16,7 +16,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_groups.first do
     topic DataCollector.topics.first do
       consumer Consumer

--- a/spec/integrations/consumption/two_consumer_groups_same_topic.rb
+++ b/spec/integrations/consumption/two_consumer_groups_same_topic.rb
@@ -15,7 +15,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_groups.first do
     topic DataCollector.topic do
       consumer Consumer

--- a/spec/integrations/consumption/with_long_living_buffer.rb
+++ b/spec/integrations/consumption/with_long_living_buffer.rb
@@ -34,13 +34,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_group do
-    topic DataCollector.topic do
-      consumer Consumer
-    end
-  end
-end
+draw_routes(Consumer)
 
 elements.each { |data| produce(DataCollector.topic, data) }
 

--- a/spec/integrations/consumption/with_max_messages.rb
+++ b/spec/integrations/consumption/with_max_messages.rb
@@ -14,7 +14,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topic do
       max_messages 5

--- a/spec/integrations/consumption/without_persistence_enabled.rb
+++ b/spec/integrations/consumption/without_persistence_enabled.rb
@@ -16,13 +16,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_group do
-    topic DataCollector.topic do
-      consumer Consumer
-    end
-  end
-end
+draw_routes(Consumer)
 
 elements.each { |data| produce(DataCollector.topic, data) }
 

--- a/spec/integrations/consumption/worker_critical_error_behaviour.rb
+++ b/spec/integrations/consumption/worker_critical_error_behaviour.rb
@@ -28,13 +28,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_group do
-    topic DataCollector.topic do
-      consumer Consumer
-    end
-  end
-end
+draw_routes(Consumer)
 
 elements.each { |data| produce(DataCollector.topic, data) }
 

--- a/spec/integrations/deserialization/custom_deserializer_usage.rb
+++ b/spec/integrations/deserialization/custom_deserializer_usage.rb
@@ -20,7 +20,7 @@ class CustomDeserializer
   end
 end
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topic do
       consumer Consumer

--- a/spec/integrations/deserialization/default_deserializer_usage.rb
+++ b/spec/integrations/deserialization/default_deserializer_usage.rb
@@ -14,13 +14,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_group do
-    topic DataCollector.topic do
-      consumer Consumer
-    end
-  end
-end
+draw_routes(Consumer)
 
 jsons.each { |data| produce(DataCollector.topic, data.to_json) }
 

--- a/spec/integrations/instrumentation/error_callback_multiple_subscription_groups.rb
+++ b/spec/integrations/instrumentation/error_callback_multiple_subscription_groups.rb
@@ -9,7 +9,7 @@ setup_karafka do |config|
   config.kafka = { 'bootstrap.servers' => '127.0.0.1:9090' }
 end
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_groups.first do
     topic DataCollector.topic do
       consumer Class.new

--- a/spec/integrations/instrumentation/error_callback_subscription.rb
+++ b/spec/integrations/instrumentation/error_callback_subscription.rb
@@ -7,13 +7,7 @@ setup_karafka do |config|
   config.kafka = { 'bootstrap.servers' => '127.0.0.1:9090' }
 end
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_groups.first do
-    topic DataCollector.topic do
-      consumer Class.new
-    end
-  end
-end
+draw_routes(Class.new)
 
 error_events = []
 

--- a/spec/integrations/instrumentation/statistics_callback_multiple_subscription_groups.rb
+++ b/spec/integrations/instrumentation/statistics_callback_multiple_subscription_groups.rb
@@ -6,7 +6,7 @@
 
 setup_karafka
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_groups.first do
     topic DataCollector.topic do
       consumer Class.new

--- a/spec/integrations/instrumentation/statistics_callback_on_client_change.rb
+++ b/spec/integrations/instrumentation/statistics_callback_on_client_change.rb
@@ -5,13 +5,7 @@
 
 setup_karafka
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_groups.first do
-    topic DataCollector.topic do
-      consumer Class.new
-    end
-  end
-end
+draw_routes(Class.new)
 
 stats_events = []
 

--- a/spec/integrations/instrumentation/statistics_callback_subscription.rb
+++ b/spec/integrations/instrumentation/statistics_callback_subscription.rb
@@ -4,13 +4,7 @@
 
 setup_karafka
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_groups.first do
-    topic DataCollector.topic do
-      consumer Class.new
-    end
-  end
-end
+draw_routes(Class.new)
 
 statistics_events = []
 

--- a/spec/integrations/lags/consumption_delayed.rb
+++ b/spec/integrations/lags/consumption_delayed.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Karafka should correctly report consumption_lag when there is a delay in between publishing
+# messages and their consumption
+
+setup_karafka
+
+elements = Array.new(5) { SecureRandom.uuid }
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DataCollector.data[:consumption_lag] = messages.metadata.consumption_lag
+  end
+end
+
+draw_routes(Consumer)
+
+elements.each do |data|
+  # We sleep here to make sure, that the lag is not computed on any of the messages except last
+  # from a single batch
+  sleep(0.5)
+  produce(DataCollector.topic, data)
+end
+
+# Give it some time so we have bigger consumption lag
+sleep(2)
+
+start_karafka_and_wait_until do
+  DataCollector.data.key?(:consumption_lag)
+end
+
+lag = DataCollector.data[:consumption_lag]
+
+assert_equal true, (2_000...4_000).include?(lag)

--- a/spec/integrations/lags/consumption_real_time.rb
+++ b/spec/integrations/lags/consumption_real_time.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Karafka should correctly report consumption_lag when we consume messages fast and it should never
+# be bigger than couple hundred ms with the defaults for integration specs
+
+setup_karafka
+
+elements = Array.new(5) { SecureRandom.uuid }
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DataCollector.data[:consumption_lags] << messages.metadata.consumption_lag
+  end
+end
+
+draw_routes(Consumer)
+
+start_karafka_and_wait_until do
+  elements.each do |data|
+    sleep(0.1)
+    produce(DataCollector.topic, data)
+  end
+
+  DataCollector.data[:consumption_lags].size >= 20
+end
+
+assert_equal true, DataCollector.data[:consumption_lags].max < 200

--- a/spec/integrations/lags/processing_fast.rb
+++ b/spec/integrations/lags/processing_fast.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# When processing data fast, the processing lag should not be big and things should be processed
+# almost real time
+
+setup_karafka do |config|
+  config.max_messages = 5
+end
+
+elements = Array.new(100) { SecureRandom.uuid }
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DataCollector.data[:processing_lags] << messages.metadata.processing_lag
+  end
+end
+
+draw_routes(Consumer)
+
+elements.each { |data| produce(DataCollector.topic, data) }
+
+start_karafka_and_wait_until do
+  DataCollector.data[:processing_lags].size >= 20
+end
+
+assert_equal true, DataCollector.data[:processing_lags].max <= 5

--- a/spec/integrations/lags/processing_not_enough_threads.rb
+++ b/spec/integrations/lags/processing_not_enough_threads.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# In case there are not enough threads to parallelize work from multiple topics/partitions we can
+# expect a processing lag, as work will wait in a queue to be picked up once resources are
+# available
+
+setup_karafka do |config|
+  config.max_messages = 1_000
+  config.concurrency = 1
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    sleep(0.2)
+    DataCollector.data[:processing_lags] << messages.metadata.processing_lag
+  end
+end
+
+draw_routes do
+  consumer_group DataCollector.consumer_group do
+    DataCollector.topics.first(2).each do |topic_name|
+      topic topic_name do
+        consumer Consumer
+      end
+
+      # Dispatching in a loop per topic will ensure the delivery order
+      20.times { produce(topic_name, SecureRandom.uuid) }
+    end
+  end
+end
+
+start_karafka_and_wait_until do
+  DataCollector.data[:processing_lags].size >= 2
+end
+
+max_lag = DataCollector.data[:processing_lags].max
+
+assert_equal true, (200..300).include?(max_lag)

--- a/spec/integrations/lags/processing_slow.rb
+++ b/spec/integrations/lags/processing_slow.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# When processing data slowly from a single partition of a single topic, we do not fetch more data
+# from Kafka, thus the processing lag should not be big as there is no more data enqueued
+
+setup_karafka do |config|
+  config.max_messages = 5
+end
+
+elements = Array.new(100) { SecureRandom.uuid }
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    sleep(0.1)
+    DataCollector.data[:processing_lags] << messages.metadata.processing_lag
+  end
+end
+
+draw_routes(Consumer)
+
+elements.each { |data| produce(DataCollector.topic, data) }
+
+start_karafka_and_wait_until do
+  DataCollector.data[:processing_lags].size >= 20
+end
+
+assert_equal true, DataCollector.data[:processing_lags].max <= 5

--- a/spec/integrations/offset_management/manual_offset_with_error_every_bang.rb
+++ b/spec/integrations/offset_management/manual_offset_with_error_every_bang.rb
@@ -26,13 +26,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_group do
-    topic DataCollector.topic do
-      consumer Consumer
-    end
-  end
-end
+draw_routes(Consumer)
 
 elements.each { |data| produce(DataCollector.topic, data) }
 

--- a/spec/integrations/offset_management/manual_offset_with_error_every_non_bang.rb
+++ b/spec/integrations/offset_management/manual_offset_with_error_every_non_bang.rb
@@ -26,13 +26,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_group do
-    topic DataCollector.topic do
-      consumer Consumer
-    end
-  end
-end
+draw_routes(Consumer)
 
 elements.each { |data| produce(DataCollector.topic, data) }
 

--- a/spec/integrations/offset_management/manual_offset_with_error_interval_bang.rb
+++ b/spec/integrations/offset_management/manual_offset_with_error_interval_bang.rb
@@ -27,13 +27,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_group do
-    topic DataCollector.topic do
-      consumer Consumer
-    end
-  end
-end
+draw_routes(Consumer)
 
 elements.each { |data| produce(DataCollector.topic, data) }
 

--- a/spec/integrations/offset_management/manual_offset_with_error_interval_non_bang.rb
+++ b/spec/integrations/offset_management/manual_offset_with_error_interval_non_bang.rb
@@ -27,13 +27,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_group do
-    topic DataCollector.topic do
-      consumer Consumer
-    end
-  end
-end
+draw_routes(Consumer)
 
 elements.each { |data| produce(DataCollector.topic, data) }
 

--- a/spec/integrations/offset_management/messages_and_metadata_details.rb
+++ b/spec/integrations/offset_management/messages_and_metadata_details.rb
@@ -14,13 +14,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_group do
-    topic DataCollector.topic do
-      consumer Consumer
-    end
-  end
-end
+draw_routes(Consumer)
 
 elements.each { |number| produce(DataCollector.topic, number) }
 

--- a/spec/integrations/pro/active_job/async_job_processing.rb
+++ b/spec/integrations/pro/active_job/async_job_processing.rb
@@ -8,7 +8,7 @@ end
 
 setup_active_job
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_group do
     active_job_topic DataCollector.topic
   end

--- a/spec/integrations/pro/active_job/ordered_jobs_with_partitioner.rb
+++ b/spec/integrations/pro/active_job/ordered_jobs_with_partitioner.rb
@@ -13,7 +13,7 @@ setup_active_job
 # This is a special topic with 3 partitions
 TOPIC_NAME = 'integrations_2_03'
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_group do
     active_job_topic TOPIC_NAME
   end

--- a/spec/integrations/pro/active_job/sync_job_processing.rb
+++ b/spec/integrations/pro/active_job/sync_job_processing.rb
@@ -8,7 +8,7 @@ end
 
 setup_active_job
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_group do
     active_job_topic DataCollector.topic
   end

--- a/spec/integrations/pro/licensing/configure_with_valid_token.rb
+++ b/spec/integrations/pro/licensing/configure_with_valid_token.rb
@@ -1,3 +1,20 @@
 # frozen_string_literal: true
 
-# Pro components should never be loaded when we do not run in pro mode
+# Pro components should be loaded when we run in pro mode and a nice message should be printed
+
+LOGS = StringIO.new
+
+setup_karafka do |config|
+  config.logger = Logger.new(LOGS)
+  config.license.token = pro_license_token
+end
+
+LOGS.rewind
+
+logs = LOGS.read
+
+assert_equal false, logs.include?('] ERROR -- : Your license expired')
+assert_equal false, logs.include?('Please reach us')
+assert_equal true, Karafka.pro?
+assert_equal true, const_visible?('Karafka::Pro::ActiveJob::Dispatcher')
+assert_equal true, const_visible?('Karafka::Pro::ActiveJob::JobOptionsContract')

--- a/spec/integrations/routing/routing_and_cli_validation.rb
+++ b/spec/integrations/routing/routing_and_cli_validation.rb
@@ -8,7 +8,7 @@ setup_karafka
 guarded = []
 
 begin
-  Karafka::App.routes.draw do
+  draw_routes do
     consumer_group 'regular' do
       topic '#$%^&*(' do
         consumer Class.new
@@ -20,7 +20,7 @@ rescue Karafka::Errors::InvalidConfigurationError
 end
 
 begin
-  Karafka::App.routes.draw do
+  draw_routes do
     consumer_group '#$%^&*(' do
       topic 'regular' do
         consumer Class.new

--- a/spec/integrations/routing/routing_with_the_simple_routes_style.rb
+++ b/spec/integrations/routing/routing_with_the_simple_routes_style.rb
@@ -5,7 +5,7 @@
 
 setup_karafka
 
-Karafka::App.routes.draw do
+draw_routes do
   topic 'topic1' do
     consumer Class.new
   end
@@ -29,7 +29,7 @@ assert_equal 'topic3', Karafka::App.consumer_groups.first.topics[2].name
 
 # Re-running simple routing should just add more topics
 
-Karafka::App.routes.draw do
+draw_routes do
   topic 'topic4' do
     consumer Class.new
   end

--- a/spec/integrations/seek/seek_backward_from_consumer.rb
+++ b/spec/integrations/seek/seek_backward_from_consumer.rb
@@ -32,13 +32,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_group do
-    topic DataCollector.topic do
-      consumer Consumer
-    end
-  end
-end
+draw_routes(Consumer)
 
 start_karafka_and_wait_until do
   DataCollector.data[0].size >= 10

--- a/spec/integrations/seek/seek_in_a_loop.rb
+++ b/spec/integrations/seek/seek_in_a_loop.rb
@@ -25,13 +25,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_group do
-    topic DataCollector.topic do
-      consumer Consumer
-    end
-  end
-end
+draw_routes(Consumer)
 
 start_karafka_and_wait_until do
   # 100 initially and then a loop from 20th 4 times

--- a/spec/integrations/seek/seek_to_a_given_offset_from_consumer.rb
+++ b/spec/integrations/seek/seek_to_a_given_offset_from_consumer.rb
@@ -27,13 +27,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_group do
-    topic DataCollector.topic do
-      consumer Consumer
-    end
-  end
-end
+draw_routes(Consumer)
 
 start_karafka_and_wait_until do
   DataCollector.data[0].size >= 10

--- a/spec/integrations/shutdown/on_hanging_jobs_and_a_shutdown.rb
+++ b/spec/integrations/shutdown/on_hanging_jobs_and_a_shutdown.rb
@@ -14,13 +14,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_group do
-    topic DataCollector.topic do
-      consumer Consumer
-    end
-  end
-end
+draw_routes(Consumer)
 
 start_karafka_and_wait_until do
   if DataCollector.data[0].empty?

--- a/spec/integrations/shutdown/on_hanging_on_shutdown_job_and_a_shutdown.rb
+++ b/spec/integrations/shutdown/on_hanging_on_shutdown_job_and_a_shutdown.rb
@@ -17,13 +17,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_group do
-    topic DataCollector.topic do
-      consumer Consumer
-    end
-  end
-end
+draw_routes(Consumer)
 
 start_karafka_and_wait_until do
   if DataCollector.data[0].empty?

--- a/spec/integrations/shutdown/on_hanging_poll_and_shutdown.rb
+++ b/spec/integrations/shutdown/on_hanging_poll_and_shutdown.rb
@@ -13,7 +13,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_group do
     topic DataCollector.topic do
       # This will force Karafka to be in a "permanent" poll

--- a/spec/integrations/shutdown/on_shutdown_when_messages_received.rb
+++ b/spec/integrations/shutdown/on_shutdown_when_messages_received.rb
@@ -23,7 +23,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
+draw_routes do
   consumer_group DataCollector.consumer_group do
     topic topic1 do
       consumer Consumer

--- a/spec/integrations/shutdown/on_shutdown_when_no_messages_received.rb
+++ b/spec/integrations/shutdown/on_shutdown_when_no_messages_received.rb
@@ -14,13 +14,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
-  consumer_group DataCollector.consumer_group do
-    topic DataCollector.topic do
-      consumer Consumer
-    end
-  end
-end
+draw_routes(Consumer)
 
 start_karafka_and_wait_until do
   sleep(2)

--- a/spec/integrations/shutdown/on_shutdown_when_partition_in_error_pause.rb
+++ b/spec/integrations/shutdown/on_shutdown_when_partition_in_error_pause.rb
@@ -19,11 +19,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-Karafka::App.routes.draw do
-  topic DataCollector.topic do
-    consumer Consumer
-  end
-end
+draw_routes(Consumer)
 
 produce(DataCollector.topic, '1')
 

--- a/spec/integrations_helper.rb
+++ b/spec/integrations_helper.rb
@@ -64,6 +64,24 @@ def setup_active_job
   ActiveJob::Base.queue_adapter = :karafka
 end
 
+# Sets up default routes (mostly used in integration specs) or allows to configure custom routes
+# by providing a block
+# @param consumer_class [Class, nil] consumer class we want to use if going with defaults
+# @param block [Proc] block with routes we want to draw if going with complex routes setup
+def draw_routes(consumer_class = nil, &block)
+  Karafka::App.routes.draw do
+    if block
+      instance_eval(&block)
+    else
+      consumer_group DataCollector.consumer_group do
+        topic DataCollector.topic do
+          consumer consumer_class
+        end
+      end
+    end
+  end
+end
+
 # Waits until block yields true
 def wait_until
   sleep(0.01) until yield

--- a/spec/lib/karafka/messages/batch_metadata_spec.rb
+++ b/spec/lib/karafka/messages/batch_metadata_spec.rb
@@ -46,4 +46,16 @@ RSpec.describe_current do
 
     it { expect(metadata.scheduled_at).to eq rand_value }
   end
+
+  describe '#consumption_lag' do
+    before { metadata['consumption_lag'] = rand_value }
+
+    it { expect(metadata.consumption_lag).to eq rand_value }
+  end
+
+  describe '#processing_lag' do
+    before { metadata['processing_lag'] = rand_value }
+
+    it { expect(metadata.processing_lag).to eq rand_value }
+  end
 end

--- a/spec/lib/karafka/messages/builders/batch_metadata_spec.rb
+++ b/spec/lib/karafka/messages/builders/batch_metadata_spec.rb
@@ -2,10 +2,10 @@
 
 RSpec.describe_current do
   let(:routing_topic) { build(:routing_topic) }
-  let(:message1) { build(:kafka_fetched_message) }
-  let(:message2) { build(:kafka_fetched_message) }
+  let(:message1) { build(:kafka_fetched_message, timestamp: 5.seconds.ago) }
+  let(:message2) { build(:kafka_fetched_message, timestamp: 3.seconds.ago) }
   let(:kafka_batch) { [message1, message2] }
-  let(:scheduled_at) { Time.now }
+  let(:scheduled_at) { Time.now - 1.second }
 
   describe '#call' do
     subject(:result) { described_class.call(kafka_batch, routing_topic, scheduled_at) }
@@ -18,6 +18,8 @@ RSpec.describe_current do
     it { expect(result.topic).to eq routing_topic.name }
     it { expect(result.deserializer).to eq routing_topic.deserializer }
     it { expect(result.scheduled_at).to eq(scheduled_at) }
+    it { expect(result.consumption_lag).to be_between(3000, 3100) }
+    it { expect(result.processing_lag).to be_between(1000, 1100) }
     it { expect(result).to be_frozen }
   end
 end


### PR DESCRIPTION
This PR:
- introduces `consumption_lag` in batch metadata (time from the moment messages were produced to the moment they were picked up for consumption
- introduces `processing_lag` In batch metadata (time from the moment messages were received by the consumer to the moment they were picked up for consumption)
- small abstraction of standard integration specs route drawing
- small fixed to integration specs
- lag related integration specs

close https://github.com/karafka/karafka/issues/784