### PR TITLE
Move all jobs scheduling to schedulers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `Shutdown` jobs are always blocking.
 - Notion of `ListenersBatch` was introduced similar to `WorkersBatch` to abstract this concept.
 - Change default `shutdown_timeout` to be more than `max_wait_time` not to cause forced shutdown when no messages are being received from Kafka.
+- Abstract away scheduling of revocation and shutdown jobs for both default and pro schedulers
 
 ## 2.0.0-beta1 (2022-05-22)
 - Update the jobs queue blocking engine and allow for non-blocking jobs execution

--- a/lib/karafka/scheduler.rb
+++ b/lib/karafka/scheduler.rb
@@ -3,12 +3,18 @@
 module Karafka
   # FIFO scheduler for messages coming from various topics and partitions
   class Scheduler
-    # Yields jobs in the fifo order
+    # Schedules jobs in the fifo order
     #
+    # @param queue [Karafka::Processing::JobsQueue] queue where we want to put the jobs
     # @param jobs_array [Array<Karafka::Processing::Jobs::Base>] jobs we want to schedule
-    # @yieldparam [Karafka::Processing::Jobs::Base] job we want to enqueue
-    def call(jobs_array, &block)
-      jobs_array.each(&block)
+    def schedule_consumption(queue, jobs_array)
+      jobs_array.each do |job|
+        queue << job
+      end
     end
+
+    # Both revocation and shutdown jobs can also run in fifo by default
+    alias schedule_revocation schedule_consumption
+    alias schedule_shutdown schedule_consumption
   end
 end

--- a/spec/lib/karafka/pro/scheduler_spec.rb
+++ b/spec/lib/karafka/pro/scheduler_spec.rb
@@ -4,64 +4,63 @@ require 'karafka/pro/performance_tracker'
 require 'karafka/pro/scheduler'
 
 RSpec.describe_current do
-  subject(:scheduled_order) do
-    scheduler = Karafka::Pro::Scheduler.new
-    ordered = []
+  let(:queue) { [] }
 
-    scheduler.call(jobs_array) do |job|
-      ordered << job
+  describe '#schedule_consumption' do
+    subject(:schedule) { described_class.new.schedule_consumption(queue, jobs_array) }
+
+    4.times { |i| let("message#{i}") { build(:messages_message) } }
+
+    let(:tracker) { Karafka::Pro::PerformanceTracker.instance }
+    let(:jobs_array) { [] }
+
+    context 'when there are no metrics on any of the topics data' do
+      before do
+        4.times do |i|
+          jobs_array << Karafka::Processing::Jobs::Consume.new(nil, [public_send("message#{i}")])
+        end
+
+        schedule
+      end
+
+      # @note This is an edge case for first batch. After that we will get measurements, so we don't
+      #   have to worry. "Ignoring" this non-optimal first case simplifies the codebase
+      it { expect(queue[0]).to eq(jobs_array[3]) }
+      it { expect(queue[1]).to eq(jobs_array[2]) }
+      it { expect(queue[2]).to eq(jobs_array[1]) }
+      it { expect(queue[3]).to eq(jobs_array[0]) }
     end
 
-    ordered
-  end
+    context 'when metrics on the computation cost for messages from topics are present' do
+      times = [5, 20, 7, 100]
 
-  4.times { |i| let("message#{i}") { build(:messages_message) } }
-
-  let(:tracker) { Karafka::Pro::PerformanceTracker.instance }
-  let(:jobs_array) { [] }
-
-  context 'when there are no metrics on any of the topics data' do
-    before do
       4.times do |i|
-        jobs_array << Karafka::Processing::Jobs::Consume.new(nil, [public_send("message#{i}")])
+        let("messages#{i}") do
+          OpenStruct.new(metadata: public_send("message#{i}").metadata, count: 1)
+        end
+
+        let("payload#{i}") do
+          { caller: OpenStruct.new(messages: public_send("messages#{i}")), time: times[i] }
+        end
+
+        let("event#{i}") do
+          Dry::Events::Event.new(rand.to_s, public_send("payload#{i}"))
+        end
       end
