### PR TITLE
Optimize jobs queue shutdown and make listeners self-sufficient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## 2.0.0-beta2 (Unreleased)
 - Abstract away notion of topics groups (until now it was just an array)
-- Optimize how jobs queue is closed. This will ensure all sync and async jobs are finished prior to the queue being closed for cases with high load processing systems with multiple consumer groups
+- Optimize how jobs queue is closed. Since we enqueue jobs only from the listeners, we can safely close jobs queue once listeners are done. By extracting this responsiblity from listeners, we remove corner cases and race conditions. Note here: for non-blocking jobs we do wait for them to finish while running the `poll`. This ensures, that for async jobs that are long-living, we do not reach `max.poll.interval`.
+- `Shutdown` jobs are executed in workers to align all the jobs behaviours.
+- `Shutdown` jobs are always blocking.
+- Notion of `ListenersBatch` was introduced similar to `WorkersBatch` to abstract this concept.
 
 ## 2.0.0-beta1 (2022-05-22)
 - Update the jobs queue blocking engine and allow for non-blocking jobs execution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `Shutdown` jobs are executed in workers to align all the jobs behaviours.
 - `Shutdown` jobs are always blocking.
 - Notion of `ListenersBatch` was introduced similar to `WorkersBatch` to abstract this concept.
+- Change default `shutdown_timeout` to be more than `max_wait_time` not to cause forced shutdown when no messages are being received from Kafka.
 
 ## 2.0.0-beta1 (2022-05-22)
 - Update the jobs queue blocking engine and allow for non-blocking jobs execution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `Shutdown` jobs are always blocking.
 - Notion of `ListenersBatch` was introduced similar to `WorkersBatch` to abstract this concept.
 - Change default `shutdown_timeout` to be more than `max_wait_time` not to cause forced shutdown when no messages are being received from Kafka.
+- Abstract away scheduling of revocation and shutdown jobs for both default and pro schedulers
 
 ## 2.0.0-beta1 (2022-05-22)
 - Update the jobs queue blocking engine and allow for non-blocking jobs execution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.0.0-beta2 (Unreleased)
 - Abstract away notion of topics groups (until now it was just an array)
-- Optimize how jobs queue is closed. Since we enqueue jobs only from the listeners, we can safely close jobs queue once listeners are done. By extracting this responsiblity from listeners, we remove corner cases and race conditions. Note here: for non-blocking jobs we do wait for them to finish while running the `poll`. This ensures, that for async jobs that are long-living, we do not reach `max.poll.interval`.
+- Optimize how jobs queue is closed. Since we enqueue jobs only from the listeners, we can safely close jobs queue once listeners are done. By extracting this responsibility from listeners, we remove corner cases and race conditions. Note here: for non-blocking jobs we do wait for them to finish while running the `poll`. This ensures, that for async jobs that are long-living, we do not reach `max.poll.interval`.
 - `Shutdown` jobs are executed in workers to align all the jobs behaviours.
 - `Shutdown` jobs are always blocking.
 - Notion of `ListenersBatch` was introduced similar to `WorkersBatch` to abstract this concept.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.0.0-beta2 (Unreleased)
 - Abstract away notion of topics groups (until now it was just an array)
+- Optimize how jobs queue is closed. This will ensure all sync and async jobs are finished prior to the queue being closed for cases with high load processing systems with multiple consumer groups
 
 ## 2.0.0-beta1 (2022-05-22)
 - Update the jobs queue blocking engine and allow for non-blocking jobs execution

--- a/lib/karafka/connection/listener.rb
+++ b/lib/karafka/connection/listener.rb
@@ -152,7 +152,6 @@ module Karafka
       # Stops the jobs queue, triggers shutdown on all the executors (sync), commits offsets and
       # stops kafka client.
       def shutdown
-        @jobs_queue.close
         # This runs synchronously, making sure we finish all the shutdowns before we stop the
         # client.
         @executors.shutdown

--- a/lib/karafka/connection/listener.rb
+++ b/lib/karafka/connection/listener.rb
@@ -135,8 +135,6 @@ module Karafka
       def schedule_revoke_lost_partitions_jobs
         revoked_partitions = @client.rebalance_manager.revoked_partitions
 
-        return if revoked_partitions.empty?
-
         revoked_partitions.each do |topic, partitions|
           partitions.each do |partition|
             pause_tracker = @pauses_manager.fetch(topic, partition)

--- a/lib/karafka/connection/listeners_batch.rb
+++ b/lib/karafka/connection/listeners_batch.rb
@@ -2,7 +2,7 @@
 
 module Karafka
   module Connection
-    # Abstraction layer around listeners batch batch.
+    # Abstraction layer around listeners batch.
     class ListenersBatch
       include Enumerable
 

