### PR TITLE
2.0 Threadsafe ActiveJob Consumption with Timeouts

### DIFF
--- a/lib/karafka/active_job/consumer.rb
+++ b/lib/karafka/active_job/consumer.rb
@@ -5,19 +5,90 @@ module Karafka
     # This is the consumer for ActiveJob that eats the messages enqueued with it one after another.
     # It marks the offset after each message, so we make sure, none of the jobs is executed twice
     class Consumer < ::Karafka::BaseConsumer
+      # Defaults for consuming
+      # The can be updated by using `#karafka_options` on the job
+      DEFAULTS = {
+        timeout: 300000,          # (5 minutes)
+        max_poll_interval: 300000 # (5 minutes) default max.poll.interval.ms
+      }.freeze
+
       # Executes the ActiveJob logic
       # @note ActiveJob does not support batches, so we just run one message after another
       def consume
         messages.each do |message|
-          ::ActiveJob::Base.execute(
-            # We technically speaking could set this as deserializer and reference it from the
-            # message instead of using the `#raw_payload`. This is not done on purpose to simplify
-            # the ActiveJob setup here
-            ::ActiveSupport::JSON.decode(message.raw_payload)
-          )
+          # Decode as JSON so we can get the Job Class (Required for finding karafka_options)
+          decoded_message_payload = ::ActiveSupport::JSON.decode(message.raw_payload)
 
-          mark_as_consumed(message)
+          begin
+            # Pause the consumer for this message partition - so we can poll without receiving
+            # new records
+            client.pause_without_reversal(topic.name, message.partition)
+
+            # Any thread exceptions will be re-raised in the main thread.
+            Thread.abort_on_exception = true
+
+            keep_alive_interval = Karafka::App.config.kafka[:'max.poll.interval.ms'] ||= DEFAULTS.fetch('max_poll_interval')
+            keep_alive_interval = keep_alive_interval / 2
+
+            # Continue calling poll while the job_thread is still working
+            #  - Prevents Kafka marking the consumer as 'dead'
+            heartbeat_thread = Thread.new do
+              while true
+                # This timeout will always be hit as no records can be pulled while the partition
+                # is paused.
+                client.keep_alive_poll(timeout: keep_alive_interval)
+              end
+            end
+
+            job_thread = Thread.new do
+              ::ActiveJob::Base.execute(decoded_message_payload)
+            end
+
+            # After timeout kill heartbeat thread
+            timeout_thread = Thread.new do
+              # Fetch the timeout for the Job class
+              # Divide by 1000 for milliseconds float precision
+              timeout = fetch_option(decoded_message_payload['job_class'], :timeout, DEFAULTS) / 1000.0
+              sleep(timeout)
+
+              # TODO: This functionality could potentially be definable
+              #  - What do you want your Job to do on Timeout:
+              #    - Continue running until close
+              #    - Raise as bellow and stop
+              job_thread.raise(RuntimeError)
+            end
+
+            # Wait until the Job thread has completed
+            job_thread.join
+
+            mark_as_consumed(message)
+
+            # TODO: On error we could give them option to mark the message as consumed and possibly publish it to a
+            #   dead letter topic - its unlikely that the message will retry with a successful result
+          ensure
+            # Ensure we close all the threads in case of an unforeseen error
+            Thread.kill(job_thread)
+            Thread.kill(timeout_thread)
+            Thread.kill(heartbeat_thread)
+            # Wait until all threads are dead
+            job_thread.join
+            timeout_thread.join
+            heartbeat_thread.join
+            # Resume the consumer for the message partition - so we can continue to pull messages
+            client.resume(topic.name, message.partition)
+          end
         end
+      end
+
+      # @param job [String] job class name
+      # @param key [Symbol] key we want to fetch
+      # @param defaults [Hash]
+      # @return [Object] options we are interested in
+      def fetch_option(job, key, defaults)
+        job
+          .constantize
+          .karafka_options
+          .fetch(key, defaults.fetch(key))
       end
     end
   end

--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -81,6 +81,15 @@ module Karafka
         @buffer
       end
 
+      # Polls Kafka with a set timeout as a keep alive
+      #
+      # @param timeout in milliseconds to wait for poll
+      # @note This is intended only as a keep alive for the consumer - the partition|topic
+      #   should be paused before using this to not repeatedly read messages
+      def keep_alive_poll(timeout:)
+        poll(timeout)
+      end
+
       # Stores offset for a given partition of a given topic based on the provided message.
       #
       # @param message [Karafka::Messages::Message]
