### PR TITLE
renamed event and consumption event integration spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2.0.0-alpha6 (Unreleased)
 - Fix a bug, where upon missing boot file and Rails, railtie would fail with a generic exception (#818) 
 - Fix an issue with parallel pristine specs colliding with each other during `bundle install` (#820)
+- Replace `consumer.consume` with `consumer.consumed` event to match the behaviour
+- Make sure, that offset committing happens before the `consumer.consumed` event is propagated
 
 ## 2.0.0-alpha5 (2022-04-03)
 - Rename StdoutListener to LoggerListener (#811)

--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -29,8 +29,8 @@ module Karafka
         # Mark as consumed only if manual offset management is not on
         return if topic.manual_offset_management
 
-        # We use the non-blocking one here. If someone needs the blocking one, can implement it with
-        # manual offset management
+        # We use the non-blocking one here. If someone needs the blocking one, can implement it
+        # with manual offset management
         mark_as_consumed(messages.last)
       end
     rescue StandardError => e

--- a/lib/karafka/instrumentation/monitor.rb
+++ b/lib/karafka/instrumentation/monitor.rb
@@ -22,7 +22,7 @@ module Karafka
         app.stopping
         app.stopped
 
-        consumer.consume
+        consumer.consumed
         consumer.revoked
         consumer.shutdown
 

--- a/spec/integrations/instrumentation/consumption_event_vs_processing.rb
+++ b/spec/integrations/instrumentation/consumption_event_vs_processing.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Karafka should publish same number of consumed events as batches consumed
+
+setup_karafka
+
+elements = Array.new(10) { SecureRandom.uuid }
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DataCollector.data[0] << messages.count
+  end
+end
+
+Karafka::App.monitor.subscribe('consumer.consumed') do |event|
+  DataCollector.data[1] << event[:caller].messages.count
+end
+
+draw_routes do
+  topic DataCollector.topic do
+    consumer Consumer
+  end
+end
+
+start_karafka_and_wait_until do
+  produce(DataCollector.topic, rand.to_s)
+  DataCollector.data[0].sum >= 100
+end
+
+assert_equal DataCollector.data[0], DataCollector.data[1]

--- a/spec/integrations/instrumentation/consumption_event_vs_processing.rb
+++ b/spec/integrations/instrumentation/consumption_event_vs_processing.rb
@@ -4,8 +4,6 @@
 
 setup_karafka
 
-elements = Array.new(10) { SecureRandom.uuid }
-
 class Consumer < Karafka::BaseConsumer
   def consume
     DataCollector.data[0] << messages.count

--- a/spec/lib/karafka/base_consumer_spec.rb
+++ b/spec/lib/karafka/base_consumer_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe_current do
       it { expect { consumer.on_consume }.not_to raise_error }
 
       it 'expect to run proper instrumentation' do
-        Karafka.monitor.subscribe('consumer.consume') do |event|
+        Karafka.monitor.subscribe('consumer.consumed') do |event|
           expect(event.payload[:caller]).to eq(consumer)
         end
 
@@ -138,7 +138,7 @@ RSpec.describe_current do
       it { expect { consumer.on_consume }.not_to raise_error }
 
       it 'expect to run proper instrumentation' do
-        Karafka.monitor.subscribe('consumer.consume') do |event|
+        Karafka.monitor.subscribe('consumer.consumed') do |event|
           expect(event.payload[:caller]).to eq(consumer)
         end
 


### PR DESCRIPTION
This PR:
- renames `consumer.consume` event to `consumer.consumed`
- ensures that offset management is part of instrumentation during consumption
- adds a spec to count events and messages produced
