### PR TITLE
Rename job, executor and consumer internal methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka framework changelog
 
+## 2.0.0-beta4 (Unreleased)
+- Rename job internal api methods from `#prepare` to `#before_call` and from `#teardown` to `#after_call` to abstract away jobs execution from any type of executors and consumers logic
+
 ## 2.0.0-beta3 (2022-06-14)
 - Jobs building responsibility extracted out of the listener code base.
 - Fix a case where specs supervisor would try to kill no longer running process (#868)

--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -21,9 +21,9 @@ module Karafka
     # @note This should not be used by the end users as it is part of the lifecycle of things but
     #   not as part of the public api. This can act as a hook when creating non-blocking
     #   consumers and doing other advanced stuff
-    def on_prepare
-      Karafka.monitor.instrument('consumer.prepared', caller: self) do
-        prepare
+    def on_before_consume
+      Karafka.monitor.instrument('consumer.before_consumed', caller: self) do
+        before_consume
       end
 
       true
@@ -32,7 +32,7 @@ module Karafka
         'error.occurred',
         error: e,
         caller: self,
-        type: 'consumer.prepare.error'
+        type: 'consumer.before_consume.error'
       )
 
       false
@@ -117,7 +117,7 @@ module Karafka
 
     # Method that gets called in the blocking flow allowing to setup any type of resources or to
     # send additional commands to Kafka before the proper execution starts.
-    def prepare; end
+    def before_consume; end
 
     # Method that will perform business logic and on data received from Kafka (it will consume
     #   the data)

--- a/lib/karafka/instrumentation/logger_listener.rb
+++ b/lib/karafka/instrumentation/logger_listener.rb
@@ -98,8 +98,8 @@ module Karafka
         details = (error.backtrace || []).join("\n")
 
         case type
-        when 'consumer.prepared.error'
-          error "Consumer prepared error: #{error}"
+        when 'consumer.before_consume.error'
+          error "Consumer before consume error: #{error}"
           error details
         when 'consumer.consume.error'
           error "Consumer consuming error: #{error}"

--- a/lib/karafka/instrumentation/monitor.rb
+++ b/lib/karafka/instrumentation/monitor.rb
@@ -22,8 +22,9 @@ module Karafka
         app.stopping
         app.stopped
 
-        consumer.prepared
+        consumer.before_consumed
         consumer.consumed
+        consumer.after_consumed
         consumer.revoked
         consumer.shutdown
 

--- a/lib/karafka/pro/base_consumer_extensions.rb
+++ b/lib/karafka/pro/base_consumer_extensions.rb
@@ -25,7 +25,7 @@ module Karafka
 
       # Pauses processing of a given partition until we're done with the processing
       # This ensures, that we can easily poll not reaching the `max.poll.interval`
-      def on_prepare
+      def on_before_consume
         # Pause at the first message in a batch. That way in case of a crash, we will not loose
         # any messages
         pause(messages.first.offset, MAX_PAUSE_TIME) if topic.long_running_job?

--- a/lib/karafka/pro/processing/jobs/consume_non_blocking.rb
+++ b/lib/karafka/pro/processing/jobs/consume_non_blocking.rb
@@ -26,7 +26,7 @@ module Karafka
         #   management. This layer of the framework knows nothing about Kafka messages consumption.
         class ConsumeNonBlocking < ::Karafka::Processing::Jobs::Consume
           # Releases the blocking lock after it is done with the preparation phase for this job
-          def prepare
+          def before_call
             super
             @non_blocking = true
           end

--- a/lib/karafka/processing/executor.rb
+++ b/lib/karafka/processing/executor.rb
@@ -45,7 +45,7 @@ module Karafka
       # @param messages [Array<Karafka::Messages::Message>]
       # @param received_at [Time] the moment we've received the batch (actually the moment we've)
       #   enqueued it, but good enough
-      def prepare(messages, received_at)
+      def before_consume(messages, received_at)
         # Recreate consumer with each batch if persistence is not enabled
         # We reload the consumers with each batch instead of relying on some external signals
         # when needed for consistency. That way devs may have it on or off and not in this
@@ -59,7 +59,7 @@ module Karafka
           received_at
         )
 
-        consumer.on_prepare
+        consumer.on_before_consume
       end
 
       # Runs consumer data processing against given batch and handles failures and errors.

--- a/lib/karafka/processing/jobs/base.rb
+++ b/lib/karafka/processing/jobs/base.rb
@@ -5,7 +5,7 @@ module Karafka
     # Namespace for all the jobs that are suppose to run in workers.
     module Jobs
       # Base class for all the jobs types that are suppose to run in workers threads.
-      # Each job can have 3 main entry-points: `#prepare`, `#call` and `#teardown`
+      # Each job can have 3 main entry-points: `#before_call`, `#call` and `#after_call`
       # Only `#call` is required.
       class Base
         extend Forwardable
@@ -23,10 +23,15 @@ module Karafka
         end
 
         # When redefined can run any code that should run before executing the proper code
