### PR TITLE
Improve specs stability + always resume paused partitions on revocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
   schedule:
     - cron:  '0 1 * * *'
 
-
 env:
   BUNDLE_RETRY: 6
   BUNDLE_JOBS: 4
@@ -111,11 +110,16 @@ jobs:
           ruby-version: ${{matrix.ruby}}
           bundler-cache: true
 
-      - name: Install latest Bundler and RubyGems
+      - name: Install latest Bundler
         run: |
           gem install bundler --no-document
           gem update --system --no-document
           bundle config set without 'tools benchmarks docs'
+
+      - name: Bundle install
+        run: |
+          bundle config set without development
+          bundle install
 
       - name: Ensure all needed Kafka topics are created and wait if not
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,16 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.1
           bundler-cache: true
+
       - name: Install Diffend plugin
         run: bundle plugin install diffend
+
       - name: Bundle Secure
         run: bundle secure
 
@@ -102,6 +105,12 @@ jobs:
         with:
           ruby-version: ${{matrix.ruby}}
           bundler-cache: true
+
+      - name: Install latest Bundler and RubyGems
+        run: |
+          gem install bundler --no-document
+          gem update --system --no-document
+          bundle config set without 'tools benchmarks docs'
 
       - name: Ensure all needed Kafka topics are created and wait if not
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron:  '0 1 * * *'
 
+
+env:
+  BUNDLE_RETRY: 6
+  BUNDLE_JOBS: 4
+
 jobs:
   diffend:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.0.0-beta5 (Unreleased)
 - Always resume processing of a revoked partition just in case it gets re-assigned.
+- Improve specs stability
 
 ## 2.0.0-beta4 (2022-06-20)
 - Rename job internal api methods from `#prepare` to `#before_call` and from `#teardown` to `#after_call` to abstract away jobs execution from any type of executors and consumers logic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka framework changelog
 
+## 2.0.0-beta5 (Unreleased)
+- Always resume processing of a revoked partition just in case it gets re-assigned.
+
 ## 2.0.0-beta4 (2022-06-20)
 - Rename job internal api methods from `#prepare` to `#before_call` and from `#teardown` to `#after_call` to abstract away jobs execution from any type of executors and consumers logic
 - Remove ability of running `before_consume` and `after_consume` completely. Those should be for internal usage only.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka (2.0.0.beta4)
+    karafka (2.0.0.beta5)
       dry-configurable (~> 0.13)
       dry-monitor (~> 0.5)
       dry-validation (~> 1.7)

--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -75,6 +75,12 @@ module Karafka
     #
     # @private
     def on_revoked
+      @revoked = true
+
+      # Revoked partition needs to be resumed. Otherwise there is a chance, that after a
+      # re-assignment, it will not be fetched despite being assigned
+      resume
+
       Karafka.monitor.instrument('consumer.revoked', caller: self) do
         revoked
       end

--- a/lib/karafka/pro/base_consumer.rb
+++ b/lib/karafka/pro/base_consumer.rb
@@ -55,21 +55,12 @@ module Karafka
           # first message from another batch from `@seek_offset`. If manual offset management
           # is on, we move to place where the user indicated it was finished.
           seek(@seek_offset || messages.first.offset)
+
           resume
         else
           # If processing failed, we need to pause
           pause(@seek_offset || messages.first.offset)
         end
-      end
-
-      # Marks this consumer revoked state as true
-      # This allows us for things like lrj to finish early as this state may change during lrj
-      # execution
-      def on_revoked
-        # @note This may already be set to true if we tried to commit offsets and failed. In case
-        # like this it will automatically be marked as revoked.
-        @revoked = true
-        super
       end
     end
   end

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '2.0.0.beta4'
+  VERSION = '2.0.0.beta5'
 end

--- a/spec/integrations/pro/consumption/lrj_with_auto_offset_management.rb
+++ b/spec/integrations/pro/consumption/lrj_with_auto_offset_management.rb
@@ -11,6 +11,9 @@ end
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     DataCollector[0] << messages.last.offset
+    # We sleep here so we don't end up consuming so many messages, that the second consumer would
+    # hang as there would be no data for him
+    sleep(1)
   end
 end
 

--- a/spec/integrations/pro/rebalancing/lrj_rebalance_consumer_recreation.rb
+++ b/spec/integrations/pro/rebalancing/lrj_rebalance_consumer_recreation.rb
@@ -55,11 +55,6 @@ Thread.new do
   end
 end
 
-# We sleep here to get some messages into kafka first
-# For any crazy reason, Kafka after topics are created still does something and before that is done
-# we may have some problems during rebalance. It happens only with freshly started docker setup
-sleep(5)
-
 # We need a second producer to trigger a rebalance
 consumer = setup_rdkafka_consumer
 
@@ -74,11 +69,11 @@ other = Thread.new do
     consumer.store_offset(message)
     consumer.commit(nil, false)
 
-    if DataCollector[:jumped].size >= 20
-      consumer.close
+    next unless DataCollector[:jumped].size >= 20
 
-      break
-    end
+    consumer.close
+
+    break
   end
 end
 


### PR DESCRIPTION
This PR:

- improves specs stability by restoring bundle install outside of the GH action (no idea why but sometimes bundler claims it cannot find packages without it)
- improves another spec stability by ensuring we do not consume too much too fast so another consumer does not hang waiting on nothing
- resume paused partitions even if we lost them. That way when reclaiming, we will continue to process.