--- a/lib/karafka/connection/listeners_batch.rb
+++ b/lib/karafka/connection/listeners_batch.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Karafka
+  module Connection
+    # Abstraction layer around listeners batch batch.
+    class ListenersBatch
+      include Enumerable
+
+      # @param jobs_queue [JobsQueue]
+      # @return [ListenersBatch]
+      def initialize(jobs_queue)
+        @batch = App.subscription_groups.map do |subscription_group|
+          Connection::Listener.new(subscription_group, jobs_queue)
+        end
+      end
+
+      # Iterates over available listeners and yields each listener
+      # @param block [Proc] block we want to run
+      def each(&block)
+        @batch.each(&block)
+      end
+    end
+  end
+end

--- a/lib/karafka/helpers/async.rb
+++ b/lib/karafka/helpers/async.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Karafka
+  module Helpers
+    module Async
+      # Allows a given class to run async in a separate thread. Provides also few methods we may
+      # want to use to control the underlying thread
+      class << self
+        def included(base)
+          base.extend ::Forwardable
+
+          base.def_delegators :@thread, :join, :terminate, :alive?
+        end
+      end
+
+      # Runs the `#call` method in a new thread
+      def async_call
+        @thread = Thread.new do
+          Thread.current.abort_on_exception = true
+
+          call
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/helpers/async.rb
+++ b/lib/karafka/helpers/async.rb
@@ -6,7 +6,7 @@ module Karafka
     # want to use to control the underlying thread
     #
     # @note Thread running code needs to manage it's own exceptions. If they leak out, they will
-    #   aborth thread on exception.
+    #   abort thread on exception.
     module Async
       class << self
         # Adds forwardable to redirect thread-based control methods to the underlying thread that

--- a/lib/karafka/helpers/async.rb
+++ b/lib/karafka/helpers/async.rb
@@ -2,10 +2,17 @@
 
 module Karafka
   module Helpers
+    # Allows a given class to run async in a separate thread. Provides also few methods we may
+    # want to use to control the underlying thread
+    #
+    # @note Thread running code needs to manage it's own exceptions. If they leak out, they will
+    #   aborth thread on exception.
     module Async
-      # Allows a given class to run async in a separate thread. Provides also few methods we may
-      # want to use to control the underlying thread
       class << self
+        # Adds forwardable to redirect thread-based control methods to the underlying thread that
+        # runs the async operations
+        #
+        # @param base [Class] class we're including this module in
         def included(base)
           base.extend ::Forwardable
 

--- a/lib/karafka/processing/executors_buffer.rb
+++ b/lib/karafka/processing/executors_buffer.rb
@@ -23,22 +23,27 @@ module Karafka
         partition,
         pause
       )
-        topic = @subscription_group.topics.find(topic)
+        ktopic = @subscription_group.topics.find(topic)
 
-        topic || raise(Errors::TopicNotFoundError, topic)
+        ktopic || raise(Errors::TopicNotFoundError, topic)
 
-        @buffer[topic][partition] ||= Executor.new(
+        @buffer[ktopic][partition] ||= Executor.new(
           @subscription_group.id,
           @client,
-          topic,
+          ktopic,
           pause
         )
       end
 
+      # Iterates over all available executors and yields them together with topic and partition
+      # info
+      # @yieldparam [Routing::Topic] karafka routing topic object
+      # @yieldparam [Integer] partition number
+      # @yieldparam [Executor] given executor
       def each
-        @buffer.each do |topic, partitions|
+        @buffer.each do |ktopic, partitions|
           partitions.each do |partition, executor|
-            yield(topic, partition, executor)
+            yield(ktopic, partition, executor)
           end
         end
       end

--- a/lib/karafka/processing/executors_buffer.rb
+++ b/lib/karafka/processing/executors_buffer.rb
@@ -35,9 +35,12 @@ module Karafka
         )
       end
 
-      # Runs the shutdown on all active executors.
-      def shutdown
-        @buffer.values.map(&:values).flatten.each(&:shutdown)
+      def each
+        @buffer.each do |topic, partitions|
+          partitions.each do |partition, executor|
+            yield(topic, partition, executor)
+          end
+        end
       end
 
       # Clears the executors buffer. Useful for critical errors recovery.

--- a/lib/karafka/processing/jobs_queue.rb
+++ b/lib/karafka/processing/jobs_queue.rb
@@ -103,7 +103,7 @@ module Karafka
       # @param group_id [String]
       #
       # @return [Boolean] tell us if we have anything in the processing (or for processing) from
-      # a given gorup.
+      # a given group.
       def empty?(group_id)
         @in_processing[group_id].empty?
       end

--- a/lib/karafka/processing/jobs_queue.rb
+++ b/lib/karafka/processing/jobs_queue.rb
@@ -90,6 +90,10 @@ module Karafka
         end
       end
 
+      def empty?(group_id)
+        @in_processing[group_id].empty?
+      end
+
       # Stops the whole processing queue.
       def close
         @mutex.synchronize do
@@ -115,8 +119,6 @@ module Karafka
       # @param group_id [String] id of the group in which jobs we're interested.
       # @return [Boolean] should we keep waiting or not
       def wait?(group_id)
