### PR TITLE
Abstract away notion of topics groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka framework changelog
 
+## 2.0.0-beta2 (Unreleased)
+- Abstract away notion of topics groups (until now it was just an array)
+
 ## 2.0.0-beta1 (2022-05-22)
 - Update the jobs queue blocking engine and allow for non-blocking jobs execution
 - Provide `#prepared` hook that always runs before the fetching loop is unblocked

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka (2.0.0.beta1)
+    karafka (2.0.0.beta2)
       dry-configurable (~> 0.13)
       dry-monitor (~> 0.5)
       dry-validation (~> 1.7)

--- a/lib/karafka/processing/executors_buffer.rb
+++ b/lib/karafka/processing/executors_buffer.rb
@@ -23,7 +23,7 @@ module Karafka
         partition,
         pause
       )
-        topic = @subscription_group.topics.find { |ktopic| ktopic.name == topic }
+        topic = @subscription_group.topics.find(topic)
 
         topic || raise(Errors::TopicNotFoundError, topic)
 

--- a/lib/karafka/routing/consumer_group.rb
+++ b/lib/karafka/routing/consumer_group.rb
@@ -17,7 +17,7 @@ module Karafka
       def initialize(name)
         @name = name
         @id = Karafka::App.config.consumer_mapper.call(name)
-        @topics = []
+        @topics = Topics.new
       end
 
       # @return [Boolean] true if this consumer group should be active in our current process

--- a/lib/karafka/routing/consumer_group.rb
+++ b/lib/karafka/routing/consumer_group.rb
@@ -17,7 +17,7 @@ module Karafka
       def initialize(name)
         @name = name
         @id = Karafka::App.config.consumer_mapper.call(name)
-        @topics = Topics.new
+        @topics = Topics.new([])
       end
 
       # @return [Boolean] true if this consumer group should be active in our current process

--- a/lib/karafka/routing/subscription_group.rb
+++ b/lib/karafka/routing/subscription_group.rb
@@ -10,7 +10,7 @@ module Karafka
     class SubscriptionGroup
       attr_reader :id, :topics
 
-      # @param topics [Array<Topic>] all the topics that share the same key settings
+      # @param topics [Karafka::Routing::Topics] all the topics that share the same key settings
       # @return [SubscriptionGroup] built subscription group
       def initialize(topics)
         @id = SecureRandom.uuid

--- a/lib/karafka/routing/subscription_groups_builder.rb
+++ b/lib/karafka/routing/subscription_groups_builder.rb
@@ -23,8 +23,8 @@ module Karafka
 
       private_constant :DISTRIBUTION_KEYS
 
-      # @param topics [Array<Topic>] array with topics based on which we want to build subscription
-      #   groups
+      # @param topics [Karafka::Routing::Topics] all the topics based on which we want to build
+      #   subscription groups
       # @return [Array<SubscriptionGroup>] all subscription groups we need in separate threads
       def call(topics)
         topics
@@ -32,6 +32,7 @@ module Karafka
           .group_by(&:first)
           .values
           .map { |value| value.map(&:last) }
+          .map { |topics| Routing::Topics.new(topics) }
           .map { |grouped_topics| SubscriptionGroup.new(grouped_topics) }
       end
 

--- a/lib/karafka/routing/subscription_groups_builder.rb
+++ b/lib/karafka/routing/subscription_groups_builder.rb
@@ -32,7 +32,7 @@ module Karafka
           .group_by(&:first)
           .values
           .map { |value| value.map(&:last) }
-          .map { |topics| Routing::Topics.new(topics) }
+          .map { |topics_array| Routing::Topics.new(topics_array) }
           .map { |grouped_topics| SubscriptionGroup.new(grouped_topics) }
       end
 

--- a/lib/karafka/routing/topics.rb
+++ b/lib/karafka/routing/topics.rb
@@ -8,8 +8,8 @@ module Karafka
     class Topics
       include Enumerable
 
-      # @param [Array<Karafka::Routing::Topic>] array with topics
-      def initialize(topics_array = [])
+      # @param topics_array [Array<Karafka::Routing::Topic>] array with topics
+      def initialize(topics_array)
         @accumulator = topics_array.dup
       end
 
@@ -23,9 +23,9 @@ module Karafka
 
       # Yields each topic
       #
-      # @yieldparam [Karafka::Routing::Topic]
-      def each
-        @accumulator.each { |topic| yield(topic) }
+      # @param [Proc] block we want to yield with on each topic
+      def each(&block)
+        @accumulator.each(&block)
       end
 
       # @return [Boolean] is the group empty or not

--- a/lib/karafka/routing/topics.rb
+++ b/lib/karafka/routing/topics.rb
@@ -38,6 +38,11 @@ module Karafka
         @accumulator.last
       end
 
+      # @return [Integer] number of topics
+      def size
+        @accumulator.size
+      end
+
       # Finds topic by its name
       #
       # @param topic_name [String] topic name

--- a/lib/karafka/routing/topics.rb
+++ b/lib/karafka/routing/topics.rb
@@ -7,18 +7,13 @@ module Karafka
     # Abstraction layer on top of groups of topics
     class Topics
       include Enumerable