-        def prepare; end
+        def before_call; end
+
+        # The main entrypoint of a job
+        def call
+          raise NotImplementedError, 'Please implement in a subclass'
+        end
 
         # When redefined can run any code that should run after executing the proper code
-        def teardown; end
+        def after_call; end
 
         # @return [Boolean] is this a non-blocking job
         #

--- a/lib/karafka/processing/jobs/consume.rb
+++ b/lib/karafka/processing/jobs/consume.rb
@@ -21,8 +21,8 @@ module Karafka
         end
 
         # Runs the preparations on the executor
-        def prepare
-          executor.prepare(@messages, @created_at)
+        def before_call
+          executor.before_consume(@messages, @created_at)
         end
 
         # Runs the given executor

--- a/lib/karafka/processing/worker.rb
+++ b/lib/karafka/processing/worker.rb
@@ -50,7 +50,7 @@ module Karafka
           Karafka.monitor.instrument('worker.process', caller: self, job: job)
 
           Karafka.monitor.instrument('worker.processed', caller: self, job: job) do
-            job.prepare
+            job.before_call
 
             # If a job is marked as non blocking, we can run a tick in the job queue and if there
             # are no other blocking factors, the job queue will be unlocked.
@@ -60,7 +60,7 @@ module Karafka
 
             job.call
 
-            job.teardown
+            job.after_call
 
             true
           end

--- a/spec/lib/karafka/base_consumer_spec.rb
+++ b/spec/lib/karafka/base_consumer_spec.rb
@@ -191,16 +191,16 @@ RSpec.describe_current do
     end
   end
 
-  describe '#on_prepare' do
+  describe '#on_before_consume' do
     context 'when everything went ok on revoked' do
-      it { expect { consumer.on_prepare }.not_to raise_error }
+      it { expect { consumer.on_before_consume }.not_to raise_error }
 
       it 'expect to run proper instrumentation' do
         Karafka.monitor.subscribe('consumer.revoked') do |event|
           expect(event.payload[:caller]).to eq(consumer)
         end
 
-        consumer.on_prepare
+        consumer.on_before_consume
       end
 
       it 'expect not to run error instrumentation' do
@@ -208,7 +208,7 @@ RSpec.describe_current do
           raise
         end
 
-        consumer.on_prepare
+        consumer.on_before_consume
       end
     end
 
@@ -221,7 +221,7 @@ RSpec.describe_current do
         end
       end
 
-      it { expect { consumer.on_prepare }.not_to raise_error }
+      it { expect { consumer.on_before_consume }.not_to raise_error }
 
       it 'expect to run the error instrumentation' do
         Karafka.monitor.subscribe('error.occurred') do |event|

--- a/spec/lib/karafka/instrumentation/logger_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/logger_listener_spec.rb
@@ -137,9 +137,9 @@ RSpec.describe_current do
       it { expect(Karafka.logger).to have_received(:error).with(message) }
     end
 
-    context 'when it is a consumer.prepared.error' do
-      let(:type) { 'consumer.prepared.error' }
-      let(:message) { "Consumer prepared error: #{error}" }
+    context 'when it is a consumer.before_consume.error' do
+      let(:type) { 'consumer.before_consume.error' }
+      let(:message) { "Consumer before consume error: #{error}" }
 
       it { expect(Karafka.logger).to have_received(:error).with(message) }
     end

--- a/spec/lib/karafka/pro/active_job/consumer_spec.rb
+++ b/spec/lib/karafka/pro/active_job/consumer_spec.rb
@@ -25,12 +25,12 @@ RSpec.describe_current do
 
   it { expect(described_class).to be < Karafka::ActiveJob::Consumer }
 
-  describe '#on_prepare behaviour' do
+  describe '#on_before_consume behaviour' do
     before { allow(consumer).to receive(:pause) }
 
     context 'when it is not a lrj' do
       it 'expect not to pause' do
-        consumer.on_prepare
+        consumer.on_before_consume
 
         expect(consumer).not_to have_received(:pause)
       end
@@ -43,7 +43,7 @@ RSpec.describe_current do
       end
 
       it 'expect to pause forever on our first message' do
-        consumer.on_prepare
+        consumer.on_before_consume
 
         expect(consumer).to have_received(:pause).with(message1.offset, 1_000_000_000_000)
       end

--- a/spec/lib/karafka/pro/processing/jobs/consume_non_blocking_spec.rb
+++ b/spec/lib/karafka/pro/processing/jobs/consume_non_blocking_spec.rb
@@ -12,19 +12,19 @@ RSpec.describe_current do
   it { expect(job.non_blocking?).to eq(false) }
   it { expect(described_class).to be < ::Karafka::Processing::Jobs::Consume }
 
-  describe '#prepare' do
+  describe '#before_call' do
     before do
       allow(Time).to receive(:now).and_return(time_now)
-      allow(executor).to receive(:prepare)
+      allow(executor).to receive(:before_consume)
     end
 
-    it 'expect to run prepare on the executor with time and messages' do
-      job.prepare
-      expect(executor).to have_received(:prepare).with(messages, time_now)
+    it 'expect to run before_consume on the executor with time and messages' do
+      job.before_call
+      expect(executor).to have_received(:before_consume).with(messages, time_now)
     end
 
     it 'expect to mark this job as non blocking after it is done with preparation' do