-        # Only wait if there are blocking jobs running for  a given subscription group
-        # Otherwise if empty or only non-blocking, it is safe to move forward
         !@in_processing[group_id].all?(&:non_blocking?)
       end
     end

--- a/lib/karafka/processing/worker.rb
+++ b/lib/karafka/processing/worker.rb
@@ -17,23 +17,19 @@ module Karafka
     #                code. This can be used to unlock certain resources or do other things that are
     #                not user code but need to run after user code base is executed.
     class Worker
-      extend Forwardable
-
-      def_delegators :@thread, :join, :terminate, :alive?
+      include Helpers::Async
 
       # @param jobs_queue [JobsQueue]
       # @return [Worker]
       def initialize(jobs_queue)
         @jobs_queue = jobs_queue
-        @thread = Thread.new do
-          # If anything goes wrong in this worker thread, it means something went really wrong and
-          # we should terminate.
-          Thread.current.abort_on_exception = true
-          loop { break unless process }
-        end
       end
 
       private
+
+      def call
+        loop { break unless process }
+      end
 
       # Fetches a single job, processes it and marks as completed.
       #

--- a/lib/karafka/processing/worker.rb
+++ b/lib/karafka/processing/worker.rb
@@ -27,6 +27,8 @@ module Karafka
 
       private
 
+      # Runs processing of jobs in a loop
+      # Stops when queue is closed.
       def call
         loop { break unless process }
       end

--- a/lib/karafka/processing/workers_batch.rb
+++ b/lib/karafka/processing/workers_batch.rb
@@ -17,6 +17,11 @@ module Karafka
       def each(&block)
         @batch.each(&block)
       end
+
+      # @return [Integer] number of workers in the batch
+      def size
+        @batch.size
+      end
     end
   end
 end

--- a/lib/karafka/runner.rb
+++ b/lib/karafka/runner.rb
@@ -21,10 +21,16 @@ module Karafka
       listeners.each(&:join)
 
       # We close the jobs queue only when no listener threads are working.
-      # This ensures, that everything was closed prior to us not accepting anymore jobs
+      # This ensures, that everything was closed prior to us not accepting anymore jobs and that
+      # no more jobs will be enqueued. Since each listener waits for jobs to finish, once those
+      # are done, we can close.
       jobs_queue.close
 
       # All the workers need to stop processing anything before we can stop the runner completely
+      # This ensures that even async long-running jobs have time to finish before we are done
+      # with everything. One thing worth keeping in mind though: It is the end user responsibility
+      # to handle the shutdown detection in their long-running processes. Otherwise if timeout
+      # is exceeded, there will be a forced shutdown.
       workers.each(&:join)
     # If anything crashes here, we need to raise the error and crush the runner because it means
     # that something terrible happened

--- a/lib/karafka/runner.rb
+++ b/lib/karafka/runner.rb
@@ -28,6 +28,11 @@ module Karafka
 
       # All the listener threads need to finish
       threads.each(&:join)
+
+      # We close the jobs queue only when no listener threads are working.
+      # This ensures, that everything was closed prior to us not accepting anymore jobs
+      jobs_queue.close
+
       # All the workers need to stop processing anything before we can stop the runner completely
       workers.each(&:join)
     # If anything crashes here, we need to raise the error and crush the runner because it means

--- a/lib/karafka/runner.rb
+++ b/lib/karafka/runner.rb
@@ -13,6 +13,9 @@ module Karafka
       workers = Processing::WorkersBatch.new(jobs_queue)
       listeners = Connection::ListenersBatch.new(jobs_queue)
 
+      workers.each(&:async_call)
+      listeners.each(&:async_call)
+
       # We aggregate threads here for a supervised shutdown process
       Karafka::Server.workers = workers
       Karafka::Server.listeners = listeners

--- a/lib/karafka/scheduler.rb
+++ b/lib/karafka/scheduler.rb
@@ -3,12 +3,18 @@
 module Karafka
   # FIFO scheduler for messages coming from various topics and partitions
   class Scheduler
-    # Yields jobs in the fifo order
+    # Schedules jobs in the fifo order
     #
+    # @param queue [Karafka::Processing::JobsQueue] queue where we want to put the jobs
     # @param jobs_array [Array<Karafka::Processing::Jobs::Base>] jobs we want to schedule
-    # @yieldparam [Karafka::Processing::Jobs::Base] job we want to enqueue
-    def call(jobs_array, &block)
-      jobs_array.each(&block)
+    def schedule_consumption(queue, jobs_array)
+      jobs_array.each do |job|
+        queue << job
+      end
     end
+
+    # Both revocation and shutdown jobs can also run in fifo by default
+    alias schedule_revocation schedule_consumption
+    alias schedule_shutdown schedule_consumption
   end
 end