+
+      before do
+        4.times do |i|
+          jobs_array << Karafka::Processing::Jobs::Consume.new(nil, [public_send("message#{i}")])
+          tracker.on_consumer_consumed(public_send("event#{i}"))
+        end
+
+        schedule
+      end
+
+      it { expect(queue[0]).to eq(jobs_array[3]) }
+      it { expect(queue[1]).to eq(jobs_array[1]) }
+      it { expect(queue[2]).to eq(jobs_array[2]) }
+      it { expect(queue[3]).to eq(jobs_array[0]) }
     end
-
-    # @note This is an edge case for first batch. After that we will get measurements, so we don't
-    #   have to worry. "Ignoring" this non-optimal first case simplifies the codebase
-    it { expect(scheduled_order[0]).to eq(jobs_array[3]) }
-    it { expect(scheduled_order[1]).to eq(jobs_array[2]) }
-    it { expect(scheduled_order[2]).to eq(jobs_array[1]) }
-    it { expect(scheduled_order[3]).to eq(jobs_array[0]) }
-  end
-
-  context 'when metrics on the computation cost for messages from topics are present' do
-    times = [5, 20, 7, 100]
-
-    4.times do |i|
-      let("messages#{i}") do
-        OpenStruct.new(metadata: public_send("message#{i}").metadata, count: 1)
-      end
-
-      let("payload#{i}") do
-        { caller: OpenStruct.new(messages: public_send("messages#{i}")), time: times[i] }
-      end
-
-      let("event#{i}") do
-        Dry::Events::Event.new(rand.to_s, public_send("payload#{i}"))
-      end
-    end
-
-    before do
-      4.times do |i|
-        jobs_array << Karafka::Processing::Jobs::Consume.new(nil, [public_send("message#{i}")])
-        tracker.on_consumer_consumed(public_send("event#{i}"))
-      end
-    end
-
-    it { expect(scheduled_order[0]).to eq(jobs_array[3]) }
-    it { expect(scheduled_order[1]).to eq(jobs_array[1]) }
-    it { expect(scheduled_order[2]).to eq(jobs_array[2]) }
-    it { expect(scheduled_order[3]).to eq(jobs_array[0]) }
   end
 end

--- a/spec/lib/karafka/scheduler_spec.rb
+++ b/spec/lib/karafka/scheduler_spec.rb
@@ -3,34 +3,33 @@
 RSpec.describe_current do
   subject(:scheduler) { described_class.new }
 
-  let(:jobs_array) { [] }
+  describe '#schedule_consumption' do
+    subject(:schedule) { scheduler.schedule_consumption(queue, jobs_array) }
 
-  context 'when there are no messages' do
-    it { expect { |block| scheduler.call(jobs_array, &block) }.not_to yield_control }
-  end
+    let(:queue) { [] }
+    let(:jobs_array) { [] }
 
-  context 'when there are jobs' do
-    let(:jobs_array) do
-      [
-        Karafka::Processing::Jobs::Consume.new(nil, []),
-        Karafka::Processing::Jobs::Consume.new(nil, []),
-        Karafka::Processing::Jobs::Consume.new(nil, []),
-        Karafka::Processing::Jobs::Consume.new(nil, [])
-      ]
+    context 'when there are no messages' do
+      it 'expect not to schedule anything' do
+        schedule
+        expect(queue).to be_empty
+      end
     end
 
-    let(:yielded) do
-      data = []
-
-      scheduler.call(jobs_array) do |job|
-        data << job
+    context 'when there are jobs' do
+      let(:jobs_array) do
+        [
+          Karafka::Processing::Jobs::Consume.new(nil, []),
+          Karafka::Processing::Jobs::Consume.new(nil, []),
+          Karafka::Processing::Jobs::Consume.new(nil, []),
+          Karafka::Processing::Jobs::Consume.new(nil, [])
+        ]
       end
 
-      data
-    end
-
-    it 'expect to yield them in the fifo order' do
-      expect(yielded).to eq(jobs_array)
+      it 'expect to schedule in the fifo order' do
+        schedule
+        expect(queue).to eq(jobs_array)
+      end
     end
   end
 end


### PR DESCRIPTION
This PR:

- moves away all the jobs scheduling to schedulers removing this semi-layer in between listeners and schedulers, where listeners would actually schedule the jobs
- provides support for shutdown and revocation jobs to be scheduled as well
