### PR TITLE
Introduce notion of non-blocking jobs

### DIFF
--- a/lib/karafka/processing/jobs/base.rb
+++ b/lib/karafka/processing/jobs/base.rb
@@ -5,7 +5,7 @@ module Karafka
     # Namespace for all the jobs that are suppose to run in workers.
     module Jobs
       # Base class for all the jobs types that are suppose to run in workers threads.
-      # Each job can have 3 main entrypoints: `#prepare`, `#call` and `#teardown`
+      # Each job can have 3 main entry-points: `#prepare`, `#call` and `#teardown`
       # Only `#call` is required.
       class Base
         extend Forwardable
@@ -35,7 +35,7 @@ module Karafka
 
         # Marks this job as no longer blocking
         def unblock!
-          @nnon_blocking = true
+          @non_blocking = true
         end
       end
     end

--- a/lib/karafka/processing/jobs/base.rb
+++ b/lib/karafka/processing/jobs/base.rb
@@ -5,6 +5,8 @@ module Karafka
     # Namespace for all the jobs that are suppose to run in workers.
     module Jobs
       # Base class for all the jobs types that are suppose to run in workers threads.
+      # Each job can have 3 main entrypoints: `#prepare`, `#call` and `#teardown`
+      # Only `#call` is required.
       class Base
         extend Forwardable
 
@@ -12,6 +14,29 @@ module Karafka
         def_delegators :executor, :id, :group_id
 
         attr_reader :executor
+
+        def initialize
+          # Every job by default is blocking and blocks the jobs queue until finished
+          @non_blocking = false
+        end
+
+        # When redefined can run any code that should run before executing the proper code
+        def prepare; end
+
+        # When redefined can run any code that should run after executing the proper code
+        def teardown; end
+
+        # @return [Boolean] is this a non-blocking job
+        # @note Blocking job is a job, that will cause the job queue to wait until it is finished
+        #   before removing the lock on new jobs being added
+        def non_blocking?
+          @non_blocking
+        end
+
+        # Marks this job as no longer blocking
+        def unblock!
+          @nnon_blocking = true
+        end
       end
     end
   end

--- a/lib/karafka/processing/jobs_queue.rb
+++ b/lib/karafka/processing/jobs_queue.rb
@@ -115,13 +115,15 @@ module Karafka
       # @param group_id [String] id of the group in which jobs we're interested.
       # @return [Boolean] should we keep waiting or not
       def wait?(group_id)
+        group = @in_processing[group_id]
+
         # If it is stopping, all the previous messages that are processed at the moment need to
         # finish. Otherwise we may risk closing the client and committing offsets afterwards
-        return false if Karafka::App.stopping? && @in_processing[group_id].empty?
+        return false if Karafka::App.stopping? && group.empty?
         return false if @queue.closed?
-        return false if @in_processing[group_id].empty?
+        return false if group.empty?
 
-        true
+        !group.all?(&:non_blocking?)
       end
     end
   end

--- a/spec/lib/karafka/processing/jobs/base_spec.rb
+++ b/spec/lib/karafka/processing/jobs/base_spec.rb
@@ -1,4 +1,15 @@
 # frozen_string_literal: true
 
-# Empty stub for Diffend
-RSpec.describe_current {}
+RSpec.describe_current do
+  describe '#non_blocking?' do
+    it 'expect all the newly created jobs to be blocking' do
+      expect(described_class.new.non_blocking?).to eq(false)
+    end
+
+    it 'expect job that is marked as unblocked not to be blocking' do
+      job = described_class.new
+      job.unblock!
+      expect(job.non_blocking?).to eq(true)
+    end
+  end
+end

--- a/spec/lib/karafka/processing/jobs_queue_spec.rb
+++ b/spec/lib/karafka/processing/jobs_queue_spec.rb
@@ -3,8 +3,8 @@
 RSpec.describe_current do
   subject(:queue) { described_class.new }
 
