### PR TITLE
use method reference to coordinator

### DIFF
--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -35,9 +35,9 @@ module Karafka
         consume
       end
 
-      @coordinator.consumption(self).success!
+      coordinator.consumption(self).success!
     rescue StandardError => e
-      @coordinator.consumption(self).failure!
+      coordinator.consumption(self).failure!
 
       Karafka.monitor.instrument(
         'error.occurred',
@@ -47,7 +47,7 @@ module Karafka
       )
     ensure
       # We need to decrease number of jobs that this coordinator coordinates as it has finished
-      @coordinator.decrement
+      coordinator.decrement
     end
 
     # @private
@@ -56,7 +56,7 @@ module Karafka
     def on_after_consume
       return if revoked?
 
-      if @coordinator.success?
+      if coordinator.success?
         coordinator.pause_tracker.reset
 
         # Mark as consumed only if manual offset management is not on

--- a/lib/karafka/pro/base_consumer.rb
+++ b/lib/karafka/pro/base_consumer.rb
@@ -39,7 +39,7 @@ module Karafka
         # Nothing to do if we lost the partition
         return if revoked?
 
-        if @coordinator.success?
+        if coordinator.success?
           coordinator.pause_tracker.reset
 
           # We use the non-blocking one here. If someone needs the blocking one, can implement it

--- a/spec/integrations/offset_management/with_sync_marking.rb
+++ b/spec/integrations/offset_management/with_sync_marking.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Karafka should not raise any errors when we use mark_as_consumed!
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      mark_as_consumed!(message)
+      DataCollector[0] << message
+    end
+  rescue
+    exit! 5
+  end
+end
+
+draw_routes(Consumer)
+
+Array.new(100) { SecureRandom.uuid }.each { |value| produce(DataCollector.topic, value) }
+
+start_karafka_and_wait_until do
+  DataCollector[0].size >= 100
+end

--- a/spec/integrations/offset_management/with_sync_marking.rb
+++ b/spec/integrations/offset_management/with_sync_marking.rb
@@ -10,7 +10,7 @@ class Consumer < Karafka::BaseConsumer
       mark_as_consumed!(message)
       DataCollector[0] << message
     end
-  rescue
+  rescue StandardError
     exit! 5
   end
 end


### PR DESCRIPTION
This PR adds additional spec and aligns the coordinator referencing style. No changes to the logic whatsoever.