### PR TITLE
Disallow job state change

### DIFF
--- a/lib/karafka/processing/jobs/base.rb
+++ b/lib/karafka/processing/jobs/base.rb
@@ -15,11 +15,6 @@ module Karafka
 
         attr_reader :executor
 
-        def initialize
-          # Every job by default is blocking and blocks the jobs queue until finished
-          @non_blocking = false
-        end
-
         # When redefined can run any code that should run before executing the proper code
         def prepare; end
 
@@ -29,13 +24,9 @@ module Karafka
         # @return [Boolean] is this a non-blocking job
         # @note Blocking job is a job, that will cause the job queue to wait until it is finished
         #   before removing the lock on new jobs being added
+        # @note All the jobs are blocking by default
         def non_blocking?
-          @non_blocking
-        end
-
-        # Marks this job as no longer blocking
-        def unblock!
-          @non_blocking = true
+          false
         end
       end
     end

--- a/spec/lib/karafka/processing/jobs/base_spec.rb
+++ b/spec/lib/karafka/processing/jobs/base_spec.rb
@@ -5,11 +5,5 @@ RSpec.describe_current do
     it 'expect all the newly created jobs to be blocking' do
       expect(described_class.new.non_blocking?).to eq(false)
     end
-
-    it 'expect job that is marked as unblocked not to be blocking' do
-      job = described_class.new
-      job.unblock!
-      expect(job.non_blocking?).to eq(true)
-    end
   end
 end

--- a/spec/lib/karafka/processing/jobs/consume_spec.rb
+++ b/spec/lib/karafka/processing/jobs/consume_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe_current do
   let(:messages) { [rand] }
   let(:time_now) { Time.now }
 
+  it { expect(job.non_blocking?).to eq(false) }
+
   describe '#prepare' do
     before do
       allow(Time).to receive(:now).and_return(time_now)

--- a/spec/lib/karafka/processing/jobs/revoked_spec.rb
+++ b/spec/lib/karafka/processing/jobs/revoked_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe_current do
 
   it { expect(job.id).to eq(executor.id) }
   it { expect(job.group_id).to eq(executor.group_id) }
+  it { expect(job.non_blocking?).to eq(false) }
 
   it 'expect to run revoked on the executor' do
     expect(executor).to have_received(:revoked).with(no_args)

--- a/spec/lib/karafka/processing/jobs/shutdown_spec.rb
+++ b/spec/lib/karafka/processing/jobs/shutdown_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe_current do
 
   it { expect(job.id).to eq(executor.id) }
   it { expect(job.group_id).to eq(executor.group_id) }
+  it { expect(job.non_blocking?).to eq(false) }
 
   it 'expect to run shutdown on the executor' do
     expect(executor).to have_received(:shutdown).with(no_args)


### PR DESCRIPTION
Job should not be able to change its own state. Each job should "decide" on whether it is blocking or now. For now all the jobs are blocking.