@@ -129,6 +138,16 @@ module Karafka
       # @param message [Messages::Message, Messages::Seek] message to which we want to seek to
       def seek(message)
         @kafka.seek(message)
+      end
+
+      # Pauses given partition and topic
+      #
+      # @param topic [String] topic name
+      # @param partition [Integer] partition
+      # @note This will pause indefinitely and requires manual `#resume`
+      def pause_without_reversal(topic, partition)
+        tpl = topic_partition_list(topic, partition)
+        @kafka.pause(tpl)
       end
 
       # Pauses given partition and moves back to last successful offset processed.

--- a/spec/integrations/rails/active_job/timeout.rb
+++ b/spec/integrations/rails/active_job/timeout.rb
@@ -3,6 +3,7 @@
 # Karafka should never process the same job multiple times from one perform call
 
 setup_karafka do |config|
+  config.concurrency = 2
   # Set a 6 second maximum poll interval for the consumer
   config.kafka[:'session.timeout.ms'] = '6000'
   config.kafka[:'max.poll.interval.ms'] = '6000'
@@ -20,12 +21,13 @@ class Job < ActiveJob::Base
   queue_as DataCollector.topic
 
   karafka_options(
-    dispatch_method: :produce_sync
+    dispatch_method: :produce_sync,
+    timeout: 8000
   )
 
   def perform(value1)
-    DataCollector.data[0] << value1
     sleep(7) # Intentionally take longer than the maximum poll interval
+    DataCollector.data[0] << value1
   end
 end
 

--- a/spec/integrations/rails/active_job/timeout.rb
+++ b/spec/integrations/rails/active_job/timeout.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Karafka should never process the same job multiple times from one perform call
+
+setup_karafka do |config|
+  # Set a 6 second maximum poll interval for the consumer
+  config.kafka[:'session.timeout.ms'] = '6000'
+  config.kafka[:'max.poll.interval.ms'] = '6000'
+end
+
+setup_active_job
+
+draw_routes do
+  consumer_group DataCollector.consumer_group do
+    active_job_topic DataCollector.topic
+  end
+end
+
+class Job < ActiveJob::Base
+  queue_as DataCollector.topic
+
+  karafka_options(
+    dispatch_method: :produce_sync
+  )
+
+  def perform(value1)
+    DataCollector.data[0] << value1
+    sleep(7) # Intentionally take longer than the maximum poll interval
+  end
+end
+
+VALUE1 = rand
+
+Job.perform_later(VALUE1)
+
+# This gives at least one second for another consumption of the message based on the sleep
+eight_seconds_later = 8.seconds.from_now
+
+start_karafka_and_wait_until do
+  Time.now > eight_seconds_later
+end
+
+aj_config = Karafka::App.config.internal.active_job
+
+assert_equal aj_config.dispatcher.class, Karafka::ActiveJob::Dispatcher
+assert_equal aj_config.job_options_contract.class, Karafka::ActiveJob::JobOptionsContract
+assert_equal VALUE1, DataCollector.data[0][0]
+assert_equal 1, DataCollector.data[0].size


### PR DESCRIPTION
Karafka has no way of knowing how long an ActiveJob task will run for.

If it runs longer than `max.poll.interval.ms` Kafka will mark the consumer as dead but the Job will continue, leaving the two systems with different contexts causing unforeseen and hard to debug errors.

Under **Detecting Consumer Failures** in the [kafka consumer documentation](https://kafka.apache.org/31/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html)

It states:

> For use cases where message processing time varies unpredictably, neither of these options may be sufficient. The recommended way to handle these cases is to move message processing to another thread, which allows the consumer to continue calling [poll](https://kafka.apache.org/31/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html#poll(java.time.Duration)) while the processor is still working. Some care must be taken to ensure that committed offsets do not get ahead of the actual position. Typically, you must disable automatic commits and manually commit processed offsets for records only after the thread has finished handling them (depending on the delivery semantics you need). Note also that you will need to [pause](https://kafka.apache.org/31/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html#pause(java.util.Collection)) the partition so that no new records are received from poll until after thread has finished handling those previously returned.

This change implements that for the ActiveJob consumer in a consistent manner with the current implementation:

- Any exceptions are still managed by the main thread.
- Messages are only marked as consumed if the Job successfully executes
`at-least-once` processing guarantee

As consumer timeouts were previously based only on the consumer configuration `max.poll.interval.ms` and this is no longer the case this also implements an **ActiveJob** configurable timeout implementation.

Fixes: https://github.com/karafka/karafka/issues/809