### PR TITLE
Allow time based pausing from the consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Update the jobs queue blocking engine and allow for non-blocking jobs execution
 - Provide `#prepared` hook that always runs before the fetching loop is unblocked
 - [Pro] Introduce performance tracker for scheduling optimizer
+- Provide ability to pause (`#pause`) and resume (`#resume`) given partitions from the consumers
+- Small integration specs refactoring + specs for pausing scenarios
 
 ## 2.0.0-alpha6 (2022-04-17)
 - Fix a bug, where upon missing boot file and Rails, railtie would fail with a generic exception (#818) 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       KAFKA_CREATE_TOPICS:
         "integrations_0_02:2:1,\
          integrations_1_02:2:1,\
+         integrations_2_02:2:1,\
          integrations_0_03:3:1,\
          integrations_1_03:3:1,\
          integrations_2_03:3:1,\

--- a/lib/karafka/connection/listener.rb
+++ b/lib/karafka/connection/listener.rb
@@ -114,8 +114,8 @@ module Karafka
 
         revoked_partitions.each do |topic, partitions|
           partitions.each do |partition|
-            pause = @pauses_manager.fetch(topic, partition)
-            executor = @executors.fetch(topic, partition, pause)
+            pause_tracker = @pauses_manager.fetch(topic, partition)
+            executor = @executors.fetch(topic, partition, pause_tracker)
             @jobs_queue << Processing::Jobs::Revoked.new(executor)
           end
         end

--- a/lib/karafka/connection/pauses_manager.rb
+++ b/lib/karafka/connection/pauses_manager.rb
@@ -12,11 +12,11 @@ module Karafka
         end
       end
 
-      # Creates or fetches pause of a given topic partition.
+      # Creates or fetches pause tracker of a given topic partition.
       #
       # @param topic [String] topic name
       # @param partition [Integer] partition number
-      # @return [Karafka::TimeTrackers::Pause] pause instance
+      # @return [Karafka::TimeTrackers::Pause] pause tracker instance
       def fetch(topic, partition)
         @pauses[topic][partition] ||= TimeTrackers::Pause.new(
           timeout: Karafka::App.config.pause_timeout,

--- a/lib/karafka/processing/executor.rb
+++ b/lib/karafka/processing/executor.rb
@@ -21,13 +21,13 @@ module Karafka
       # @param group_id [String] id of the subscription group to which the executor belongs
       # @param client [Karafka::Connection::Client] kafka client
       # @param topic [Karafka::Routing::Topic] topic for which this executor will run
-      # @param pause [Karafka::TimeTrackers::Pause] fetch pause object for crash pausing
-      def initialize(group_id, client, topic, pause)
+      # @param pause_tracker [Karafka::TimeTrackers::Pause] fetch pause tracker for pausing
+      def initialize(group_id, client, topic, pause_tracker)
         @id = SecureRandom.uuid
         @group_id = group_id
         @client = client
         @topic = topic
-        @pause = pause
+        @pause_tracker = pause_tracker
       end
 
       # Builds the consumer instance and sets all that is needed to run the user consumption logic
@@ -91,7 +91,7 @@ module Karafka
           consumer = @topic.consumer.new
           consumer.topic = @topic
           consumer.client = @client
-          consumer.pause = @pause
+          consumer.pause_tracker = @pause_tracker
           consumer.producer = ::Karafka::App.producer
           consumer
         end

--- a/lib/karafka/time_trackers/pause.rb
+++ b/lib/karafka/time_trackers/pause.rb
@@ -41,15 +41,23 @@ module Karafka
 
       # Pauses the processing from now till the end of the interval (backoff or non-backoff)
       # and records the count.
-      def pause
+      # @param timeout [Integer] timeout value in milliseconds that overwrites the default timeout
+      # @note Providing this value can be useful when we explicitly want to pause for a certain
+      #   period of time, outside of any regular pausing logic
+      def pause(timeout = backoff_interval)
         @started_at = now
-        @ends_at = @started_at + backoff_interval
+        @ends_at = @started_at + timeout
         @count += 1
       end
 
       # Marks the pause as resumed.
       def resume
         @started_at = nil
+        @ends_at = nil
+      end
+
+      # Expires the pause, so it can be considered expired
+      def expire
         @ends_at = nil
       end
 

--- a/spec/integrations/consumption/from_earliest.rb
+++ b/spec/integrations/consumption/from_earliest.rb
@@ -4,8 +4,6 @@
 
 setup_karafka
 
-elements = Array.new(100) { SecureRandom.uuid }
-
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
@@ -16,6 +14,7 @@ end
 
 draw_routes(Consumer)
 
+elements = Array.new(100) { SecureRandom.uuid }
 elements.each { |data| produce(DataCollector.topic, data) }
 
 start_karafka_and_wait_until do

--- a/spec/integrations/consumption/from_earliest_simple_routing.rb
+++ b/spec/integrations/consumption/from_earliest_simple_routing.rb
@@ -5,8 +5,6 @@
 
 setup_karafka
 
-elements = Array.new(10) { SecureRandom.uuid }
-
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
@@ -21,6 +19,7 @@ draw_routes do
   end
 end
 
+elements = Array.new(10) { SecureRandom.uuid }
 elements.each { |data| produce(DataCollector.topic, data) }
 
 start_karafka_and_wait_until do

--- a/spec/integrations/consumption/non_constant_error_and_other_topics.rb
+++ b/spec/integrations/consumption/non_constant_error_and_other_topics.rb
@@ -11,9 +11,6 @@ setup_karafka do |config|
   config.pause_with_exponential_backoff = false
 end
 
-elements1 = Array.new(10) { SecureRandom.uuid }
-elements2 = Array.new(10) { SecureRandom.uuid }
-
 class Listener
   def on_error_occurred(event)
     DataCollector.data[:errors] << event
@@ -60,6 +57,9 @@ draw_routes do
     end
   end
 end
+
+elements1 = Array.new(10) { SecureRandom.uuid }
+elements2 = Array.new(10) { SecureRandom.uuid }
 
 elements1.each { |data| produce(DataCollector.topics.first, data) }
 # We send one message so the topic gets created

--- a/spec/integrations/consumption/non_critical_error_recovery.rb
+++ b/spec/integrations/consumption/non_critical_error_recovery.rb
@@ -13,8 +13,6 @@ Karafka.monitor.subscribe(Listener.new)
 
 setup_karafka
 
-elements = Array.new(5) { SecureRandom.uuid }
-
 class Consumer < Karafka::BaseConsumer
   def consume
     @count ||= 0
@@ -35,6 +33,7 @@ draw_routes do
   end
 end
 
+elements = Array.new(5) { SecureRandom.uuid }
 elements.each { |data| produce(DataCollector.topic, data) }
 
 start_karafka_and_wait_until do

--- a/spec/integrations/consumption/of_messages_with_headers.rb
+++ b/spec/integrations/consumption/of_messages_with_headers.rb
@@ -4,8 +4,6 @@
 
 setup_karafka
 
-elements = Array.new(10) { SecureRandom.uuid }
-
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
@@ -16,6 +14,7 @@ end
 
 draw_routes(Consumer)
 
+elements = Array.new(10) { SecureRandom.uuid }
 elements.each { |data| produce(DataCollector.topic, data, headers: { 'value' => data }) }
 
 start_karafka_and_wait_until do

--- a/spec/integrations/consumption/rate_limited.rb
+++ b/spec/integrations/consumption/rate_limited.rb
@@ -14,8 +14,6 @@ setup_karafka do |config|
   config.concurrency = 1
 end
 
-elements = Array.new(50) { SecureRandom.uuid }
-
 class Consumer < Karafka::BaseConsumer
   def initialize
     super
@@ -44,6 +42,7 @@ end
 
 draw_routes(Consumer)
 
+elements = Array.new(50) { SecureRandom.uuid }
 elements.each { |data| produce(DataCollector.topic, data) }
 
 started_at = Time.now.to_f

--- a/spec/integrations/consumption/rate_limited.rb
+++ b/spec/integrations/consumption/rate_limited.rb
@@ -35,8 +35,8 @@ class Consumer < Karafka::BaseConsumer
       DataCollector.data[:pauses] << Time.now.to_f
 
       @seconds_available = 5
-      client.pause(topic.name, message.partition, message.offset + 1)
-      pause_tracker.pause
+      pause(message.offset + 1)
+
       break
     end
   end

--- a/spec/integrations/consumption/rate_limited.rb
+++ b/spec/integrations/consumption/rate_limited.rb
@@ -36,7 +36,7 @@ class Consumer < Karafka::BaseConsumer
 
       @seconds_available = 5
       client.pause(topic.name, message.partition, message.offset + 1)
-      pause.pause
+      pause_tracker.pause
       break
     end
   end

--- a/spec/integrations/consumption/removing_a_topic_should_still_consume_rest.rb
+++ b/spec/integrations/consumption/removing_a_topic_should_still_consume_rest.rb
@@ -5,9 +5,6 @@
 
 setup_karafka
 
-elements1 = Array.new(10) { SecureRandom.uuid }
-elements2 = Array.new(10) { SecureRandom.uuid }
-
 class Consumer1 < Karafka::BaseConsumer
   def consume
     messages.each do |message|
@@ -36,6 +33,8 @@ draw_routes do
   end
 end
 
+elements1 = Array.new(10) { SecureRandom.uuid }
+elements2 = Array.new(10) { SecureRandom.uuid }
 elements1.each { |data| produce(DataCollector.topics.first, data) }
 elements2.each { |data| produce(DataCollector.topics.last, data) }
 

--- a/spec/integrations/consumption/simple_from_earliest.rb
+++ b/spec/integrations/consumption/simple_from_earliest.rb
@@ -4,8 +4,6 @@
 
 setup_karafka
 
-elements = Array.new(100) { SecureRandom.uuid }
-
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
@@ -21,6 +19,7 @@ Thread.new do
   Karafka::Server.stop
 end
 
+elements = Array.new(100) { SecureRandom.uuid }
 elements.each { |data| produce(DataCollector.topic, data) }
 
 Karafka::Server.run

--- a/spec/integrations/consumption/single_message_consumer.rb
+++ b/spec/integrations/consumption/single_message_consumer.rb
@@ -5,8 +5,6 @@
 
 setup_karafka
 
-elements = Array.new(20) { SecureRandom.uuid }
-
 # Abstraction layer on top of Karafka to build a "per message" consumers
 class SingleMessageBaseConsumer < Karafka::BaseConsumer
   attr_reader :message
@@ -31,6 +29,7 @@ end
 
 draw_routes(Consumer)
 
+elements = Array.new(20) { SecureRandom.uuid }
 elements.each { |data| produce(DataCollector.topic, data) }
 
 start_karafka_and_wait_until do

--- a/spec/integrations/consumption/time_bound_consumption.rb
+++ b/spec/integrations/consumption/time_bound_consumption.rb
@@ -8,8 +8,6 @@ setup_karafka
 # How long do we want to process stuff before shutting down Karafka process
 MAX_TIME = 10
 
-elements = Array.new(100) { SecureRandom.uuid }
-
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
@@ -21,6 +19,7 @@ end
 draw_routes(Consumer)
 
 # Sends some data so we know all is good
+elements = Array.new(100) { SecureRandom.uuid }
 elements.each { |data| produce(DataCollector.topic, data) }
 
 # Stop after 10 seconds

--- a/spec/integrations/consumption/two_consumer_groups_one_active.rb
+++ b/spec/integrations/consumption/two_consumer_groups_one_active.rb
@@ -5,8 +5,6 @@
 
 setup_karafka
 
-jsons = Array.new(10) { { SecureRandom.uuid => rand.to_s } }
-
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
@@ -32,6 +30,8 @@ end
 
 # Listen only on one consumer group
 Karafka::Server.consumer_groups = [DataCollector.consumer_groups.first]
+
+jsons = Array.new(10) { { SecureRandom.uuid => rand.to_s } }
 
 # We send same messages to both topics, but except only one to run and consume
 jsons.each do |data|

--- a/spec/integrations/consumption/two_consumer_groups_same_topic.rb
+++ b/spec/integrations/consumption/two_consumer_groups_same_topic.rb
@@ -4,8 +4,6 @@
 
 setup_karafka
 
-jsons = Array.new(100) { { SecureRandom.uuid => rand.to_s } }
-
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
@@ -29,6 +27,7 @@ draw_routes do
   end
 end
 
+jsons = Array.new(100) { { SecureRandom.uuid => rand.to_s } }
 jsons.each { |data| produce(DataCollector.topic, data.to_json) }
 
 start_karafka_and_wait_until do

--- a/spec/integrations/consumption/with_long_living_buffer.rb
+++ b/spec/integrations/consumption/with_long_living_buffer.rb
@@ -6,8 +6,6 @@
 # This will force several batches, so we won't end up with 1 huge as this is not what we want here
 setup_karafka { |config| config.max_messages = 2 }
 
-elements = Array.new(100) { SecureRandom.uuid }
-
 class Consumer < Karafka::BaseConsumer
   def initialize
     super
@@ -36,6 +34,7 @@ end
 
 draw_routes(Consumer)
 
+elements = Array.new(100) { SecureRandom.uuid }
 elements.each { |data| produce(DataCollector.topic, data) }
 
 start_karafka_and_wait_until do

--- a/spec/integrations/consumption/with_manual_pause_in_between_messages.rb
+++ b/spec/integrations/consumption/with_manual_pause_in_between_messages.rb
@@ -35,12 +35,12 @@ start_karafka_and_wait_until do
   DataCollector.data[:messages].size >= 10
 end
 
-# Pausing and getting back to consumption should not scew order or number of messages
+# Pausing and getting back to consumption should not screw order or number of messages
 assert_equal elements, DataCollector.data[:messages]
 
 previous = nil
 
-# Pausing should also be at least as much as we paused + time to get back after unpause
+# Pausing should also be at least as much as we paused + time to get back after un-pause
 DataCollector.data[:times].each do |timestamp|
   unless previous
     previous = timestamp

--- a/spec/integrations/consumption/with_manual_pause_in_between_messages.rb
+++ b/spec/integrations/consumption/with_manual_pause_in_between_messages.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# We should be able to manually pause for any time we want, bypassing the default pause time
+# if we declare the pause time ourselves.
+
+setup_karafka do |config|
+  config.max_messages = 1
+  # We assign a really big value as we want to make sure this value is not used with this spec
+  # since we override this
+  config.pause_timeout = 1_000_000
+  config.pause_max_timeout = 1_000_000
+end
+
+elements = Array.new(10) { SecureRandom.uuid }
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DataCollector.data[:times] << Time.now.to_f
+      DataCollector.data[:messages] << message.raw_payload
+    end
+
+    # Pause for 1 second
+    pause_tracker.pause(1_000)
+    # Pause and start frm the next message
+    client.pause(topic.name, messages.last.partition, messages.last.offset + 1)
+  end
+end
+
+draw_routes(Consumer)
+
+elements.each { |data| produce(DataCollector.topic, data) }
+
+start_karafka_and_wait_until do
+  DataCollector.data[:messages].size >= 10
+end
+
+# Pausing and getting back to consumption should not scew order or number of messages
+assert_equal elements, DataCollector.data[:messages]
+
+previous = nil
+
+# Pausing should also be at least as much as we paused + time to get back after unpause
+DataCollector.data[:times].each do |timestamp|
+  unless previous
+    previous = timestamp
+    next
+  end
+
+  pause = (timestamp - previous)
+  assert_equal true, pause >= 1 && pause <= 5
+
+  previous = timestamp
+end

--- a/spec/integrations/consumption/with_manual_pause_in_between_messages.rb
+++ b/spec/integrations/consumption/with_manual_pause_in_between_messages.rb
@@ -21,9 +21,7 @@ class Consumer < Karafka::BaseConsumer
     end
 
     # Pause for 1 second
-    pause_tracker.pause(1_000)
-    # Pause and start frm the next message
-    client.pause(topic.name, messages.last.partition, messages.last.offset + 1)
+    pause(messages.last.offset + 1, 1_000)
   end
 end
 

--- a/spec/integrations/consumption/with_manual_pause_in_between_messages.rb
+++ b/spec/integrations/consumption/with_manual_pause_in_between_messages.rb
@@ -35,7 +35,7 @@ start_karafka_and_wait_until do
   DataCollector.data[:messages].size >= 10
 end
 
-# Pausing and getting back to consumption should not screw order or number of messages
+# Pausing and getting back to consumption should not mess order or number of messages
 assert_equal elements, DataCollector.data[:messages]
 
 previous = nil

--- a/spec/integrations/consumption/with_max_messages.rb
+++ b/spec/integrations/consumption/with_max_messages.rb
@@ -5,7 +5,6 @@
 setup_karafka
 
 elements = Array.new(40) { SecureRandom.uuid }
-
 elements.each { |data| produce(DataCollector.topic, data) }
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/consumption/with_prepared_method.rb
+++ b/spec/integrations/consumption/with_prepared_method.rb
@@ -8,8 +8,6 @@
 
 setup_karafka
 
-elements = Array.new(100) { SecureRandom.uuid }
-
 class Consumer < Karafka::BaseConsumer
   # We should have access here to anything that we can get when consuming, so we duplicate
   # this and we can compare that later
@@ -32,6 +30,7 @@ end
 
 draw_routes(Consumer)
 
+elements = Array.new(100) { SecureRandom.uuid }
 elements.each { |data| produce(DataCollector.topic, data) }
 
 start_karafka_and_wait_until do

--- a/spec/integrations/consumption/without_persistence_enabled.rb
+++ b/spec/integrations/consumption/without_persistence_enabled.rb
@@ -8,8 +8,6 @@ setup_karafka do |config|
   config.max_messages = 1
 end
 
-elements = Array.new(100) { SecureRandom.uuid }
-
 class Consumer < Karafka::BaseConsumer
   def consume
     DataCollector.data[0] << object_id
@@ -18,6 +16,7 @@ end
 
 draw_routes(Consumer)
 
+elements = Array.new(100) { SecureRandom.uuid }
 elements.each { |data| produce(DataCollector.topic, data) }
 
 start_karafka_and_wait_until do

--- a/spec/integrations/lags/consumption_delayed.rb
+++ b/spec/integrations/lags/consumption_delayed.rb
@@ -5,8 +5,6 @@
 
 setup_karafka
 
-elements = Array.new(5) { SecureRandom.uuid }
-
 class Consumer < Karafka::BaseConsumer
   def consume
     DataCollector.data[:consumption_lag] = messages.metadata.consumption_lag
@@ -14,6 +12,8 @@ class Consumer < Karafka::BaseConsumer
 end
 
 draw_routes(Consumer)
+
+elements = Array.new(5) { SecureRandom.uuid }
 
 elements.each do |data|
   # We sleep here to make sure, that the lag is not computed on any of the messages except last

--- a/spec/integrations/lags/processing_fast.rb
+++ b/spec/integrations/lags/processing_fast.rb
@@ -7,8 +7,6 @@ setup_karafka do |config|
   config.max_messages = 5
 end
 
-elements = Array.new(100) { SecureRandom.uuid }
-
 class Consumer < Karafka::BaseConsumer
   def consume
     DataCollector.data[:processing_lags] << messages.metadata.processing_lag
@@ -17,6 +15,7 @@ end
 
 draw_routes(Consumer)
 
+elements = Array.new(100) { SecureRandom.uuid }
 elements.each { |data| produce(DataCollector.topic, data) }
 
 start_karafka_and_wait_until do

--- a/spec/integrations/lags/processing_slow.rb
+++ b/spec/integrations/lags/processing_slow.rb
@@ -9,8 +9,6 @@ setup_karafka do |config|
   config.max_messages = 5
 end
 
-elements = Array.new(100) { SecureRandom.uuid }
-
 class Consumer < Karafka::BaseConsumer
   def consume
     sleep(0.1)
@@ -20,6 +18,7 @@ end
 
 draw_routes(Consumer)
 
+elements = Array.new(100) { SecureRandom.uuid }
 elements.each { |data| produce(DataCollector.topic, data) }
 
 start_karafka_and_wait_until do

--- a/spec/integrations/offset_management/manual_offset_with_error_every_bang.rb
+++ b/spec/integrations/offset_management/manual_offset_with_error_every_bang.rb
@@ -8,8 +8,6 @@ setup_karafka do |config|
   config.manual_offset_management = true
 end
 
-elements = Array.new(100) { SecureRandom.uuid }
-
 class Consumer < Karafka::BaseConsumer
   def consume
     @consumed ||= 0
@@ -28,6 +26,7 @@ end
 
 draw_routes(Consumer)
 
+elements = Array.new(100) { SecureRandom.uuid }
 elements.each { |data| produce(DataCollector.topic, data) }
 
 start_karafka_and_wait_until do

--- a/spec/integrations/offset_management/manual_offset_with_error_every_non_bang.rb
+++ b/spec/integrations/offset_management/manual_offset_with_error_every_non_bang.rb
@@ -8,8 +8,6 @@ setup_karafka do |config|
   config.manual_offset_management = true
 end
 
-elements = Array.new(100) { SecureRandom.uuid }
-
 class Consumer < Karafka::BaseConsumer
   def consume
     @consumed ||= 0
@@ -28,6 +26,7 @@ end
 
 draw_routes(Consumer)
 
+elements = Array.new(100) { SecureRandom.uuid }
 elements.each { |data| produce(DataCollector.topic, data) }
 
 start_karafka_and_wait_until do

--- a/spec/integrations/offset_management/manual_offset_with_error_interval_bang.rb
+++ b/spec/integrations/offset_management/manual_offset_with_error_interval_bang.rb
@@ -8,8 +8,6 @@ setup_karafka do |config|
   config.manual_offset_management = true
 end
 
-elements = Array.new(100) { SecureRandom.uuid }
-
 class Consumer < Karafka::BaseConsumer
   def consume
     @consumed ||= 0
@@ -29,6 +27,7 @@ end
 
 draw_routes(Consumer)
 
+elements = Array.new(100) { SecureRandom.uuid }
 elements.each { |data| produce(DataCollector.topic, data) }
 
 start_karafka_and_wait_until do

--- a/spec/integrations/offset_management/manual_offset_with_error_interval_non_bang.rb
+++ b/spec/integrations/offset_management/manual_offset_with_error_interval_non_bang.rb
@@ -8,8 +8,6 @@ setup_karafka do |config|
   config.manual_offset_management = true
 end
 
-elements = Array.new(100) { SecureRandom.uuid }
-
 class Consumer < Karafka::BaseConsumer
   def consume
     @consumed ||= 0
@@ -29,6 +27,7 @@ end
 
 draw_routes(Consumer)
 
+elements = Array.new(100) { SecureRandom.uuid }
 elements.each { |data| produce(DataCollector.topic, data) }
 
 start_karafka_and_wait_until do

--- a/spec/integrations/offset_management/messages_and_metadata_details.rb
+++ b/spec/integrations/offset_management/messages_and_metadata_details.rb
@@ -4,8 +4,6 @@
 
 setup_karafka
 
-elements = Array.new(10) { SecureRandom.uuid }
-
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
@@ -16,6 +14,7 @@ end
 
 draw_routes(Consumer)
 
+elements = Array.new(10) { SecureRandom.uuid }
 elements.each { |number| produce(DataCollector.topic, number) }
 
 start_karafka_and_wait_until do

--- a/spec/integrations/pausing/using_manual_pause_with_backoff_defaults.rb
+++ b/spec/integrations/pausing/using_manual_pause_with_backoff_defaults.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Important: this may not work as expected for a manual pause case. Please read the below message.
+#
+# When we pause a partition without providing the timeout, it should use the timeout defined
+# in the retry settings. The case here is, that when processing is successful we reset the pause
+# counter, so the retry is never acknowledged (like it is for cases with errors). This means that
+# manual pausing will never use the automatic exponential backoff.
+
+setup_karafka do |config|
+  config.max_messages = 1
+  config.pause_timeout = 2_000
+  config.pause_max_timeout = 10_000
+  config.pause_with_exponential_backoff = true
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    pause(messages.last.offset + 1)
+
+    DataCollector.data[:pauses] << Time.now
+  end
+end
+
+draw_routes(Consumer)
+
+elements = Array.new(5) { SecureRandom.uuid }
+elements.each { |data| produce(DataCollector.topic, data) }
+
+start_karafka_and_wait_until do
+  DataCollector.data[:pauses].size >= 5
+end
+
+previous = nil
+
+assert_equal 5, DataCollector.data[:pauses].count
+
+previous = nil
+
+DataCollector.data[:pauses].each_with_index do |time, iter|
+  unless previous
+    previous = time
+    next
+  end
+
+  assert_equal true, (time - previous) * 1_000 >= 2_000
+  assert_equal true, (time - previous) * 1_000 <= 4_000
+
+  previous = time
+end

--- a/spec/integrations/pausing/using_manual_pause_with_backoff_defaults.rb
+++ b/spec/integrations/pausing/using_manual_pause_with_backoff_defaults.rb
@@ -37,7 +37,7 @@ assert_equal 5, DataCollector.data[:pauses].count
 
 previous = nil
 
-DataCollector.data[:pauses].each_with_index do |time, iter|
+DataCollector.data[:pauses].each do |time|
   unless previous
     previous = time
     next

--- a/spec/integrations/pausing/using_manual_pause_with_non_backoff_defaults.rb
+++ b/spec/integrations/pausing/using_manual_pause_with_non_backoff_defaults.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# When we pause a partition without providing the timeout, it should use the timeout defined
+# in the retry settings
+
+setup_karafka do |config|
+  config.max_messages = 1
+  config.pause_timeout = 2_000
+  config.pause_max_timeout = 2_000
+  config.pause_with_exponential_backoff = false
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    pause(messages.last.offset + 1)
+
+    DataCollector.data[:pauses] << Time.now
+  end
+end
+
+draw_routes(Consumer)
+
+elements = Array.new(5) { SecureRandom.uuid }
+elements.each { |data| produce(DataCollector.topic, data) }
+
+start_karafka_and_wait_until do
+  DataCollector.data[:pauses].size >= 5
+end
+
+previous = nil
+
+assert_equal 5, DataCollector.data[:pauses].count
+
+previous = nil
+
+DataCollector.data[:pauses].each do |time|
+  unless previous
+    previous = time
+    next
+  end
+
+  assert_equal true, (time - previous) * 1_000 >= 2_000
+
+  previous = time
+end

--- a/spec/integrations/pausing/with_manual_pause_and_other_partitions_working.rb
+++ b/spec/integrations/pausing/with_manual_pause_and_other_partitions_working.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# When one partition is paused by us manually, we should be consuming others without interruption.
+#
+# Here we check, that the paused partition data is consumed as last (since we pause long enough)
+# and that the other partition's data was consumed first.
+
+setup_karafka do |config|
+  # We set it to 1 as in case of not pausing as expected with one worker the job would stop all
+  # processing and we would fail.
+  config.concurrency = 1
+  config.max_messages = 10
+  config.initial_offset = 'latest'
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    if messages.metadata.partition.zero?
+      DataCollector.data[:ticks] << true
+      pause(messages.first.offset, 500)
+
+      return
+    end
+
+    sleep(0.5)
+
+    messages.each do |message|
+      DataCollector.data[:partitions] << message.partition
+    end
+  end
+end
+
+draw_routes do
+  consumer_group DataCollector.consumer_group do
+    # Special topic with 2 partitions available
+    topic 'integrations_2_02' do
+      consumer Consumer
+    end
+  end
+end
+
+draw_routes(Consumer)
+
+Thread.new do
+  sleep(1)
+
+  sleep(0.1) while DataCollector.data[:running].empty?
+
+  100.times do
+    2.times do |partition|
+      produce('integrations_2_02', SecureRandom.uuid, partition: partition)
+    end
+  end
+end
+
+start_karafka_and_wait_until do
+  DataCollector.data[:running] << true
+  DataCollector.data[:partitions].size >= 100
+end
+
+assert_equal [1], DataCollector.data[:partitions].uniq
+assert_equal true, DataCollector.data[:ticks].count > 1

--- a/spec/integrations/pausing/with_manual_pause_in_between_messages.rb
+++ b/spec/integrations/pausing/with_manual_pause_in_between_messages.rb
@@ -11,8 +11,6 @@ setup_karafka do |config|
   config.pause_max_timeout = 1_000_000
 end
 
-elements = Array.new(10) { SecureRandom.uuid }
-
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
@@ -27,6 +25,7 @@ end
 
 draw_routes(Consumer)
 
+elements = Array.new(10) { SecureRandom.uuid }
 elements.each { |data| produce(DataCollector.topic, data) }
 
 start_karafka_and_wait_until do

--- a/spec/integrations/pausing/with_manual_pause_same_message_loop.rb
+++ b/spec/integrations/pausing/with_manual_pause_same_message_loop.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# We should be able pause on a message we've already seen from the batch and should always start
+# from it after resuming. This will mean, we just process same message over and over again.
+
+setup_karafka do |config|
+  config.max_messages = 10
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DataCollector.data[:messages] << messages.first.raw_payload
+
+    # Pause for 1 second
+    pause(messages.first.offset, 1_000)
+  end
+end
+
+draw_routes(Consumer)
+
+elements = Array.new(100) { SecureRandom.uuid }
+elements.each { |data| produce(DataCollector.topic, data) }
+
+start_karafka_and_wait_until do
+  DataCollector.data[:messages].size >= 10
+end
+
+assert_equal 1, DataCollector.data[:messages].uniq.size
+assert_equal elements[0], DataCollector.data[:messages][0]

--- a/spec/integrations/pausing/with_pause_and_resume.rb
+++ b/spec/integrations/pausing/with_pause_and_resume.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# We should be able to do things like pausing and resume in the same consumer flow.
+# This should not break the ordering
+
+setup_karafka do |config|
+  config.max_messages = 10
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    # We pause for a really long time, so unless our resume works, this will hang
+    pause(messages.last.offset + 1, 100_000)
+
+    messages.each do |message|
+      DataCollector.data[:messages] << message.raw_payload
+    end
+
+    resume
+  end
+end
+
+draw_routes(Consumer)
+
+elements = Array.new(100) { SecureRandom.uuid }
+elements.each { |data| produce(DataCollector.topic, data) }
+
+start_karafka_and_wait_until do
+  DataCollector.data[:messages].size >= 100
+end
+
+assert_equal elements, DataCollector.data[:messages]

--- a/spec/integrations/rebalancing/on_partition_data_revoked.rb
+++ b/spec/integrations/rebalancing/on_partition_data_revoked.rb
@@ -20,6 +20,11 @@ class Consumer < Karafka::BaseConsumer
   end
 
   def revoked
+    # We are interested only in the first rebalance
+    return unless DataCollector.data[:done].empty?
+
+    DataCollector.data[:done] << true
+
     DataCollector.data[:revoked] << { messages.metadata.partition => Time.now }
   end
 end

--- a/spec/integrations/rebalancing/on_partition_data_revoked.rb
+++ b/spec/integrations/rebalancing/on_partition_data_revoked.rb
@@ -4,8 +4,6 @@
 
 setup_karafka
 
-elements = Array.new(100) { SecureRandom.uuid }
-
 DataCollector.data[:revoked] = Concurrent::Array.new
 DataCollector.data[:pre] = Set.new
 DataCollector.data[:post] = Set.new
@@ -38,6 +36,7 @@ draw_routes do
   end
 end
 
+elements = Array.new(100) { SecureRandom.uuid }
 elements.each { |data| produce('integrations_1_03', data, partition: rand(0..2)) }
 
 config = {

--- a/spec/lib/karafka/base_consumer_spec.rb
+++ b/spec/lib/karafka/base_consumer_spec.rb
@@ -3,12 +3,12 @@
 RSpec.describe_current do
   subject(:consumer) do
     instance = working_class.new
-    instance.pause = pause
+    instance.pause_tracker = pause_tracker
     instance.topic = topic
     instance
   end
 
-  let(:pause) { build(:time_trackers_pause) }
+  let(:pause_tracker) { build(:time_trackers_pause) }
   let(:topic) { build(:routing_topic) }
   let(:client) { instance_double(Karafka::Connection::Client, pause: true) }
   let(:first_message) { instance_double(Karafka::Messages::Message, offset: offset, partition: 0) }
@@ -66,10 +66,10 @@ RSpec.describe_current do
 
   describe '#on_consume' do
     before do
-      consumer.pause = pause
+      consumer.pause_tracker = pause_tracker
       consumer.client = client
       consumer.messages = messages
-      allow(pause).to receive(:pause)
+      allow(pause_tracker).to receive(:pause)
     end
 
     context 'when everything went ok on consume with manual offset management' do
@@ -117,7 +117,7 @@ RSpec.describe_current do
 
       it 'expect to pause with time tracker' do
         consumer.on_consume
-        expect(pause).to have_received(:pause)
+        expect(pause_tracker).to have_received(:pause)
       end
 
       it 'expect to track this with an instrumentation' do
@@ -178,7 +178,7 @@ RSpec.describe_current do
 
       it 'expect to pause with time tracker' do
         consumer.on_consume
-        expect(pause).to have_received(:pause)
+        expect(pause_tracker).to have_received(:pause)
       end
 
       it 'expect to track this with an instrumentation' do

--- a/spec/lib/karafka/base_consumer_spec.rb
+++ b/spec/lib/karafka/base_consumer_spec.rb
@@ -382,4 +382,12 @@ RSpec.describe_current do
       expect(client).to have_received(:seek).with(seek)
     end
   end
+
+  describe '#pause' do
+    pending
+  end
+
+  describe '#resume' do
+    pending
+  end
 end

--- a/spec/lib/karafka/base_consumer_spec.rb
+++ b/spec/lib/karafka/base_consumer_spec.rb
@@ -384,10 +384,30 @@ RSpec.describe_current do
   end
 
   describe '#pause' do
-    pending
+    context 'when we pause without providing the timeout' do
+      pending
+    end
+
+    context 'when we pause providing the timeout' do
+      pending
+    end
   end
 
   describe '#resume' do
-    pending
+    before do
+      consumer.client = client
+      consumer.messages = messages
+
+      allow(client).to receive(:resume)
+
+      consumer.send(:resume)
+    end
+
+    it 'expect to forward to client using current execution context data' do
+      expect(client).to have_received(:resume).with(
+        messages.metadata.topic,
+        messages.metadata.partition
+      )
+    end
   end
 end

--- a/spec/lib/karafka/base_consumer_spec.rb
+++ b/spec/lib/karafka/base_consumer_spec.rb
@@ -384,12 +384,46 @@ RSpec.describe_current do
   end
 
   describe '#pause' do
+    before do
+      consumer.client = client
+      consumer.messages = messages
+
+      allow(pause_tracker).to receive(:pause)
+      allow(client).to receive(:pause)
+    end
+
     context 'when we pause without providing the timeout' do
-      pending
+      let(:expected_args) do
+        [
+          messages.metadata.topic,
+          messages.metadata.partition,
+          100
+        ]
+      end
+
+      before { consumer.send(:pause, 100) }
+
+      it 'expect to pause via client and use pause tracker without any arguments' do
+        expect(client).to have_received(:pause).with(*expected_args)
+        expect(pause_tracker).to have_received(:pause).with(no_args)
+      end
     end
 
     context 'when we pause providing the timeout' do
-      pending
+      let(:expected_args) do
+        [
+          messages.metadata.topic,
+          messages.metadata.partition,
+          100
+        ]
+      end
+
+      before { consumer.send(:pause, 100, 2_000) }
+
+      it 'expect to pause via client and use pause tracker with provided timeout' do
+        expect(client).to have_received(:pause).with(*expected_args)
+        expect(pause_tracker).to have_received(:pause).with(2_000)
+      end
     end
   end
 

--- a/spec/lib/karafka/time_trackers/pause_spec.rb
+++ b/spec/lib/karafka/time_trackers/pause_spec.rb
@@ -222,4 +222,82 @@ RSpec.describe_current do
       it { expect(tracker.count).to eq(0) }
     end
   end
+
+  context 'when we define a custom manual pause time' do
+    let(:timeout) { 100 }
+    let(:max_timeout) { 100 }
+    let(:exponential_backoff) { false }
+
+    context 'when pause tracker is created' do
+      it { expect(tracker.expired?).to eq(true) }
+      it { expect(tracker.paused?).to eq(false) }
+      it { expect(tracker.count).to eq(0) }
+    end
+
+    context 'when immediately after paused' do
+      before { tracker.pause(1) }
+
+      it { expect(tracker.expired?).to eq(false) }
+      it { expect(tracker.paused?).to eq(true) }
+      it { expect(tracker.count).to eq(1) }
+    end
+
+    context 'when paused and manually expired' do
+      before do
+        tracker.pause(1_000)
+        tracker.expire
+      end
+
+      it { expect(tracker.expired?).to eq(true) }
+      it { expect(tracker.paused?).to eq(true) }
+      it { expect(tracker.count).to eq(1) }
+    end
+
+    context 'when not paused over timeout nor max timeout' do
+      before do
+        tracker.pause(2)
+        sleep(0.001)
+      end
+
+      it { expect(tracker.expired?).to eq(false) }
+      it { expect(tracker.paused?).to eq(true) }
+      it { expect(tracker.count).to eq(1) }
+    end
+
+    context 'when paused over max timeout' do
+      before do
+        tracker.pause(1)
+        sleep(0.006)
+      end
+
+      it { expect(tracker.expired?).to eq(true) }
+      it { expect(tracker.paused?).to eq(true) }
+      it { expect(tracker.count).to eq(1) }
+    end
+
+    context 'when paused over timeout and resumed' do
+      before do
+        tracker.pause(1)
+        sleep(0.01)
+        tracker.resume
+      end
+
+      it { expect(tracker.expired?).to eq(true) }
+      it { expect(tracker.paused?).to eq(false) }
+      it { expect(tracker.count).to eq(1) }
+    end
+
+    context 'when paused over timeout, resumed and reset' do
+      before do
+        tracker.pause(1)
+        sleep(0.01)
+        tracker.resume
+        tracker.reset
+      end
+
+      it { expect(tracker.expired?).to eq(true) }
+      it { expect(tracker.paused?).to eq(false) }
+      it { expect(tracker.count).to eq(0) }
+    end
+  end
 end


### PR DESCRIPTION
This PR allows us to pause for an explicitly provided amount of time.

It introduces to the consumer `#pause` and `#resume` methods + adds both unit and integration specs.

This can be useful for when manually controlling the pausing (advanced usage).