-      expect { job.prepare }.to change(job, :non_blocking?).from(false).to(true)
+      expect { job.before_call }.to change(job, :non_blocking?).from(false).to(true)
     end
   end
 end

--- a/spec/lib/karafka/processing/executor_spec.rb
+++ b/spec/lib/karafka/processing/executor_spec.rb
@@ -31,25 +31,25 @@ RSpec.describe_current do
     it { expect(executor.group_id).to eq(group_id) }
   end
 
-  describe '#prepare' do
-    before { allow(consumer).to receive(:on_prepare) }
+  describe '#before_consume' do
+    before { allow(consumer).to receive(:on_before_consume) }
 
-    it { expect { executor.prepare(messages, received_at) }.not_to raise_error }
+    it { expect { executor.before_consume(messages, received_at) }.not_to raise_error }
 
     it 'expect to build appropriate messages batch' do
-      executor.prepare(messages, received_at)
+      executor.before_consume(messages, received_at)
       expect(consumer.messages.first.raw_payload).to eq(messages.first.raw_payload)
     end
 
     it 'expect to build metadata with proper details' do
-      executor.prepare(messages, received_at)
+      executor.before_consume(messages, received_at)
       expect(consumer.messages.metadata.scheduled_at).to eq(received_at)
       expect(consumer.messages.metadata.topic).to eq(topic.name)
     end
 
-    it 'expect to run consumer on_prepare' do
-      executor.prepare(messages, received_at)
-      expect(consumer).to have_received(:on_prepare).with(no_args)
+    it 'expect to run consumer on_before_consume' do
+      executor.before_consume(messages, received_at)
+      expect(consumer).to have_received(:on_before_consume).with(no_args)
     end
   end
 

--- a/spec/lib/karafka/processing/jobs/consume_spec.rb
+++ b/spec/lib/karafka/processing/jobs/consume_spec.rb
@@ -9,15 +9,15 @@ RSpec.describe_current do
 
   it { expect(job.non_blocking?).to eq(false) }
 
-  describe '#prepare' do
+  describe '#before_consume' do
     before do
       allow(Time).to receive(:now).and_return(time_now)
-      allow(executor).to receive(:prepare)
-      job.prepare
+      allow(executor).to receive(:before_consume)
+      job.before_call
     end
 
-    it 'expect to run prepare on the executor with time and messages' do
-      expect(executor).to have_received(:prepare).with(messages, time_now)
+    it 'expect to run before_consume on the executor with time and messages' do
+      expect(executor).to have_received(:before_consume).with(messages, time_now)
     end
   end
 

--- a/spec/lib/karafka/processing/worker_spec.rb
+++ b/spec/lib/karafka/processing/worker_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe_current do
       let(:job) { OpenStruct.new(group_id: 1, id: 1, call: true) }
 
       before do
-        allow(job).to receive(:prepare)
+        allow(job).to receive(:before_call)
         allow(job).to receive(:call)
-        allow(job).to receive(:teardown)
+        allow(job).to receive(:after_call)
         allow(queue).to receive(:tick)
 
         queue << job
@@ -50,9 +50,9 @@ RSpec.describe_current do
       end
 
       it { expect(queue).not_to have_received(:tick) }
-      it { expect(job).to have_received(:prepare).with(no_args) }
+      it { expect(job).to have_received(:before_call).with(no_args) }
       it { expect(job).to have_received(:call).with(no_args) }
-      it { expect(job).to have_received(:teardown).with(no_args) }
+      it { expect(job).to have_received(:after_call).with(no_args) }
       it { expect(queue).to have_received(:complete).with(job) }
     end
 
@@ -60,9 +60,9 @@ RSpec.describe_current do
       let(:job) { OpenStruct.new(group_id: 1, id: 1, call: true, non_blocking?: true) }
 
       before do
-        allow(job).to receive(:prepare)
+        allow(job).to receive(:before_call)
         allow(job).to receive(:call)
-        allow(job).to receive(:teardown)
+        allow(job).to receive(:after_call)
         allow(queue).to receive(:tick)
 
         queue << job
@@ -73,9 +73,9 @@ RSpec.describe_current do
       end
 
       it { expect(queue).to have_received(:tick).with(job.group_id) }
-      it { expect(job).to have_received(:prepare).with(no_args) }
+      it { expect(job).to have_received(:before_call).with(no_args) }
       it { expect(job).to have_received(:call).with(no_args) }
-      it { expect(job).to have_received(:teardown).with(no_args) }
+      it { expect(job).to have_received(:after_call).with(no_args) }
       it { expect(queue).to have_received(:complete).with(job) }
     end
 
@@ -89,7 +89,7 @@ RSpec.describe_current do
       end
 
       before do
-        allow(job).to receive(:prepare).and_raise(StandardError)
+        allow(job).to receive(:before_call).and_raise(StandardError)
 
         detected_errors
 


### PR DESCRIPTION
This PR renames internal methods to better describe what they do and to simplify the API for some internal refactoring.