### PR TITLE
Make scheduler work with jobs instead of messages

### DIFF
--- a/lib/karafka/scheduler.rb
+++ b/lib/karafka/scheduler.rb
@@ -5,12 +5,10 @@ module Karafka
   class Scheduler
     # Yields jobs in the fifo order
     #
-    # @param [Array<Karafka::Processing::Jobs::Base>] jobs we want to schedule
+    # @param jobs_array [Array<Karafka::Processing::Jobs::Base>] jobs we want to schedule
     # @yieldparam [Karafka::Processing::Jobs::Base] job we want to enqueue
-    def call(jobs_array)
-      jobs_array.each do |job|
-        yield job
-      end
+    def call(jobs_array, &block)
+      jobs_array.each(&block)
     end
   end
 end

--- a/lib/karafka/scheduler.rb
+++ b/lib/karafka/scheduler.rb
@@ -3,18 +3,13 @@
 module Karafka
   # FIFO scheduler for messages coming from various topics and partitions
   class Scheduler
-    # Yields messages from partitions in the fifo order
+    # Yields jobs in the fifo order
     #
-    # @param messages_buffer [Karafka::Connection::MessagesBuffer] messages buffer with data from
-    #   multiple topics and partitions
-    # @yieldparam [String] topic name
-    # @yieldparam [Integer] partition number
-    # @yieldparam [Array<Rdkafka::Consumer::Message>] topic partition aggregated results
-    def call(messages_buffer)
-      messages_buffer.each do |topic, partitions|
-        partitions.each do |partition, messages|
-          yield(topic, partition, messages)
-        end
+    # @param [Array<Karafka::Processing::Jobs::Base>] jobs we want to schedule
+    # @yieldparam [Karafka::Processing::Jobs::Base] job we want to enqueue
+    def call(jobs_array)
+      jobs_array.each do |job|
+        yield job
       end
     end
   end

--- a/spec/lib/karafka/connection/messages_buffer_spec.rb
+++ b/spec/lib/karafka/connection/messages_buffer_spec.rb
@@ -3,9 +3,13 @@
 RSpec.describe_current do
   subject(:buffer) { described_class.new }
 
-  describe '#<< and #size' do
+  describe '#<<, #size and #each' do
     context 'when there are no messages' do
       it { expect(buffer.size).to eq(0) }
+
+      it 'expect not to yield anything' do
+        expect { |block| buffer.each(&block) }.not_to yield_control
+      end
     end
 
     context 'when there is a message' do
@@ -14,6 +18,11 @@ RSpec.describe_current do
       before { buffer << message }
 
       it { expect(buffer.size).to eq(1) }
+
+      it 'expect to yield with messages from this topic partition' do
+        expect { |block| buffer.each(&block) }
+          .to yield_with_args(message.topic, message.partition, [message])
+      end
     end
 
     context 'when there are messages from same partitions of the same topic' do
@@ -22,6 +31,11 @@ RSpec.describe_current do
       before { 3.times { buffer << message } }
 
       it { expect(buffer.size).to eq(3) }
+
+      it 'expect to yield with messages from this topic partition' do
+        expect { |block| buffer.each(&block) }
+          .to yield_with_args(message.topic, message.partition, [message, message, message])
+      end
     end
 
     context 'when there are messages from different partitions of the same topic' do
@@ -38,6 +52,14 @@ RSpec.describe_current do
       end
 
       it { expect(buffer.size).to eq(2) }
+
+      it 'expect to yield with messages from given partitions separately' do
+        expect { |block| buffer.each(&block) }
+          .to yield_successive_args(
+            [message1.topic, message1.partition, [message1]],
+            [message2.topic, message2.partition, [message2]]
+          )
+      end
     end
 
     context 'when there are messages from same partitions of different topics' do
@@ -54,6 +76,14 @@ RSpec.describe_current do
       end
 
       it { expect(buffer.size).to eq(2) }
+
+      it 'expect to yield with messages from given topics partitions separately' do
+        expect { |block| buffer.each(&block) }
+          .to yield_successive_args(
+            [message1.topic, message1.partition, [message1]],
+            [message2.topic, message2.partition, [message2]]
+          )
+      end
     end
   end
 
@@ -61,6 +91,11 @@ RSpec.describe_current do
     before { buffer << build(:messages_message) }
 
     it { expect { buffer.clear }.to change(buffer, :size).from(1).to(0) }
+
+    it 'expect not to have anything to process after cleaning' do
+      buffer.clear
+      expect { |block| buffer.each(&block) }.not_to yield_control
+    end
   end
 
   describe '#delete' do
@@ -85,6 +120,12 @@ RSpec.describe_current do
       it 'expect change the buffer size to reflect the change' do
         expect { buffer.delete(message1.topic, 0) }.to change(buffer, :size).by(-1)
       end
+
+      it 'expect to completely remove the topic when no other partitions present' do
+        buffer.delete(message1.topic, 0)
+
+        expect { |block| buffer.each(&block) }.not_to yield_control
+      end
     end
 
     context 'when given partition exists and is not the only one' do
@@ -101,14 +142,38 @@ RSpec.describe_current do
         buffer.delete(message1.topic, 0)
         expect(buffer.size).to eq(1)
       end
