### PR TITLE
Remove bundler cache from the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{matrix.ruby}}
-          bundler-cache: true
 
       - name: Install latest Bundler
         run: |


### PR DESCRIPTION
This bundler cache in the action causes weird errors. I reported that to bundler team but for now need to reverse this cache.