-  let(:job1) { OpenStruct.new(group_id: 1, id: 1, call: true) }
-  let(:job2) { OpenStruct.new(group_id: 2, id: 1, call: true) }
+  let(:job1) { OpenStruct.new(group_id: 1, id: 1, call: true, non_blocking?: false) }
+  let(:job2) { OpenStruct.new(group_id: 2, id: 1, call: true, non_blocking?: false) }
   let(:internal_queue) { ::Queue.new }
 
   before { queue.instance_variable_set('@queue', internal_queue) }
@@ -103,7 +103,7 @@ RSpec.describe_current do
       end
     end
 
-    context 'when we have to wait' do
+    context 'when we have to wait for a job' do
       before { queue << job1 }
 
       it 'expect to pass until no longer needing to wait' do
@@ -138,6 +138,14 @@ RSpec.describe_current do
         before = Time.now.to_f
         queue.wait(job1.group_id)
         expect(Time.now.to_f - before).to be >= 1
+      end
+    end
+
+    context 'when we have non blocking jobs in the queue only' do
+      before { queue << OpenStruct.new(group_id: 1, id: 1, call: true, non_blocking?: true) }
+
+      it 'expect not to block' do
+        queue.wait(job1.group_id)
       end
     end
 

--- a/spec/lib/karafka/processing/worker_spec.rb
+++ b/spec/lib/karafka/processing/worker_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe_current do
         allow(job).to receive(:prepare)
         allow(job).to receive(:call)
         allow(job).to receive(:teardown)
+        allow(queue).to receive(:tick)
+
         queue << job
         # Force the background job work, so we can validate the expectation as the thread will
         # execute correctly the given job
@@ -47,7 +49,7 @@ RSpec.describe_current do
         sleep(0.05)
       end
 
-      it { expect(queue).not_to receive(:tick) }
+      it { expect(queue).not_to have_received(:tick) }
       it { expect(job).to have_received(:prepare).with(no_args) }
       it { expect(job).to have_received(:call).with(no_args) }
       it { expect(job).to have_received(:teardown).with(no_args) }

--- a/spec/lib/karafka/processing/worker_spec.rb
+++ b/spec/lib/karafka/processing/worker_spec.rb
@@ -33,11 +33,13 @@ RSpec.describe_current do
       it { expect(queue).not_to have_received(:complete) }
     end
 
-    context 'when it is not a closing job' do
+    context 'when it is a non-closing, blocking job' do
       let(:job) { OpenStruct.new(group_id: 1, id: 1, call: true) }
 
       before do
+        allow(job).to receive(:prepare)
         allow(job).to receive(:call)
+        allow(job).to receive(:teardown)
         queue << job
         # Force the background job work, so we can validate the expectation as the thread will
         # execute correctly the given job
@@ -45,7 +47,33 @@ RSpec.describe_current do
         sleep(0.05)
       end
 
+      it { expect(queue).not_to receive(:tick) }
+      it { expect(job).to have_received(:prepare).with(no_args) }
       it { expect(job).to have_received(:call).with(no_args) }
+      it { expect(job).to have_received(:teardown).with(no_args) }
+      it { expect(queue).to have_received(:complete).with(job) }
+    end
+
+    context 'when it is a non-closing, non-blocking job' do
+      let(:job) { OpenStruct.new(group_id: 1, id: 1, call: true, non_blocking?: true) }
+
+      before do
+        allow(job).to receive(:prepare)
+        allow(job).to receive(:call)
+        allow(job).to receive(:teardown)
+        allow(queue).to receive(:tick)
+
+        queue << job
+        # Force the background job work, so we can validate the expectation as the thread will
+        # execute correctly the given job
+        Thread.pass
+        sleep(0.05)
+      end
+
+      it { expect(queue).to have_received(:tick).with(job.group_id) }
+      it { expect(job).to have_received(:prepare).with(no_args) }
+      it { expect(job).to have_received(:call).with(no_args) }
+      it { expect(job).to have_received(:teardown).with(no_args) }
       it { expect(queue).to have_received(:complete).with(job) }
     end
   end


### PR DESCRIPTION
This PR introduces notion of non blocking jobs as well as per-job lifecycle methods that can be used to prepare things needed for the async jobs to run safely.