### PR TITLE
Add prepare hook to consumer and run it via executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Karafka framework changelog
 
 ## 2.0.0-beta1 (Unreleased)
+- Update the jobs queue blocking engine and allow for non-blocking jobs execution
+- Provide `#prepared` hook that always runs before the fetching loop is unblocked
 - [Pro] Introduce performance tracker for scheduling optimizer
 
 ## 2.0.0-alpha6 (2022-04-17)

--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -76,7 +76,30 @@ module Karafka
       )
     end
 
+    # Can be used to run preparation code
+    #
+    # @private
+    # @note This should not be used by the end users as it is part of the lifecycle of things but
+    #   not as part of the public api. This can act as a hook when creating non-blocking
+    #   consumers and doing other advanced stuff
+    def on_prepared
+      Karafka.monitor.instrument('consumer.prepared', caller: self) do
+        prepared
+      end
+    rescue StandardError => e
+      Karafka.monitor.instrument(
+        'error.occurred',
+        error: e,
+        caller: self,
+        type: 'consumer.prepared.error'
+      )
+    end
+
     private
+
+    # Method that gets called in the blocking flow allowing to setup any type of resources or to
+    # send additional commands to Kafka before the proper execution starts.
+    def prepared; end
 
     # Method that will perform business logic and on data received from Kafka (it will consume
     #   the data)

--- a/lib/karafka/instrumentation/monitor.rb
+++ b/lib/karafka/instrumentation/monitor.rb
@@ -22,6 +22,7 @@ module Karafka
         app.stopping
         app.stopped
 
+        consumer.prepared
         consumer.consumed
         consumer.revoked
         consumer.shutdown

--- a/lib/karafka/processing/executor.rb
+++ b/lib/karafka/processing/executor.rb
@@ -48,6 +48,8 @@ module Karafka
           @topic,
           received_at
         )
+
+        consumer.on_prepared
       end
 
       # Runs consumer data processing against given batch and handles failures and errors.

--- a/spec/integrations/consumption/with_prepared_method.rb
+++ b/spec/integrations/consumption/with_prepared_method.rb
@@ -3,7 +3,7 @@
 # Karafka consumer can be used with `#prepared` method to run some preparations before running the
 # proper code
 # While it is not recommended to use it unless you are advanced user and want to elevate certain
-# karafka capabilities, we still add this spec to make sure things operate as expecteda and that
+# karafka capabilities, we still add this spec to make sure things operate as expected and that
 # this method is called
 
 setup_karafka

--- a/spec/integrations/consumption/with_prepared_method.rb
+++ b/spec/integrations/consumption/with_prepared_method.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Karafka consumer can be used with `#prepared` method to run some preparations before running the
+# proper code
+# While it is not recommended to use it unless you are advanced user and want to elevate certain
+# karafka capabilities, we still add this spec to make sure things operate as expecteda and that
+# this method is called
+
+setup_karafka
+
+elements = Array.new(100) { SecureRandom.uuid }
+
+class Consumer < Karafka::BaseConsumer
+  # We should have access here to anything that we can get when consuming, so we duplicate
+  # this and we can compare that later
+  def prepared
+    messages.each do |message|
+      DataCollector.data["prep-#{message.metadata.partition}"] << message.raw_payload
+    end
+  end
+
+  def consume
+    messages.each do |message|
+      DataCollector.data[message.metadata.partition] << message.raw_payload
+    end
+  end
+end
+
+Karafka::App.monitor.instrument('consumer.prepared') do
+  DataCollector.data[:prepared] = true
+end
+
+draw_routes(Consumer)
+
+elements.each { |data| produce(DataCollector.topic, data) }
+
+start_karafka_and_wait_until do
+  DataCollector.data[0].size >= 100
+end
+
+assert_equal DataCollector.data['prep-0'], DataCollector.data[0]
+assert_equal 3, DataCollector.data.size
+assert_equal true, DataCollector.data[:prepared]

--- a/spec/lib/karafka/base_consumer_spec.rb
+++ b/spec/lib/karafka/base_consumer_spec.rb
@@ -191,6 +191,52 @@ RSpec.describe_current do
     end
   end
 
+  describe '#on_prepared' do
+    context 'when everything went ok on revoked' do
+      it { expect { consumer.on_prepared }.not_to raise_error }
+
+      it 'expect to run proper instrumentation' do
+        Karafka.monitor.subscribe('consumer.revoked') do |event|
+          expect(event.payload[:caller]).to eq(consumer)
+        end
+
+        consumer.on_prepared
+      end
+
+      it 'expect not to run error instrumentation' do
+        Karafka.monitor.subscribe('error.occurred') do |event|
+          expect(event.payload[:caller]).not_to eq(consumer)
+          expect(event.payload[:error]).not_to be_a(StandardError)
+          expect(event.payload[:type]).to eq('consumer.prepared.error')
+        end
+
+        consumer.on_prepared
+      end
+    end
+
+    context 'when something goes wrong on prepared' do
+      let(:working_class) do
+        ClassBuilder.inherit(described_class) do
+          def prepared
+            raise StandardError
+          end
+        end
+      end
+
+      it { expect { consumer.on_prepared }.not_to raise_error }
+
+      it 'expect to run the error instrumentation' do
+        Karafka.monitor.subscribe('error.occurred') do |event|
+          expect(event.payload[:caller]).to eq(consumer)
+          expect(event.payload[:error]).to be_a(StandardError)
+          expect(event.payload[:type]).to eq('consumer.prepared.error')
+        end
+
+        consumer.on_revoked
+      end
+    end
+  end
+
   describe '#on_revoked' do
     context 'when everything went ok on revoked' do
       it { expect { consumer.on_revoked }.not_to raise_error }

--- a/spec/lib/karafka/processing/executor_spec.rb
+++ b/spec/lib/karafka/processing/executor_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe_current do
   end
 
   describe '#prepare' do
+    before { allow(consumer).to receive(:on_prepared) }
+
     it { expect { executor.prepare(messages, received_at) }.not_to raise_error }
 
     it 'expect to build appropriate messages batch' do
@@ -43,6 +45,11 @@ RSpec.describe_current do
       executor.prepare(messages, received_at)
       expect(consumer.messages.metadata.scheduled_at).to eq(received_at)
       expect(consumer.messages.metadata.topic).to eq(topic.name)
+    end
+
+    it 'expect to run consumer on_prepared' do
+      executor.prepare(messages, received_at)
+      expect(consumer).to have_received(:on_prepared).with(no_args)
     end
   end
 


### PR DESCRIPTION
This PR adds proper lifecycle method to the consumer and runs it via the executor + specs and integrations to make sure it is executed.