### PR TITLE
Improve logger listener and introduce workers related notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - Introduce extra integration specs for various ActiveJob usage scenarios
 - Rename consumer method `#prepared` to `#prepare` to reflect better its use-case
 - For test and dev raise an error when expired license key is used (never for non dev)
+- Add worker related monitor events (`worker.process` and `worker.processed`)
+- Update `LoggerListener` to include more useful information about processing and polling messages
 
 ## 2.0.0-beta2 (2022-06-07)
 - Abstract away notion of topics groups (until now it was just an array)

--- a/lib/karafka/instrumentation/monitor.rb
+++ b/lib/karafka/instrumentation/monitor.rb
@@ -33,6 +33,9 @@ module Karafka
         connection.listener.fetch_loop
         connection.listener.fetch_loop.received
 
+        worker.process
+        worker.processed
+
         statistics.emitted
 
         error.occurred

--- a/spec/lib/karafka/instrumentation/logger_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/logger_listener_spec.rb
@@ -19,8 +19,9 @@ RSpec.describe_current do
   describe '#on_connection_listener_fetch_loop' do
     subject(:trigger) { listener.on_connection_listener_fetch_loop(event) }
 
-    let(:payload) { { caller: caller } }
-    let(:message) { 'Receiving new messages from Kafka...' }
+    let(:connection_listener) { instance_double(Karafka::Connection::Listener, id: 'id') }
+    let(:payload) { { caller: connection_listener, time: 2 } }
+    let(:message) { '[id] Polling messages...' }
 
     it 'expect logger to log proper message' do
       expect(Karafka.logger).to have_received(:info).with(message)
@@ -30,8 +31,9 @@ RSpec.describe_current do
   describe '#on_connection_listener_fetch_loop_received' do
     subject(:trigger) { listener.on_connection_listener_fetch_loop_received(event) }
 
-    let(:payload) { { caller: caller, messages_buffer: Array.new(5) } }
-    let(:message) { 'Received 5 new messages from Kafka' }
+    let(:connection_listener) { instance_double(Karafka::Connection::Listener, id: 'id') }
+    let(:payload) { { caller: connection_listener, messages_buffer: Array.new(5), time: 2 } }
+    let(:message) { '[id] Polled 5 messages in 2ms' }
 
     it 'expect logger to log proper message' do
       expect(Karafka.logger).to have_received(:info).with(message)

--- a/spec/lib/karafka/instrumentation/logger_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/logger_listener_spec.rb
@@ -40,6 +40,26 @@ RSpec.describe_current do
     end
   end
 
+  describe '#on_worker_process' do
+    subject(:trigger) { listener.on_worker_process(event) }
+
+    let(:job) { ::Karafka::Processing::Jobs::Shutdown.new(executor) }
+    let(:executor) { build(:processing_executor) }
+    let(:payload) { { job: job } }
+
+    it { expect(Karafka.logger).to have_received(:info) }
+  end
+
+  describe '#on_worker_processed' do
+    subject(:trigger) { listener.on_worker_processed(event) }
+
+    let(:job) { ::Karafka::Processing::Jobs::Shutdown.new(executor) }
+    let(:executor) { build(:processing_executor) }
+    let(:payload) { { job: job, time: 2 } }
+
+    it { expect(Karafka.logger).to have_received(:info) }
+  end
+
   describe '#on_process_notice_signal' do
     subject(:trigger) { listener.on_process_notice_signal(event) }
 


### PR DESCRIPTION
This PR improves the logger listener and introduces basic worker job processing related notifications.

They look much better now:

```
I, [timestamp]  INFO -- : [fa5110b8ce54] Consume job for Consumer on 423902f0ab78 started
I, [timestamp]  INFO -- : [019a1adb4686] Consume job for Consumer on 4f63a8fa8689 started
I, [timestamp]  INFO -- : [4f589b9420ee] Consume job for Consumer on 45bc0010a12f started
I, [timestamp]  INFO -- : [f943b327d13b] Consume job for Consumer on 45bc0010a12f finished in 100ms
I, [timestamp]  INFO -- : [4e80018b600f] Consume job for Consumer on 423902f0ab78 finished in 101ms
I, [timestamp]  INFO -- : [0c8bd915f7f4] Consume job for Consumer on 4f63a8fa8689 finished in 100ms
```