--- a/lib/karafka/server.rb
+++ b/lib/karafka/server.rb
@@ -38,6 +38,8 @@ module Karafka
 
         # We always need to wait for Karafka to stop here since we should wait for the stop running
         # in a separate thread (or trap context) to indicate everything is closed
+        # Since `#start` is blocking, we were get here only after the runner is done. This will
+        # not add any performance degradation because of that.
         Thread.pass until Karafka::App.stopped?
       # Try its best to shutdown underlying components before re-raising
       # rubocop:disable Lint/RescueException

--- a/lib/karafka/server.rb
+++ b/lib/karafka/server.rb
@@ -15,7 +15,7 @@ module Karafka
 
     class << self
       # Set of consuming threads. Each consumer thread contains a single consumer
-      attr_accessor :consumer_threads
+      attr_accessor :listeners
 
       # Set of workers
       attr_accessor :workers
@@ -25,9 +25,12 @@ module Karafka
 
       # Method which runs app
       def run
-        process.on_sigint { stop }
-        process.on_sigquit { stop }
-        process.on_sigterm { stop }
+        # Since we do a lot of threading and queuing, we don't want to stop from the trap context
+        # as some things may not work there as expected, that is why we spawn a separate thread to
+        # handle the stopping process
+        process.on_sigint { Thread.new { stop } }
+        process.on_sigquit { Thread.new { stop } }
+        process.on_sigterm { Thread.new { stop } }
 
         # Start is blocking until stop is called and when we stop, it will wait until
         # all of the things are ready to stop
@@ -70,16 +73,16 @@ module Karafka
       def stop
         Karafka::App.stop!
 
-        timeout = Thread.new { Karafka::App.config.shutdown_timeout }.join.value
+        timeout = Karafka::App.config.shutdown_timeout
 
         # We check from time to time (for the timeout period) if all the threads finished
         # their work and if so, we can just return and normal shutdown process will take place
         # We divide it by 1000 because we use time in ms.
         ((timeout / 1_000) * SUPERVISION_CHECK_FACTOR).to_i.times do
-          if consumer_threads.count(&:alive?).zero? &&
+          if listeners.count(&:alive?).zero? &&
              workers.count(&:alive?).zero?
 
-            Thread.new { Karafka::App.producer.close }.join
+            Karafka::App.producer.close
 
             return
           end
@@ -89,22 +92,18 @@ module Karafka
 
         raise Errors::ForcefulShutdownError
       rescue Errors::ForcefulShutdownError => e
-        thread = Thread.new do
-          Karafka.monitor.instrument(
-            'error.occurred',
-            caller: self,
-            error: e,
-            type: 'app.stopping.error'
-          )
+        Karafka.monitor.instrument(
+          'error.occurred',
+          caller: self,
+          error: e,
+          type: 'app.stopping.error'
+        )
 
-          # We're done waiting, lets kill them!
-          workers.each(&:terminate)
-          consumer_threads.each(&:terminate)
+        # We're done waiting, lets kill them!
+        workers.each(&:terminate)
+        listeners.each(&:terminate)
 
-          Karafka::App.producer.close
-        end
-
-        thread.join
+        Karafka::App.producer.close
 
         # exit! is not within the instrumentation as it would not trigger due to exit
         Kernel.exit! FORCEFUL_EXIT_CODE

--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -62,11 +62,11 @@ module Karafka
       # options max_messages [Integer] how many messages do we want to fetch from Kafka in one go
       setting :max_messages, default: 1_000
       # option [Integer] number of milliseconds we can wait while fetching data
-      setting :max_wait_time, default: 10_000
+      setting :max_wait_time, default: 1_000
       # option shutdown_timeout [Integer] the number of milliseconds after which Karafka no
       #   longer waits for the consumers to stop gracefully but instead we force terminate
       #   everything.
-      setting :shutdown_timeout, default: 60_000
+      setting :shutdown_timeout, default: 10_000
       # option [Integer] number of threads in which we want to do parallel processing
       setting :concurrency, default: 5
       # option [Integer] how long should we wait upon processing error

--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -62,11 +62,11 @@ module Karafka
       # options max_messages [Integer] how many messages do we want to fetch from Kafka in one go
       setting :max_messages, default: 1_000
       # option [Integer] number of milliseconds we can wait while fetching data
-      setting :max_wait_time, default: 1_000
+      setting :max_wait_time, default: 10_000
       # option shutdown_timeout [Integer] the number of milliseconds after which Karafka no
       #   longer waits for the consumers to stop gracefully but instead we force terminate
       #   everything.
-      setting :shutdown_timeout, default: 10_000
+      setting :shutdown_timeout, default: 30_000
       # option [Integer] number of threads in which we want to do parallel processing
       setting :concurrency, default: 5
       # option [Integer] how long should we wait upon processing error

--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -66,7 +66,7 @@ module Karafka
       # option shutdown_timeout [Integer] the number of milliseconds after which Karafka no
       #   longer waits for the consumers to stop gracefully but instead we force terminate
       #   everything.
