### PR TITLE
Remove dry configurable in favour of homebrew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix `example_consumer.rb.erb` `#shutdown` and `#revoked` signatures to correct once.
 - Improve the install user experience (print status and created files).
 - Change default `max_wait_time` from 10s to 5s.
+- Remove direct dependency on `dry-configurable` in favour of a home-brew.
 
 ## 2.0.0-rc1 (2022-07-08)
 - Extract consumption partitioner out of listener inline code.

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-#plugin 'diffend'
+plugin 'diffend'
 
 gemspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-plugin 'diffend'
+#plugin 'diffend'
 
 gemspec
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,21 +2,20 @@ PATH
   remote: .
   specs:
     karafka (2.0.0.rc2)
-      dry-configurable (~> 0.13)
       dry-monitor (~> 0.5)
       dry-validation (~> 1.7)
       rdkafka (>= 0.10)
       thor (>= 0.20)
-      waterdrop (>= 2.3.1, < 3.0.0)
+      waterdrop (>= 2.3.2, < 3.0.0)
       zeitwerk (~> 2.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activejob (7.0.3)
-      activesupport (= 7.0.3)
+    activejob (7.0.3.1)
+      activesupport (= 7.0.3.1)
       globalid (>= 0.3.6)
-    activesupport (7.0.3)
+    activesupport (7.0.3.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -30,12 +29,12 @@ GEM
       dry-core (~> 0.6)
     dry-container (0.10.0)
       concurrent-ruby (~> 1.0)
-    dry-core (0.7.1)
+    dry-core (0.8.0)
       concurrent-ruby (~> 1.0)
     dry-events (0.3.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.5, >= 0.5)
-    dry-inflector (0.2.1)
+    dry-inflector (0.3.0)
     dry-initializer (3.1.1)
     dry-logic (1.2.0)
       concurrent-ruby (~> 1.0)
@@ -69,10 +68,10 @@ GEM
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     mini_portile2 (2.8.0)
-    minitest (5.15.0)
+    minitest (5.16.2)
     rake (13.0.6)
     rdkafka (0.12.0)
       ffi (~> 1.15)
@@ -100,9 +99,8 @@ GEM
     thor (1.2.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    waterdrop (2.3.1)
+    waterdrop (2.3.2)
       concurrent-ruby (>= 1.1)
-      dry-configurable (~> 0.13)
       dry-monitor (~> 0.5)
       dry-validation (~> 1.7)
       rdkafka (>= 0.10)
@@ -121,4 +119,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.3.11
+   2.3.15

--- a/karafka.gemspec
+++ b/karafka.gemspec
@@ -16,12 +16,11 @@ Gem::Specification.new do |spec|
   spec.description = 'Framework used to simplify Apache Kafka based Ruby applications development'
   spec.licenses    = ['LGPL-3.0', 'Commercial']
 
-  spec.add_dependency 'dry-configurable', '~> 0.13'
   spec.add_dependency 'dry-monitor', '~> 0.5'
   spec.add_dependency 'dry-validation', '~> 1.7'
   spec.add_dependency 'rdkafka', '>= 0.10'
   spec.add_dependency 'thor', '>= 0.20'
-  spec.add_dependency 'waterdrop', '>= 2.3.1', '< 3.0.0'
+  spec.add_dependency 'waterdrop', '>= 2.3.2', '< 3.0.0'
   spec.add_dependency 'zeitwerk', '~> 2.3'
 
   spec.required_ruby_version = '>= 2.6.0'

--- a/lib/karafka.rb
+++ b/lib/karafka.rb
@@ -12,7 +12,6 @@
   openssl
   base64
   date
-  dry-configurable
   dry-validation
   dry/events/publisher
   dry/monitor/notifications

--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -12,7 +12,7 @@ module Karafka
     #   enough and will still keep the code simple
     # @see Karafka::Setup::Configurators::Base for more details about configurators api
     class Config
-      extend Dry::Configurable
+      extend ::WaterDrop::Configurable
 
       # Defaults for kafka settings, that will be overwritten only if not present already
       KAFKA_DEFAULTS = {
@@ -122,6 +122,10 @@ module Karafka
           setting :consumer_class, default: ActiveJob::Consumer
         end
       end
+
+      # This will load all the defaults that can be later overwritten.
+      # Thanks to that we have an initial state out of the box.
+      configure
 
       class << self
         # Configuring method

--- a/spec/lib/karafka/licenser_spec.rb
+++ b/spec/lib/karafka/licenser_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe_current do
   subject(:verify) { described_class.new.verify(license_config) }
 
-  let(:license_config) { Karafka::App.config.license.dup }
+  let(:license_config) { Karafka::App.config.license.deep_dup.tap(&:configure) }
 
   context 'when there is no license token' do
     before { license_config.token = false }

--- a/spec/lib/karafka/pro/loader_spec.rb
+++ b/spec/lib/karafka/pro/loader_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe_current do
   subject(:loader) { described_class }
 
   context 'when we are loading active_job pro compoments' do
-    let(:aj_defaults) { Karafka::App.config.internal.active_job.dup }
+    let(:aj_defaults) { Karafka::App.config.internal.active_job.deep_dup.tap(&:configure) }
     let(:aj_config) { Karafka::App.config.internal.active_job }
 
     before { aj_defaults }
 
     after do
       aj_defaults.to_h.each do |key, value|
-        Karafka::App.config.internal.active_job[key] = value
+        Karafka::App.config.internal.active_job.public_send("#{key}=", value)
       end
     end
 


### PR DESCRIPTION
As part of removing gems that are fairly easy to replace (to lower the complexity of the supply chain), this PR removes dependency on dry-configurable.

No changes to the end user API needed.