+
+      it 'expect not to mix the topics' do
+        buffer.delete(message1.topic, 0)
+
+        buffer.each do |topic, _, _|
+          expect(topic).to eq(message2.topic)
+        end
+      end
+
+      it 'expect not to mix partitions' do
+        buffer.delete(message1.topic, 0)
+
+        buffer.each do |_, partition, _|
+          expect(partition).to eq(message2.partition)
+        end
+      end
+
+      it 'expect not to mix messages in the buffer' do
+        buffer.delete(message1.topic, 0)
+
+        buffer.each do |_, _, messages|
+          expect(messages).to eq([message2])
+        end
+      end
     end
   end
 
   describe 'uniq!' do
-    let(:message1) { build(:messages_message) }
-    let(:message2) { build(:messages_message) }
-    let(:message3) { build(:messages_message) }
-    let(:message4) { build(:messages_message) }
+    let(:message1) { build(:messages_message, topic: 'test', partition: 0) }
+    let(:message2) { build(:messages_message, topic: 'test', partition: 0) }
+    let(:message3) { build(:messages_message, topic: 'test', partition: 0) }
+    let(:message4) { build(:messages_message, topic: 'test', partition: 0) }
 
     context 'when we have same message twice for the same topic partition' do
       before do
@@ -120,6 +185,14 @@ RSpec.describe_current do
       end
 
       it { expect { buffer.uniq! }.to change(buffer, :size).by(-1) }
+
+      it 'expect to maintain messages order' do
+        buffer.uniq!
+
+        buffer.each do |_, _, messages|
+          expect(messages).to eq([message1, message2, message3, message4])
+        end
+      end
     end
   end
 end

--- a/spec/lib/karafka/scheduler_spec.rb
+++ b/spec/lib/karafka/scheduler_spec.rb
@@ -3,62 +3,34 @@
 RSpec.describe_current do
   subject(:scheduler) { described_class.new }
 
-  let(:messages_buffer) { Karafka::Connection::MessagesBuffer.new }
+  let(:jobs_array) { [] }
 
   context 'when there are no messages' do
-    it { expect { |block| scheduler.call(messages_buffer, &block) }.not_to yield_control }
+    it { expect { |block| scheduler.call(jobs_array, &block) }.not_to yield_control }
   end
 
-  context 'when there are messages' do
-    2.times do |topic_nr|
-      2.times do |partition_nr|
-        2.times do |message_nr|
-          let(:"t#{topic_nr}p#{partition_nr}m#{message_nr}") do
-            build(
-              :messages_message,
-              metadata: build(
-                :messages_metadata,
-                topic: "topic#{topic_nr}",
-                partition: partition_nr
-              )
-            )
-          end
-        end
-      end
+  context 'when there are jobs' do
+    let(:jobs_array) do
+      [
+        Karafka::Processing::Jobs::Consume.new(nil, []),
+        Karafka::Processing::Jobs::Consume.new(nil, []),
+        Karafka::Processing::Jobs::Consume.new(nil, []),
+        Karafka::Processing::Jobs::Consume.new(nil, [])
+      ]
     end
 
     let(:yielded) do
       data = []
 
-      scheduler.call(messages_buffer) do |topic, partition, messages|
-        data << [topic, partition, messages]
+      scheduler.call(jobs_array) do |job|
+        data << job
       end
 
       data
     end
 
-    let(:expected) do
-      [
-        [t0p0m0.topic, t0p0m0.partition, [t0p0m0, t0p0m1]],
-        [t0p1m0.topic, t0p1m0.partition, [t0p1m0, t0p1m1]],
-        [t1p0m0.topic, t1p0m0.partition, [t1p0m0, t1p0m1]],
-        [t1p1m0.topic, t1p1m0.partition, [t1p1m0, t1p1m1]]
-      ]
-    end
-
-    before do
-      messages_buffer << t0p0m0
-      messages_buffer << t0p0m1
-      messages_buffer << t0p1m0
-      messages_buffer << t0p1m1
-      messages_buffer << t1p0m0
-      messages_buffer << t1p0m1
-      messages_buffer << t1p1m0
-      messages_buffer << t1p1m1
-    end
-
     it 'expect to yield them in the fifo order' do
-      expect(yielded).to eq(expected)
+      expect(yielded).to eq(jobs_array)
     end
   end
 end

--- a/spec/support/factories/messages/message.rb
+++ b/spec/support/factories/messages/message.rb
@@ -4,8 +4,13 @@ FactoryBot.define do
   factory :messages_message, class: 'Karafka::Messages::Message' do
     skip_create
 
+    transient do
+      sequence(:topic) { |nr| "topic#{nr}" }
+      partition { 0 }
+    end
+
     raw_payload { '{}' }
-    metadata { build(:messages_metadata) }
+    metadata { build(:messages_metadata, topic: topic, partition: partition) }
 
     initialize_with do
       new(raw_payload, metadata)


### PR DESCRIPTION
This PR updates the scheduler API to work with the jobs array instead of directly with messages. That way we can actually reorder jobs even if they come from same partition to make sure that in case of parallel processing we enqueue in good order (for other schedulers).