+      extend Forwardable
+
+      def_delegators :@accumulator, :[], :size, :empty?, :last, :<<
 
       # @param topics_array [Array<Karafka::Routing::Topic>] array with topics
       def initialize(topics_array)
         @accumulator = topics_array.dup
-      end
-
-      # Adds topic to the topics group
-      #
-      # @param topic [Karafka::Routing::Topic]
-      # @return [Karafka::Routing::Topic]
-      def <<(topic)
-        @accumulator << topic
       end
 
       # Yields each topic
@@ -26,21 +21,6 @@ module Karafka
       # @param [Proc] block we want to yield with on each topic
       def each(&block)
         @accumulator.each(&block)
-      end
-
-      # @return [Boolean] is the group empty or not
-      def empty?
-        @accumulator.empty?
-      end
-
-      # @return [Karafka::Routing::Topic] last available topic
-      def last
-        @accumulator.last
-      end
-
-      # @return [Integer] number of topics
-      def size
-        @accumulator.size
       end
 
       # Finds topic by its name

--- a/lib/karafka/routing/topics.rb
+++ b/lib/karafka/routing/topics.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# frozen_string_literal: true
+
+module Karafka
+  module Routing
+    # Abstraction layer on top of groups of topics
+    class Topics
+      include Enumerable
+
+      # @param [Array<Karafka::Routing::Topic>] array with topics
+      def initialize(topics_array = [])
+        @accumulator = topics_array.dup
+      end
+
+      # Adds topic to the topics group
+      #
+      # @param topic [Karafka::Routing::Topic]
+      # @return [Karafka::Routing::Topic]
+      def <<(topic)
+        @accumulator << topic
+      end
+
+      # Yields each topic
+      #
+      # @yieldparam [Karafka::Routing::Topic]
+      def each
+        @accumulator.each { |topic| yield(topic) }
+      end
+
+      # @return [Boolean] is the group empty or not
+      def empty?
+        @accumulator.empty?
+      end
+
+      # @return [Karafka::Routing::Topic] last available topic
+      def last
+        @accumulator.last
+      end
+
+      # Finds topic by its name
+      #
+      # @param topic_name [String] topic name
+      # @return [Karafka::Routing::Topic]
+      # @raise [Karafka::Errors::TopicNotFoundError] this should never happen. If you see it,
+      #   please create an issue.
+      def find(topic_name)
+        @accumulator.find { |topic| topic.name == topic_name } ||
+          raise(Karafka::Errors::TopicNotFoundError, topic_name)
+      end
+    end
+  end
+end

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '2.0.0.beta1'
+  VERSION = '2.0.0.beta2'
 end

--- a/spec/lib/karafka/routing/topics_spec.rb
+++ b/spec/lib/karafka/routing/topics_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe_current do
-  subject(:topics) { described_class.new }
+  subject(:topics) { described_class.new([]) }
 
   let(:topic) { build(:routing_topic) }
 

--- a/spec/lib/karafka/routing/topics_spec.rb
+++ b/spec/lib/karafka/routing/topics_spec.rb
@@ -29,6 +29,18 @@ RSpec.describe_current do
     end
   end
 
+  describe '#size' do
+    context 'when there are no topics' do
+      it { expect(topics.size).to eq(0) }
+    end
+
+    context 'when there are some topics' do
+      before { topics << topic }
+
+      it { expect(topics.size).to eq(1) }
+    end
+  end
+
   describe '#each' do
     before { topics << topic }
 

--- a/spec/lib/karafka/routing/topics_spec.rb
+++ b/spec/lib/karafka/routing/topics_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:topics) { described_class.new }
+
+  let(:topic) { build(:routing_topic) }
+
+  describe '#empty?' do
+    context 'when it is a new topics group' do
+      it { expect(topics.empty?).to eq(true) }
+    end
+
+    context 'when there are some topics' do
+      before { topics << topic }
+
+      it { expect(topics.empty?).to eq(false) }
+    end
+  end
+
+  describe '#last' do
+    context 'when there are no topics' do
+      it { expect(topics.last).to eq(nil) }
+    end
+
+    context 'when there are some topics' do
+      before { topics << topic }
+
+      it { expect(topics.last).to eq(topic) }
+    end
+  end
+
+  describe '#each' do
+    before { topics << topic }
+
+    it { expect { |block| topics.each(&block) }.to yield_with_args(topic) }
+  end
+
+  describe '#find' do
+    before { topics << topic }
+
+    context 'when topic with given name exists' do
+      it { expect(topics.find(topic.name)).to eq(topic) }
+    end
+
+    context 'when topic with given name does not exist' do
+      it 'expect to raise an exception as this should never happen' do
+        expect { topics.find('na') }.to raise_error(Karafka::Errors::TopicNotFoundError, 'na')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR abstracts away the notion of topic groups. So far it was a simple array, but now for the simplicity and future development of virtual partitions, it makes sense to abstract this away.

It was the last non-abstract karafka routing component.