-      setting :shutdown_timeout, default: 30_000
+      setting :shutdown_timeout, default: 60_000
       # option [Integer] number of threads in which we want to do parallel processing
       setting :concurrency, default: 5
       # option [Integer] how long should we wait upon processing error

--- a/spec/integrations/shutdown/shutdown_jobs_threads_processing.rb
+++ b/spec/integrations/shutdown/shutdown_jobs_threads_processing.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Karafka shutdown jobs should run in workers threads, not form the fetcher thread
+
+setup_karafka do |config|
+  # This will ensure all work runs from one worker thread
+  config.concurrency = 1
+end
+
+# This will allow us to establish the listener thread id. Shutdown jobs should run from the
+# worker threads
+Karafka::App.monitor.subscribe('connection.listener.before_fetch_loop') do |event|
+  DataCollector.data[:listener_thread_id] = Thread.current.object_id
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DataCollector.data[:worker_thread_id] = Thread.current.object_id
+  end
+
+  def on_shutdown
+    DataCollector.data[:shutdown_thread_id] = Thread.current.object_id
+  end
+end
+
+draw_routes(Consumer)
+
+produce(DataCollector.topic, '1')
+
+start_karafka_and_wait_until do
+  DataCollector.data.key?(:worker_thread_id)
+end
+
+assert_equal true, DataCollector.data.key?(:listener_thread_id)
+assert_equal true, DataCollector.data.key?(:worker_thread_id)
+assert_equal true, DataCollector.data.key?(:shutdown_thread_id)
+assert_equal true, DataCollector.data[:listener_thread_id] != DataCollector.data[:worker_thread_id]
+assert_equal DataCollector.data[:worker_thread_id], DataCollector.data[:shutdown_thread_id]

--- a/spec/integrations/shutdown/shutdown_jobs_threads_processing.rb
+++ b/spec/integrations/shutdown/shutdown_jobs_threads_processing.rb
@@ -9,7 +9,7 @@ end
 
 # This will allow us to establish the listener thread id. Shutdown jobs should run from the
 # worker threads
-Karafka::App.monitor.subscribe('connection.listener.before_fetch_loop') do |event|
+Karafka::App.monitor.subscribe('connection.listener.before_fetch_loop') do
   DataCollector.data[:listener_thread_id] = Thread.current.object_id
 end
 

--- a/spec/lib/karafka/connection/listeners_batch_spec.rb
+++ b/spec/lib/karafka/connection/listeners_batch_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  pending
+end

--- a/spec/lib/karafka/connection/listeners_batch_spec.rb
+++ b/spec/lib/karafka/connection/listeners_batch_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe_current do
     end
 
     it 'expect to yield each listener' do
-      batch.each do |listener|
-        expect(listener).to be_a(Karafka::Connection::Listener)
-      end
+      expect(batch).to all be_a(Karafka::Connection::Listener)
     end
   end
 end

--- a/spec/lib/karafka/connection/listeners_batch_spec.rb
+++ b/spec/lib/karafka/connection/listeners_batch_spec.rb
@@ -1,5 +1,20 @@
 # frozen_string_literal: true
 
 RSpec.describe_current do
-  pending
+  subject(:batch) { described_class.new(jobs_queue) }
+
+  let(:jobs_queue) { Karafka::Processing::JobsQueue.new }
+  let(:subscription_group) { build(:routing_subscription_group) }
+
+  describe '#each' do
+    before do
+      allow(Karafka::App).to receive(:subscription_groups).and_return([subscription_group])
+    end
+
+    it 'expect to yield each listener' do
+      batch.each do |listener|
+        expect(listener).to be_a(Karafka::Connection::Listener)
+      end
+    end
+  end
 end

--- a/spec/lib/karafka/helpers/async_spec.rb
+++ b/spec/lib/karafka/helpers/async_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  pending
+end

--- a/spec/lib/karafka/helpers/async_spec.rb
+++ b/spec/lib/karafka/helpers/async_spec.rb
@@ -1,5 +1,25 @@
 # frozen_string_literal: true
 
 RSpec.describe_current do
-  pending
+  describe '#async_call' do
+    subject(:async_executor) do
+      Class.new do
+        include ::Karafka::Helpers::Async
+
+        attr_reader :thread_id
+
+        def call
+          @thread_id = Thread.current.object_id
+        end
+      end.new
+    end
+
+    # The easiest way to check it is to run the code and save object id
+    it 'expect to run call async' do
+      async_executor.async_call
+      async_executor.join
+
+      expect(async_executor.thread_id).not_to eq(Thread.current.object_id)
+    end
+  end
 end

--- a/spec/lib/karafka/pro/scheduler_spec.rb
+++ b/spec/lib/karafka/pro/scheduler_spec.rb
@@ -4,64 +4,63 @@ require 'karafka/pro/performance_tracker'
 require 'karafka/pro/scheduler'
 
 RSpec.describe_current do
