### PR TITLE
move consumer preparation to prepare

### DIFF
--- a/lib/karafka/processing/jobs/consume.rb
+++ b/lib/karafka/processing/jobs/consume.rb
@@ -18,9 +18,14 @@ module Karafka
           super()
         end
 
-        # Runs the given executor.
+        # Runs the preparations on the executor
+        def prepare
+          executor.prepare(@messages, @created_at)
+        end
+
+        # Runs the given executor
         def call
-          executor.consume(@messages, @created_at)
+          executor.consume
         end
       end
     end

--- a/spec/lib/karafka/processing/executor_spec.rb
+++ b/spec/lib/karafka/processing/executor_spec.rb
@@ -31,25 +31,29 @@ RSpec.describe_current do
     it { expect(executor.group_id).to eq(group_id) }
   end
 
-  describe '#consume' do
-    before { allow(consumer).to receive(:on_consume) }
-
-    it { expect { executor.consume(messages, received_at) }.not_to raise_error }
-
-    it 'expect to run the consumer appropriate method' do
-      executor.consume(messages, received_at)
-      expect(consumer).to have_received(:on_consume).with(no_args)
-    end
+  describe '#prepare' do
+    it { expect { executor.prepare(messages, received_at) }.not_to raise_error }
 
     it 'expect to build appropriate messages batch' do
-      executor.consume(messages, received_at)
+      executor.prepare(messages, received_at)
       expect(consumer.messages.first.raw_payload).to eq(messages.first.payload)
     end
 
     it 'expect to build metadata with proper details' do
-      executor.consume(messages, received_at)
+      executor.prepare(messages, received_at)
       expect(consumer.messages.metadata.scheduled_at).to eq(received_at)
       expect(consumer.messages.metadata.topic).to eq(topic.name)
+    end
+  end
+
+  describe '#consume' do
+    before do
+      allow(consumer).to receive(:on_consume)
+      executor.consume
+    end
+
+    it 'expect to run consumer' do
+      expect(consumer).to have_received(:on_consume)
     end
   end
 
@@ -67,7 +71,7 @@ RSpec.describe_current do
     context 'when the consumer was in use and exists' do
       before do
         allow(consumer).to receive(:on_consume)
-        executor.consume(messages, received_at)
+        executor.consume
         executor.revoked
       end
 
@@ -91,7 +95,7 @@ RSpec.describe_current do
     context 'when the consumer was in use and exists' do
       before do
         allow(consumer).to receive(:on_consume)
-        executor.consume(messages, received_at)
+        executor.consume
         executor.shutdown
       end
 

--- a/spec/lib/karafka/processing/jobs/consume_spec.rb
+++ b/spec/lib/karafka/processing/jobs/consume_spec.rb
@@ -7,16 +7,26 @@ RSpec.describe_current do
   let(:messages) { [rand] }
   let(:time_now) { Time.now }
 
-  before do
-    allow(Time).to receive(:now).and_return(time_now)
-    allow(executor).to receive(:consume)
-    job.call
+  describe '#prepare' do
+    before do
+      allow(Time).to receive(:now).and_return(time_now)
+      allow(executor).to receive(:prepare)
+      job.prepare
+    end
+
+    it 'expect to run prepare on the executor with time and messages' do
+      expect(executor).to have_received(:prepare).with(messages, time_now)
+    end
   end
 
-  it { expect(job.id).to eq(executor.id) }
-  it { expect(job.group_id).to eq(executor.group_id) }
+  describe '#call' do
+    before do
+      allow(executor).to receive(:consume)
+      job.call
+    end
 
-  it 'expect to run consumption on the executor with time and messages' do
-    expect(executor).to have_received(:consume).with(messages, time_now)
+    it 'expect to run consume' do
+      expect(executor).to have_received(:consume)
+    end
   end
 end


### PR DESCRIPTION
This PR moves the preparation of the consumer in the executor to the `#prepare` step to align with the lifecycle methods flow.