### PR TITLE
support initialized state and add integration for states flow

### DIFF
--- a/lib/karafka/instrumentation/monitor.rb
+++ b/lib/karafka/instrumentation/monitor.rb
@@ -17,6 +17,7 @@ module Karafka
       #   complete list of all the events. Please use the #available_events on fully loaded
       #   Karafka system to determine all of the events you can use.
       BASE_EVENTS = %w[
+        app.initialized
         app.running
         app.stopping
         app.stopped

--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -118,6 +118,8 @@ module Karafka
           Licenser.new.verify(config.license)
 
           configure_components
+
+          Karafka::App.initialized!
         end
 
         private

--- a/lib/karafka/status.rb
+++ b/lib/karafka/status.rb
@@ -6,6 +6,7 @@ module Karafka
     # Available states and their transitions.
     STATES = {
       initializing: :initialize!,
+      initialized: :initialized!,
       running: :run!,
       stopping: :stop!,
       stopped: :stopped!

--- a/spec/integrations/instrumentation/app_status_lifecycle_flow.rb
+++ b/spec/integrations/instrumentation/app_status_lifecycle_flow.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Karafka when started and stopped should go through all the lifecycle stages
+
+# States changes that are published
+PUBLISHED_STATES = %w[
+  app.initialized
+  app.running
+  app.stopping
+  app.stopped
+].freeze
+
+PUBLISHED_STATES.each do |state|
+  Karafka::App.monitor.subscribe(state) do |event|
+    DataCollector.data[:states] << state
+  end
+end
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DataCollector.data[0] << true
+  end
+end
+
+draw_routes(Consumer)
+
+produce(DataCollector.topic, '1')
+
+start_karafka_and_wait_until do
+  DataCollector.data[0].size >= 1
+end
+
+# We need to sleep as state changes propagate in a separate thread
+sleep(0.01) until DataCollector.data[:states].size >= 4
+
+PUBLISHED_STATES.each_with_index do |state, index|
+  assert_equal state, DataCollector.data[:states][index]
+end

--- a/spec/integrations/instrumentation/app_status_lifecycle_flow.rb
+++ b/spec/integrations/instrumentation/app_status_lifecycle_flow.rb
@@ -11,7 +11,7 @@ PUBLISHED_STATES = %w[
 ].freeze
 
 PUBLISHED_STATES.each do |state|
-  Karafka::App.monitor.subscribe(state) do |event|
+  Karafka::App.monitor.subscribe(state) do
     DataCollector.data[:states] << state
   end
 end

--- a/spec/lib/karafka/status_spec.rb
+++ b/spec/lib/karafka/status_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe_current do
   before { status_manager.instance_variable_set(:'@status', status) }
 
   context 'when we start with a default state' do
+    it { expect(status_manager.initialized?).to eq false }
     it { expect(status_manager.running?).to eq false }
     it { expect(status_manager.stopping?).to eq false }
     it { expect(status_manager.stopped?).to eq false }
@@ -22,6 +23,7 @@ RSpec.describe_current do
     context 'when status is set to running' do
       let(:status) { :running }
 
+      it { expect(status_manager.initialized?).to eq false }
       it { expect(status_manager.running?).to eq true }
     end
   end
@@ -32,6 +34,7 @@ RSpec.describe_current do
 
       it { expect(status_manager.running?).to eq true }
       it { expect(status_manager.initializing?).to eq false }
+      it { expect(status_manager.initialized?).to eq false }
       it { expect(status_manager.stopping?).to eq false }
       it { expect(status_manager.stopped?).to eq false }
     end
@@ -43,6 +46,7 @@ RSpec.describe_current do
         status_manager.instance_variable_set(:'@status', rand)
       end
 
+      it { expect(status_manager.initialized?).to eq false }
       it { expect(status_manager.stopping?).to eq false }
       it { expect(status_manager.stopped?).to eq false }
     end
@@ -52,6 +56,7 @@ RSpec.describe_current do
         status_manager.instance_variable_set(:'@status', :stopping)
       end
 
+      it { expect(status_manager.initialized?).to eq false }
       it { expect(status_manager.stopping?).to eq true }
       it { expect(status_manager.stopped?).to eq false }
     end
@@ -66,6 +71,7 @@ RSpec.describe_current do
 
       it { expect(status_manager.running?).to eq false }
       it { expect(status_manager.initializing?).to eq false }
+      it { expect(status_manager.initialized?).to eq false }
       it { expect(status_manager.stopping?).to eq true }
       it { expect(status_manager.stopped?).to eq false }
     end
@@ -81,6 +87,7 @@ RSpec.describe_current do
 
       it { expect(status_manager.running?).to eq false }
       it { expect(status_manager.initializing?).to eq false }
+      it { expect(status_manager.initialized?).to eq false }
       it { expect(status_manager.stopping?).to eq false }
       it { expect(status_manager.stopped?).to eq true }
     end
@@ -95,6 +102,7 @@ RSpec.describe_current do
       let(:status) { :initializing }
 
       it { expect(status_manager.initializing?).to eq true }
+      it { expect(status_manager.initialized?).to eq false }
     end
   end
 
@@ -106,6 +114,19 @@ RSpec.describe_current do
 
       it { expect(status_manager.running?).to eq false }
       it { expect(status_manager.initializing?).to eq true }
+      it { expect(status_manager.stopping?).to eq false }
+    end
+  end
+
+  describe 'initialized!' do
+    context 'when we set it to initialized' do
+      before do
+        status_manager.initialized!
+      end
+
+      it { expect(status_manager.initialized?).to eq true }
+      it { expect(status_manager.running?).to eq false }
+      it { expect(status_manager.initializing?).to eq false }
       it { expect(status_manager.stopping?).to eq false }
     end
   end


### PR DESCRIPTION
This PR restores the app.initialized state change and adds integration tests to ensure states changes flow order