### PR TITLE
do not fail when not first class citizen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix an issue with parallel pristine specs colliding with each other during `bundle install` (#820)
 - Replace `consumer.consume` with `consumer.consumed` event to match the behaviour
 - Make sure, that offset committing happens before the `consumer.consumed` event is propagated
+- Fix for failing when not installed (just a dependency) (#817)
 
 ## 2.0.0-alpha5 (2022-04-03)
 - Rename StdoutListener to LoggerListener (#811)

--- a/lib/karafka/railtie.rb
+++ b/lib/karafka/railtie.rb
@@ -82,7 +82,7 @@ if rails
       initializer 'karafka.require_karafka_boot_file' do |app|
         rails6plus = Rails.gem_version >= Gem::Version.new('6.0.0')
 
-        # If the bootfile location is set to "false", we should not raise an exception and we
+        # If the boot file location is set to "false", we should not raise an exception and we
         # should just not load karafka stuff. Setting this explicitly to false indicates, that
         # karafka is part of the supply chain but it is not a first class citizen of a given
         # system (may be just a dependency of a dependency), thus railtie should not kick in to

--- a/lib/karafka/railtie.rb
+++ b/lib/karafka/railtie.rb
@@ -82,6 +82,13 @@ if rails
       initializer 'karafka.require_karafka_boot_file' do |app|
         rails6plus = Rails.gem_version >= Gem::Version.new('6.0.0')
 
+        # If the bootfile location is set to "false", we should not raise an exception and we
+        # should just not load karafka stuff. Setting this explicitly to false indicates, that
+        # karafka is part of the supply chain but it is not a first class citizen of a given
+        # system (may be just a dependency of a dependency), thus railtie should not kick in to
+        # load the non-existing boot file
+        next if Karafka.boot_file.to_s == 'false'
+
         karafka_boot_file = Rails.root.join(Karafka.boot_file.to_s).to_s
 
         # Provide more comprehensive error for when no boot file

--- a/spec/integrations/rails/rails6/just-a-dependency/Gemfile
+++ b/spec/integrations/rails/rails6/just-a-dependency/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'karafka', path: ENV.fetch('KARAFKA_GEM_DIR')
+gem 'rails', '6.1.4.6', require: true

--- a/spec/integrations/rails/rails6/just-a-dependency/rails_setup.rb
+++ b/spec/integrations/rails/rails6/just-a-dependency/rails_setup.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Karafka should work fine with Rails 6 even when it is just a transitive dependency and is not
+# in active use. In case like this KARAFKA_BOOT_FILE needs to be set to "false"
+#
+# @see https://github.com/karafka/karafka/issues/813
+
+Bundler.require(:default)
+
+ENV['RAILS_ENV'] = 'test'
+
+Bundler.require(:default)
+
+class ExampleApp < Rails::Application
+  config.eager_load = 'test'
+end
+
+ENV['KARAFKA_BOOT_FILE'] = 'false'
+
+disabled = true
+
+begin
+  ExampleApp.initialize!
+rescue Karafka::Errors::MissingBootFileError
+  disabled = false
+end
+
+assert_equal true, disabled

--- a/spec/integrations/rails/rails7/just-a-dependency/Gemfile
+++ b/spec/integrations/rails/rails7/just-a-dependency/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'karafka', path: ENV.fetch('KARAFKA_GEM_DIR')
+gem 'rails', '7.0.2.2', require: true

--- a/spec/integrations/rails/rails7/just-a-dependency/rails_setup.rb
+++ b/spec/integrations/rails/rails7/just-a-dependency/rails_setup.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Karafka should work fine with Rails 7 even when it is just a transitive dependency and is not
+# in active use. In case like this KARAFKA_BOOT_FILE needs to be set to "false"
+#
+# @see https://github.com/karafka/karafka/issues/813
+
+Bundler.require(:default)
+
+ENV['RAILS_ENV'] = 'test'
+
+Bundler.require(:default)
+
+class ExampleApp < Rails::Application
+  config.eager_load = 'test'
+end
+
+ENV['KARAFKA_BOOT_FILE'] = 'false'
+
+disabled = true
+
+begin
+  ExampleApp.initialize!
+rescue Karafka::Errors::MissingBootFileError
+  disabled = false
+end
+
+assert_equal true, disabled

--- a/spec/integrations/rails/rails7/without-active_job/railtie_setup.rb
+++ b/spec/integrations/rails/rails7/without-active_job/railtie_setup.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Karafka should work with Rails 6 that does not use ActiveJob using the default setup and should
+# Karafka should work with Rails 7 that does not use ActiveJob using the default setup and should
 # just ignore the ActiveJob components
 
 Bundler.require(:default)

--- a/spec/integrations/rails/rails7/without-active_job_rspec/rspec_rails_setup.rb
+++ b/spec/integrations/rails/rails7/without-active_job_rspec/rspec_rails_setup.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Karafka should work with Rails 6 and rspec/rails when it is required and should not crash
+# Karafka should work with Rails 7 and rspec/rails when it is required and should not crash
 #
 # @see https://github.com/karafka/karafka/issues/803
 


### PR DESCRIPTION
Karafka should not fail, when it is just a dependency. In case like this `KARAFKA_BOOT_FILE` should be set to `"false"` string

close: https://github.com/karafka/karafka/issues/817