-  subject(:scheduled_order) do
-    scheduler = Karafka::Pro::Scheduler.new
-    ordered = []
+  let(:queue) { [] }
 
-    scheduler.call(jobs_array) do |job|
-      ordered << job
+  describe '#schedule_consumption' do
+    subject(:schedule) { described_class.new.schedule_consumption(queue, jobs_array) }
+
+    4.times { |i| let("message#{i}") { build(:messages_message) } }
+
+    let(:tracker) { Karafka::Pro::PerformanceTracker.instance }
+    let(:jobs_array) { [] }
+
+    context 'when there are no metrics on any of the topics data' do
+      before do
+        4.times do |i|
+          jobs_array << Karafka::Processing::Jobs::Consume.new(nil, [public_send("message#{i}")])
+        end
+
+        schedule
+      end
+
+      # @note This is an edge case for first batch. After that we will get measurements, so we don't
+      #   have to worry. "Ignoring" this non-optimal first case simplifies the codebase
+      it { expect(queue[0]).to eq(jobs_array[3]) }
+      it { expect(queue[1]).to eq(jobs_array[2]) }
+      it { expect(queue[2]).to eq(jobs_array[1]) }
+      it { expect(queue[3]).to eq(jobs_array[0]) }
     end
 
-    ordered
-  end
+    context 'when metrics on the computation cost for messages from topics are present' do
+      times = [5, 20, 7, 100]
 
-  4.times { |i| let("message#{i}") { build(:messages_message) } }
-
-  let(:tracker) { Karafka::Pro::PerformanceTracker.instance }
-  let(:jobs_array) { [] }
-
-  context 'when there are no metrics on any of the topics data' do
-    before do
       4.times do |i|
-        jobs_array << Karafka::Processing::Jobs::Consume.new(nil, [public_send("message#{i}")])
+        let("messages#{i}") do
+          OpenStruct.new(metadata: public_send("message#{i}").metadata, count: 1)
+        end
+
+        let("payload#{i}") do
+          { caller: OpenStruct.new(messages: public_send("messages#{i}")), time: times[i] }
+        end
+
+        let("event#{i}") do
+          Dry::Events::Event.new(rand.to_s, public_send("payload#{i}"))
+        end
       end
+
+      before do
+        4.times do |i|
+          jobs_array << Karafka::Processing::Jobs::Consume.new(nil, [public_send("message#{i}")])
+          tracker.on_consumer_consumed(public_send("event#{i}"))
+        end
+
+        schedule
+      end
+
+      it { expect(queue[0]).to eq(jobs_array[3]) }
+      it { expect(queue[1]).to eq(jobs_array[1]) }
+      it { expect(queue[2]).to eq(jobs_array[2]) }
+      it { expect(queue[3]).to eq(jobs_array[0]) }
     end
-
-    # @note This is an edge case for first batch. After that we will get measurements, so we don't
-    #   have to worry. "Ignoring" this non-optimal first case simplifies the codebase
-    it { expect(scheduled_order[0]).to eq(jobs_array[3]) }
-    it { expect(scheduled_order[1]).to eq(jobs_array[2]) }
-    it { expect(scheduled_order[2]).to eq(jobs_array[1]) }
-    it { expect(scheduled_order[3]).to eq(jobs_array[0]) }
-  end
-
-  context 'when metrics on the computation cost for messages from topics are present' do
-    times = [5, 20, 7, 100]
-
-    4.times do |i|
-      let("messages#{i}") do
-        OpenStruct.new(metadata: public_send("message#{i}").metadata, count: 1)
-      end
-
-      let("payload#{i}") do
-        { caller: OpenStruct.new(messages: public_send("messages#{i}")), time: times[i] }
-      end
-
-      let("event#{i}") do
-        Dry::Events::Event.new(rand.to_s, public_send("payload#{i}"))
-      end
-    end
-
-    before do
-      4.times do |i|
-        jobs_array << Karafka::Processing::Jobs::Consume.new(nil, [public_send("message#{i}")])
-        tracker.on_consumer_consumed(public_send("event#{i}"))
-      end
-    end
-
-    it { expect(scheduled_order[0]).to eq(jobs_array[3]) }
-    it { expect(scheduled_order[1]).to eq(jobs_array[1]) }
-    it { expect(scheduled_order[2]).to eq(jobs_array[2]) }
-    it { expect(scheduled_order[3]).to eq(jobs_array[0]) }
   end
 end

--- a/spec/lib/karafka/processing/executors_buffer_spec.rb
+++ b/spec/lib/karafka/processing/executors_buffer_spec.rb
@@ -42,18 +42,20 @@ RSpec.describe_current do
     end
   end
 
-  describe '#shutdown' do
-    context 'when there is nothing in the buffer' do
-      it { expect { buffer.shutdown }.not_to raise_error }
+  describe '#each' do
+    context 'when there are no executors' do
+      it 'expect not to yield anything' do
+        expect { |block| buffer.each(&block) }.not_to yield_control
+      end
     end
 
