### PR TITLE
introduce polling wait for shutdown + specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Abstract away scheduling of revocation and shutdown jobs for both default and pro schedulers
 - Introduce a second (internal) messages buffer to distinguish between raw messages buffer and karafka messages buffer
 - Move messages and their metadata remap process to the listener thread to allow for their inline usage
+- Change how we wait in the shutdown phase, so shutdown jobs can still use Kafka connection even if they run for a longer period of time. This will prevent us from being kicked out from the group early.
+- Introduce validation that ensures, that `shutdown_timeout` is more than `max_wait_time`. This will prevent users from ending up with a config that could lead to frequent forceful shutdowns.
 
 ## 2.0.0-beta1 (2022-05-22)
 - Update the jobs queue blocking engine and allow for non-blocking jobs execution

--- a/lib/karafka/processing/jobs_queue.rb
+++ b/lib/karafka/processing/jobs_queue.rb
@@ -108,8 +108,9 @@ module Karafka
         @in_processing[group_id].empty?
       end
 
-      # Blocks when there are things in the queue in a given group and waits until all the jobs
-      #   from a given group are completed
+      # Blocks when there are things in the queue in a given group and waits until all the blocking
+      #   jobs from a given group are completed
+      #
       # @param group_id [String] id of the group in which jobs we're interested.
       # @note This method is blocking.
       def wait(group_id)

--- a/spec/integrations/rebalancing/without_using_revoked_partition_data.rb
+++ b/spec/integrations/rebalancing/without_using_revoked_partition_data.rb
@@ -15,6 +15,11 @@ setup_karafka do |config|
   config.shutdown_timeout = 50_000
   config.max_messages = 1_000
   config.initial_offset = 'earliest'
+  # Shutdown timeout should be bigger than the max wait as during shutdown we poll as well to be
+  # able to finalize all work and not to loose the assignment
+  # We need to set it that way in this particular spec so we do not force shutdown when we poll
+  # during the shutdown phase
+  config.shutdown_timeout = 60_000
 end
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/shutdown/shutdown_jobs_exceeding_max_poll_interval.rb
+++ b/spec/integrations/shutdown/shutdown_jobs_exceeding_max_poll_interval.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# When Karafka is configured with short 'max.poll.interval.ms', shorter than a shutdown job, it
+# should not matter. Shutdown jobs should not be terminated unless they exceed `shutdown_timeout`
+
+setup_karafka do |config|
+  # We set it here that way not too wait too long on stuff
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+  config.max_wait_time = 1_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DataCollector.data[:received] << true
+  end
+
+  def shutdown
+    # Simulate doing something longer than the poll interval
+    # In case this would block polling, the other consumer will take over the job and raise an
+    # exception
+    sleep(15)
+    DataCollector.data[:done] << true
+  end
+end
+
+draw_routes(Consumer)
+
+Thread.new do
+  loop do
+    produce(DataCollector.topic, '1')
+    sleep(0.5)
+  rescue WaterDrop::Errors::ProducerClosedError
+    break
+  end
+end
+
+# We need a second producer so we are sure that there was no revocation due to a timeout
+config = {
+  'bootstrap.servers': 'localhost:9092',
+  'group.id': Karafka::App.consumer_groups.first.id,
+  'auto.offset.reset': 'earliest'
+}
+consumer = Rdkafka::Config.new(config).consumer
+
+other = Thread.new do
+  sleep(5)
+
+  consumer.subscribe(DataCollector.topic)
+
+  consumer.each do
+    # This should never happen.
+    # We have one partition and it should be karafka that consumes it
+    exit! 5
+  end
+end
+
+Thread.new do
+  sleep(0.1) while DataCollector.data[:done].empty?
+
+  consumer.close
+end
+
+start_karafka_and_wait_until do
+  !DataCollector.data[:received].empty?
+end
+
+other.join


### PR DESCRIPTION
This PR slightly changes how we run shutdown process.

We do an active polling shutdown not to be kicked out from the consumer group. This allows us to have active connection to kafka to finalize anything we would need.

This PR adds also a spec for it.