### PR TITLE
Use PRO ActiveJob consumer in PRO mode

### DIFF
--- a/lib/karafka/pro/active_job/consumer.rb
+++ b/lib/karafka/pro/active_job/consumer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Karafka
+  module Pro
+    module ActiveJob
+      # This Karafka component is a Pro component.
+      # All of the commercial components are present in the lib/karafka/pro directory of this
+      # repository and their usage requires commercial license agreement.
+      #
+      # Karafka has also commercial-friendly license, commercial support and commercial components.
+      #
+      # By sending a pull request to the pro components, you are agreeing to transfer the copyright
+      # of your code to Maciej Mensfeld.
+
+      # Pro ActiveJob consumer that is suppose to handle long-running jobs as well as short
+      # running jobs
+      class Consumer < Karafka::ActiveJob::Consumer
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/active_job/dispatcher.rb
+++ b/lib/karafka/pro/active_job/dispatcher.rb
@@ -18,7 +18,7 @@ module Karafka
       # much better and more granular control over the dispatch and consumption process.
       class Dispatcher < ::Karafka::ActiveJob::Dispatcher
         # Defaults for dispatching
-        # The can be updated by using `#karafka_options` on the job
+        # They can be updated by using `#karafka_options` on the job
         DEFAULTS = {
           dispatch_method: :produce_async,
           # We don't create a dummy proc based partitioner as we would have to evaluate it with

--- a/lib/karafka/pro/loader.rb
+++ b/lib/karafka/pro/loader.rb
@@ -20,10 +20,12 @@ module Karafka
         def setup(config)
           require_relative 'performance_tracker'
           require_relative 'scheduler'
+          require_relative 'active_job/consumer'
           require_relative 'active_job/dispatcher'
           require_relative 'active_job/job_options_contract'
 
           config.internal.scheduler = Scheduler.new
+          config.internal.active_job.consumer = ActiveJob::Consumer
           config.internal.active_job.dispatcher = ActiveJob::Dispatcher.new
           config.internal.active_job.job_options_contract = ActiveJob::JobOptionsContract.new
 

--- a/lib/karafka/pro/loader.rb
+++ b/lib/karafka/pro/loader.rb
@@ -20,6 +20,7 @@ module Karafka
         def setup(config)
           require_relative 'performance_tracker'
           require_relative 'scheduler'
+          require_relative 'processing/jobs/consume_non_blocking'
           require_relative 'active_job/consumer'
           require_relative 'active_job/dispatcher'
           require_relative 'active_job/job_options_contract'

--- a/lib/karafka/pro/processing/jobs/consume_non_blocking.rb
+++ b/lib/karafka/pro/processing/jobs/consume_non_blocking.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Karafka
+  module Pro
+    # Pro components related to processing part of Karafka
+    module Processing
+      # Pro jobs
+      module Jobs
+        # This Karafka component is a Pro component.
+        # All of the commercial components are present in the lib/karafka/pro directory of this
+        # repository and their usage requires commercial license agreement.
+        #
+        # Karafka has also commercial-friendly license, commercial support and commercial
+        # components.
+        #
+        # By sending a pull request to the pro components, you are agreeing to transfer the
+        # copyright of your code to Maciej Mensfeld.
+
+        # The main job type in a non-blocking variant.
+        # This variant works "like" the regular consumption but pauses the partition for as long
+        # as it is needed until a job is done.
+        #
+        # It can be useful when having long lasting jobs that would exceed `max.poll.interval`
+        # if would block.
+        #
+        # @note It needs to be working with a proper consumer that will handle the partition
+        #   management. This layer of the framework knows nothing about Kafka messages consumption.
+        class ConsumeNonBlocking < ::Karafka::Processing::Jobs::Consume
+          # Releases the blocking lock after it is done with the preparation phase for this job
+          def prepare
+            super
+            @non_blocking = true
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/processing/jobs/base.rb
+++ b/lib/karafka/processing/jobs/base.rb
@@ -15,6 +15,13 @@ module Karafka
 
         attr_reader :executor
 
+        # Creates a new job instance
+        def initialize
+          # All jobs are blocking by default and they can release the lock when blocking operations
+          # are done (if needed)
+          @non_blocking = false
+        end
+
         # When redefined can run any code that should run before executing the proper code
         def prepare; end
 
@@ -22,11 +29,16 @@ module Karafka
         def teardown; end
 
         # @return [Boolean] is this a non-blocking job
+        #
         # @note Blocking job is a job, that will cause the job queue to wait until it is finished
         #   before removing the lock on new jobs being added
+        #
         # @note All the jobs are blocking by default
+        #
+        # @note Job **needs** to mark itself as non-blocking only **after** it is done with all
+        #   the blocking things (pausing partition, etc).
         def non_blocking?
-          false
+          @non_blocking
         end
       end
     end

--- a/spec/integrations/pausing/with_manual_pause_and_other_partitions_working.rb
+++ b/spec/integrations/pausing/with_manual_pause_and_other_partitions_working.rb
@@ -42,7 +42,7 @@ end
 draw_routes(Consumer)
 
 Thread.new do
-  sleep(1)
+  sleep(5)
 
   sleep(0.1) while DataCollector.data[:running].empty?
 

--- a/spec/integrations/pro/licensing/configure_with_expired_token.rb
+++ b/spec/integrations/pro/licensing/configure_with_expired_token.rb
@@ -37,6 +37,7 @@ assert_equal true, logs.include?('Please reach us at contact@karafka.io')
 assert_equal true, Karafka.pro?
 
 # We do not want to break systems, so even with expired keys, pro components should be loaded
+assert_equal true, const_visible?('Karafka::Pro::ActiveJob::Consumer')
 assert_equal true, const_visible?('Karafka::Pro::ActiveJob::Dispatcher')
 assert_equal true, const_visible?('Karafka::Pro::ActiveJob::JobOptionsContract')
 assert_equal true, const_visible?('Karafka::Pro::PerformanceTracker')

--- a/spec/integrations/pro/licensing/configure_with_expired_token.rb
+++ b/spec/integrations/pro/licensing/configure_with_expired_token.rb
@@ -37,6 +37,7 @@ assert_equal true, logs.include?('Please reach us at contact@karafka.io')
 assert_equal true, Karafka.pro?
 
 # We do not want to break systems, so even with expired keys, pro components should be loaded
+assert_equal true, const_visible?('Karafka::Pro::Processing::Jobs::ConsumeNonBlocking')
 assert_equal true, const_visible?('Karafka::Pro::ActiveJob::Consumer')
 assert_equal true, const_visible?('Karafka::Pro::ActiveJob::Dispatcher')
 assert_equal true, const_visible?('Karafka::Pro::ActiveJob::JobOptionsContract')

--- a/spec/integrations/pro/licensing/configure_with_invalid_token.rb
+++ b/spec/integrations/pro/licensing/configure_with_invalid_token.rb
@@ -16,6 +16,7 @@ assert_equal true, failed_as_expected
 assert_equal false, Karafka.pro?
 
 # Pro components should not be visible
+assert_equal false, const_visible?('Karafka::Pro::Processing::Jobs::ConsumeNonBlocking')
 assert_equal false, const_visible?('Karafka::Pro::ActiveJob::Consumer')
 assert_equal false, const_visible?('Karafka::Pro::ActiveJob::Dispatcher')
 assert_equal false, const_visible?('Karafka::Pro::ActiveJob::JobOptionsContract')

--- a/spec/integrations/pro/licensing/configure_with_invalid_token.rb
+++ b/spec/integrations/pro/licensing/configure_with_invalid_token.rb
@@ -16,6 +16,7 @@ assert_equal true, failed_as_expected
 assert_equal false, Karafka.pro?
 
 # Pro components should not be visible
+assert_equal false, const_visible?('Karafka::Pro::ActiveJob::Consumer')
 assert_equal false, const_visible?('Karafka::Pro::ActiveJob::Dispatcher')
 assert_equal false, const_visible?('Karafka::Pro::ActiveJob::JobOptionsContract')
 assert_equal false, const_visible?('Karafka::Pro::PerformanceTracker')

--- a/spec/integrations/pro/licensing/configure_with_valid_token.rb
+++ b/spec/integrations/pro/licensing/configure_with_valid_token.rb
@@ -16,6 +16,7 @@ logs = LOGS.read
 assert_equal false, logs.include?('] ERROR -- : Your license expired')
 assert_equal false, logs.include?('Please reach us')
 assert_equal true, Karafka.pro?
+assert_equal true, const_visible?('Karafka::Pro::ActiveJob::Consumer')
 assert_equal true, const_visible?('Karafka::Pro::ActiveJob::Dispatcher')
 assert_equal true, const_visible?('Karafka::Pro::ActiveJob::JobOptionsContract')
 assert_equal true, const_visible?('Karafka::Pro::PerformanceTracker')

--- a/spec/integrations/pro/licensing/configure_with_valid_token.rb
+++ b/spec/integrations/pro/licensing/configure_with_valid_token.rb
@@ -16,6 +16,7 @@ logs = LOGS.read
 assert_equal false, logs.include?('] ERROR -- : Your license expired')
 assert_equal false, logs.include?('Please reach us')
 assert_equal true, Karafka.pro?
+assert_equal true, const_visible?('Karafka::Pro::Processing::Jobs::ConsumeNonBlocking')
 assert_equal true, const_visible?('Karafka::Pro::ActiveJob::Consumer')
 assert_equal true, const_visible?('Karafka::Pro::ActiveJob::Dispatcher')
 assert_equal true, const_visible?('Karafka::Pro::ActiveJob::JobOptionsContract')

--- a/spec/integrations/pro/rails/active_job/async_job_processing.rb
+++ b/spec/integrations/pro/rails/active_job/async_job_processing.rb
@@ -38,6 +38,7 @@ end
 
 aj_config = Karafka::App.config.internal.active_job
 
+assert_equal aj_config.consumer, Karafka::Pro::ActiveJob::Consumer
 assert_equal aj_config.dispatcher.class, Karafka::Pro::ActiveJob::Dispatcher
 assert_equal aj_config.job_options_contract.class, Karafka::Pro::ActiveJob::JobOptionsContract
 assert_equal VALUE1, DataCollector.data[0][0]

--- a/spec/integrations/pro/rails/active_job/sync_job_processing.rb
+++ b/spec/integrations/pro/rails/active_job/sync_job_processing.rb
@@ -38,6 +38,7 @@ end
 
 aj_config = Karafka::App.config.internal.active_job
 
+assert_equal aj_config.consumer, Karafka::Pro::ActiveJob::Consumer
 assert_equal aj_config.dispatcher.class, Karafka::Pro::ActiveJob::Dispatcher
 assert_equal aj_config.job_options_contract.class, Karafka::Pro::ActiveJob::JobOptionsContract
 assert_equal VALUE1, DataCollector.data[0][0]

--- a/spec/lib/karafka/pro/active_job/consumer_spec.rb
+++ b/spec/lib/karafka/pro/active_job/consumer_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'karafka/pro/active_job/consumer'
+
+RSpec.describe_current do
+  it { expect(described_class).to be < Karafka::ActiveJob::Consumer }
+end

--- a/spec/lib/karafka/pro/processing/jobs/consume_non_blocking_spec.rb
+++ b/spec/lib/karafka/pro/processing/jobs/consume_non_blocking_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'karafka/pro/processing/jobs/consume_non_blocking'
+
+RSpec.describe_current do
+  subject(:job) { described_class.new(executor, messages) }
+
+  let(:executor) { build(:processing_executor) }
+  let(:messages) { [rand] }
+  let(:time_now) { Time.now }
+
+  it { expect(job.non_blocking?).to eq(false) }
+  it { expect(described_class).to be < ::Karafka::Processing::Jobs::Consume }
+
+  describe '#prepare' do
+    before do
+      allow(Time).to receive(:now).and_return(time_now)
+      allow(executor).to receive(:prepare)
+    end
+
+    it 'expect to run prepare on the executor with time and messages' do
+      job.prepare
+      expect(executor).to have_received(:prepare).with(messages, time_now)
+    end
+
+    it 'expect to mark this job as non blocking after it is done with preparation' do
+      expect { job.prepare }.to change(job, :non_blocking?).from(false).to(true)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds pro activejob consumer. For now it does not provide any extra functionalities but it is needed for further development.

it also adds a non-blocking consumption job type for future usage.