-    context 'when there are executors in the buffer' do
-      before do
-        allow(fetched_executor).to receive(:shutdown)
-        buffer.shutdown
-      end
+    context 'when there are executors' do
+      before { fetched_executor }
 
-      it { expect(fetched_executor).to have_received(:shutdown) }
+      it 'expect to yield with executor from this topic partition' do
+        expect { |block| buffer.each(&block) }
+          .to yield_with_args(consumer_groups.first.topics.first, partition_id, fetched_executor)
+      end
     end
   end
 

--- a/spec/lib/karafka/processing/jobs_queue_spec.rb
+++ b/spec/lib/karafka/processing/jobs_queue_spec.rb
@@ -214,4 +214,8 @@ RSpec.describe_current do
       it { expect(queue.size).to eq(2) }
     end
   end
+
+  describe '#empty?' do
+    pending
+  end
 end

--- a/spec/lib/karafka/processing/jobs_queue_spec.rb
+++ b/spec/lib/karafka/processing/jobs_queue_spec.rb
@@ -108,9 +108,8 @@ RSpec.describe_current do
 
       it 'expect to pass until no longer needing to wait' do
         Thread.new do
-          # We need to close it in order to unlock
           sleep(0.01)
-          queue.close
+          queue.complete(job1)
         end
 
         queue.wait(job1.group_id)
@@ -122,14 +121,13 @@ RSpec.describe_current do
         queue << job1
 
         Thread.new do
-          # We need to close it in order to unlock
           sleep(0.1)
           10.times { queue.tick(job1.group_id) }
         end
 
         Thread.new do
           sleep(1)
-          queue.close
+          queue.complete(job1)
         end
       end
 
@@ -165,9 +163,8 @@ RSpec.describe_current do
 
       it 'expect to wait' do
         Thread.new do
-          # We need to close it in order to unlock
           sleep(0.01)
-          queue.close
+          queue.complete(job1)
         end
 
         queue.wait(job1.group_id)

--- a/spec/lib/karafka/processing/jobs_queue_spec.rb
+++ b/spec/lib/karafka/processing/jobs_queue_spec.rb
@@ -216,6 +216,22 @@ RSpec.describe_current do
   end
 
   describe '#empty?' do
-    pending
+    let(:job) { OpenStruct.new(group_id: 1, id: 1, call: true) }
+
+    context 'when there are no jobs at all' do
+      it { expect(queue.empty?(1)).to eq(true) }
+    end
+
+    context 'when there are jobs from a different subscription group' do
+      before { queue << job }
+
+      it { expect(queue.empty?(2)).to eq(true) }
+    end
+
+    context 'when there are jobs from our subscription group' do
+      before { queue << job }
+
+      it { expect(queue.empty?(job.group_id)).to eq(false) }
+    end
   end
 end

--- a/spec/lib/karafka/processing/worker_spec.rb
+++ b/spec/lib/karafka/processing/worker_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe_current do
-  subject(:worker) { described_class.new(queue) }
+  subject(:worker) { described_class.new(queue).tap(&:async_call) }
 
   let(:queue) { Karafka::Processing::JobsQueue.new }
 

--- a/spec/lib/karafka/processing/workers_batch_spec.rb
+++ b/spec/lib/karafka/processing/workers_batch_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe_current do
 
   context 'when creating workers batch' do
     let(:concurrency) { Karafka::App.config.concurrency }
-    let(:thread_count) { -> { Thread.list.size } }
 
-    it { expect { described_class.new(jobs_queue) }.to change(&thread_count).by(concurrency) }
+    it { expect(described_class.new(jobs_queue).size).to eq(concurrency) }
   end
 end

--- a/spec/lib/karafka/runner_spec.rb
+++ b/spec/lib/karafka/runner_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe_current do
     context 'when everything is ok' do
       let(:listeners) { [listener] }
       let(:async_scope) { listener }
-      let(:listener) { instance_double(Karafka::Connection::Listener, call: nil) }
+      let(:listener) { instance_double(Karafka::Connection::Listener, async_call: nil, join: nil) }
 
       before do
-        allow(runner)
-          .to receive(:listeners)
+        allow(Karafka::Connection::ListenersBatch)
+          .to receive(:new)
           .and_return(listeners)
       end
 

--- a/spec/lib/karafka/runner_spec.rb
+++ b/spec/lib/karafka/runner_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe_current do
       end
 
       before do
-        allow(runner).to receive(:listeners).and_raise(error)
+        allow(Karafka::Processing::JobsQueue).to receive(:new).and_raise(error)
         allow(Karafka::App).to receive(:stop!)
         allow(Karafka.monitor).to receive(:instrument)
       end
@@ -45,23 +45,5 @@ RSpec.describe_current do
         expect(Karafka::App).to have_received(:stop!).with(no_args)
       end
     end
