### PR TITLE
Use Kraft (Kafka without Zookeeper)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,28 +1,19 @@
 version: '2'
 services:
-  zookeeper:
-    image: wurstmeister/zookeeper
-    ports:
-      - '2181:2181'
   kafka:
-    image: wurstmeister/kafka
+    image: bitnami/kafka:latest
     ports:
       - '9092:9092'
     environment:
-      KAFKA_ADVERTISED_HOST_NAME: localhost
-      KAFKA_ADVERTISED_PORT: 9092
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
-      KAFKA_CREATE_TOPICS:
-        "integrations_0_02:2:1,\
-         integrations_1_02:2:1,\
-         integrations_0_03:3:1,\
-         integrations_1_03:3:1,\
-         integrations_2_03:3:1,\
-         integrations_0_10:10:1,\
-         integrations_1_10:10:1,\
-         benchmarks_0_01:1:1,\
-         benchmarks_0_05:5:1,\
-         benchmarks_0_10:10:1"
+      - KAFKA_ENABLE_KRAFT=yes
+      - KAFKA_CFG_PROCESS_ROLES=broker,controller
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:9092
+      - KAFKA_CFG_BROKER_ID=1
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@127.0.0.1:9093
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
  - Uses Kafka itself for the Quorum Controller
    - see: https://developer.confluent.io/learn/kraft/
  - Switch to the much more up to date Bitnami Kafka Image
    - up to Kafka 3.1 (wurstmeister is still on 2.8)

**NOTE: This change ignores `KAFKA_CREATE_TOPICS` that was originally set in `docker-compose.yml` assuming it's not actually required given `KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true` if this is not true this will need changes.**

Change requested from: https://github.com/karafka/example-apps/pull/152#issuecomment-1086687646