### PR TITLE
pausing with message skip and seeking during pause

### DIFF
--- a/spec/integrations/pausing/pausing_with_message_skip.rb
+++ b/spec/integrations/pausing/pausing_with_message_skip.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 # We should be able to pause the partition in a way that would allow us to skip a message. This
-# is not something you want to do in production, nonetheless usecase like this should be supported.
+# is not something you want to do in production, nonetheless use-case like this should be
+# supported.
 
 setup_karafka do |config|
   config.max_messages = 5

--- a/spec/integrations/pausing/pausing_with_message_skip.rb
+++ b/spec/integrations/pausing/pausing_with_message_skip.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# We should be able to pause the partition in a way that would allow us to skip a message. This
+# is not something you want to do in production, nonetheless usecase like this should be supported.
+
+setup_karafka do |config|
+  config.max_messages = 5
+  config.pause_timeout = 2_000
+  config.pause_max_timeout = 10_000
+  config.pause_with_exponential_backoff = true
+  config.manual_offset_management = true
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    unless @paused
+      @paused = true
+      # Skip one from the next batch
+      pause(messages.last.offset + 2)
+      DataCollector.data[:skipped] = messages.last.offset + 1
+    end
+
+    messages.each do |message|
+      DataCollector.data[:messages] << message.offset
+    end
+  end
+end
+
+draw_routes(Consumer)
+
+20.times { |i| produce(DataCollector.topic, i.to_s) }
+
+start_karafka_and_wait_until do
+  DataCollector.data[:messages].size >= 19
+end
+
+assert_equal 19, DataCollector.data[:messages].size
+# This message should have been skipped when pausing
+assert_equal false, DataCollector.data[:messages].include?(DataCollector.data[:skipped])

--- a/spec/integrations/pausing/seeking_offset_after_pausing.rb
+++ b/spec/integrations/pausing/seeking_offset_after_pausing.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# After we pause and continue processing, we should be able to seek to previous offset and after
+# un-pausing, we should be able to start from where we wanted (not from where we paused)
+
+setup_karafka do |config|
+  config.max_messages = 5
+  config.pause_timeout = 2_000
+  config.pause_max_timeout = 10_000
+  config.pause_with_exponential_backoff = true
+  config.manual_offset_management = true
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    @first_message ||= messages.first
+
+    unless @paused
+      @paused = true
+      # Skip one from the next batch
+      pause(messages.last.offset + 5)
+      sleep 1
+      seek(@first_message.offset)
+    end
+
+    messages.each do |message|
+      DataCollector.data[:messages] << message.offset
+    end
+  end
+end
+
+draw_routes(Consumer)
+
+20.times { |i| produce(DataCollector.topic, i.to_s) }
+
+start_karafka_and_wait_until do
+  DataCollector.data[:messages].size >= 19
+end
+
+assert_equal 25, DataCollector.data[:messages].size
+assert_equal 20, DataCollector.data[:messages].uniq.size


### PR DESCRIPTION
This PR adds two additional cases for integration specs that ensure we can run certain operations during pause.