-  end
-
-  describe '#listeners' do
-    let(:jobs_queue) { Karafka::Processing::JobsQueue.new }
-    let(:subscription_group) { build(:routing_subscription_group) }
-    let(:subscription_groups) { [subscription_group] }
-
-    before do
-      allow(Karafka::App)
-        .to receive(:subscription_groups)
-        .and_return(subscription_groups)
-
-      allow(Karafka::Connection::Listener)
-        .to receive(:new)
-        .with(subscription_group, jobs_queue)
-    end
-
-    it { expect(runner.send(:listeners, jobs_queue)).to be_a(Array) }
   end
 end

--- a/spec/lib/karafka/scheduler_spec.rb
+++ b/spec/lib/karafka/scheduler_spec.rb
@@ -3,34 +3,33 @@
 RSpec.describe_current do
   subject(:scheduler) { described_class.new }
 
-  let(:jobs_array) { [] }
+  describe '#schedule_consumption' do
+    subject(:schedule) { scheduler.schedule_consumption(queue, jobs_array) }
 
-  context 'when there are no messages' do
-    it { expect { |block| scheduler.call(jobs_array, &block) }.not_to yield_control }
-  end
+    let(:queue) { [] }
+    let(:jobs_array) { [] }
 
-  context 'when there are jobs' do
-    let(:jobs_array) do
-      [
-        Karafka::Processing::Jobs::Consume.new(nil, []),
-        Karafka::Processing::Jobs::Consume.new(nil, []),
-        Karafka::Processing::Jobs::Consume.new(nil, []),
-        Karafka::Processing::Jobs::Consume.new(nil, [])
-      ]
+    context 'when there are no messages' do
+      it 'expect not to schedule anything' do
+        schedule
+        expect(queue).to be_empty
+      end
     end
 
-    let(:yielded) do
-      data = []
-
-      scheduler.call(jobs_array) do |job|
-        data << job
+    context 'when there are jobs' do
+      let(:jobs_array) do
+        [
+          Karafka::Processing::Jobs::Consume.new(nil, []),
+          Karafka::Processing::Jobs::Consume.new(nil, []),
+          Karafka::Processing::Jobs::Consume.new(nil, []),
+          Karafka::Processing::Jobs::Consume.new(nil, [])
+        ]
       end
 
-      data
-    end
-
-    it 'expect to yield them in the fifo order' do
-      expect(yielded).to eq(jobs_array)
+      it 'expect to schedule in the fifo order' do
+        schedule
+        expect(queue).to eq(jobs_array)
+      end
     end
   end
 end

--- a/spec/lib/karafka/server_spec.rb
+++ b/spec/lib/karafka/server_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe_current do
     allow(Karafka::App).to receive(:stopped?).and_return(true)
     allow(Karafka::Runner).to receive(:new).and_return(runner)
     allow(runner).to receive(:call)
-    described_class.consumer_threads = []
+    described_class.listeners = []
     described_class.workers = []
   end
 
@@ -87,7 +87,7 @@ RSpec.describe_current do
 
     after do
       server_class.stop
-      described_class.consumer_threads.clear
+      described_class.listeners.clear
       described_class.workers = []
       # After shutdown we need to reinitialize the app for other specs
       Karafka::App.initialize!
@@ -106,7 +106,7 @@ RSpec.describe_current do
       context 'when there are no active threads (all shutdown ok)' do
         before do
           server_class.stop
-          described_class.consumer_threads.clear
+          described_class.listeners.clear
         end
 
         it 'expect stop without exit or sleep' do
@@ -120,9 +120,9 @@ RSpec.describe_current do
         let(:active_thread) { instance_double(Thread, alive?: true, terminate: true, join: true) }
 
         before do
-          described_class.consumer_threads = [active_thread]
+          described_class.listeners = [active_thread]
           server_class.stop
-          described_class.consumer_threads.clear
+          described_class.listeners.clear
         end
 
         it 'expect stop and exit with sleep' do

--- a/spec/lib/karafka/server_spec.rb
+++ b/spec/lib/karafka/server_spec.rb
@@ -16,7 +16,11 @@ RSpec.describe_current do
   end
 
   describe '#run' do
-    after { server_class.run }
+    after do
+      server_class.run
+      # Since stopping happens in a separate thread, we need to wait
+      sleep(0.5)
+    end
 
     context 'when we want to run in supervision' do
       it 'runs in supervision, start consuming' do


### PR DESCRIPTION
This PR moves the queue closing process to the runner. That way:

- we do not attempt to close jobs queue from multiple listeners (in the multi-consumer group scenario)
- we ensure that all the work in listeners is done so no new jobs will be enqueued
- we ensure that we will not reach `max.poll.timeout` for non-blocking jobs that are running during shutdown

It also:
- Moves shutdown supervision to a separate thread not to run it in a trap context
- Makes listeners self-sufficient like workers
- Makes the runner only run the code not do stuff with threads
- Introduces the notion of ListenersBatch similar WorkersBatch to abstract the design better
- aligns some internal naming conventions

**No** external apis are changed.
