### PR TITLE
v1.4.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Karafka framework changelog
 
-## master (Unreleased)
+## 1.4.13 (2022-02-19)
 - Drop support for ruby 2.6
+- Add mfa requirement
 
 ## 1.4.12 (2022-01-13)
 - Ruby 3.1 support

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka (1.4.12)
+    karafka (1.4.13)
       dry-configurable (~> 0.13)
       dry-inflector (~> 0.2)
       dry-monitor (~> 0.5)
@@ -49,7 +49,7 @@ GEM
       dry-configurable (~> 0.13, >= 0.13.0)
       dry-core (~> 0.5, >= 0.5)
       dry-events (~> 0.2)
-    dry-schema (1.8.0)
+    dry-schema (1.9.1)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.13, >= 0.13.0)
       dry-core (~> 0.5, >= 0.5)
@@ -62,12 +62,12 @@ GEM
       dry-core (~> 0.5, >= 0.5)
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 1.0, >= 1.0.2)
-    dry-validation (1.7.0)
+    dry-validation (1.8.0)
       concurrent-ruby (~> 1.0)
       dry-container (~> 0.7, >= 0.7.1)
       dry-core (~> 0.5, >= 0.5)
       dry-initializer (~> 3.0)
-      dry-schema (~> 1.8, >= 1.8.0)
+      dry-schema (~> 1.9, >= 1.9.1)
     envlogic (1.1.4)
       dry-inflector (~> 0.1)
     factory_bot (6.2.0)

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '1.4.12'
+  VERSION = '1.4.13'
 end


### PR DESCRIPTION
## 1.4.13 (2022-02-19)
- Drop support for ruby 2.6
- Add mfa requirement

ref https://github.com/karafka/karafka/issues/764