### PR TITLE
Remove extensive messaging from default dev info logging level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 - Validate that Pro consumer is always used for Pro subscription.
 - Improve ActiveJob consumer shutdown behaviour.
 - Change default 'max_wait_time' to 1 second.
-- Change default `max_messages` to 100.
-- Move logger listener polling reporting level to debug when no messages.
+- Change default `max_messages` to 100 (#915).
+- Move logger listener polling reporting level to debug when no messages (#916).
 
 ## 2.0.0.rc2 (2022-07-19)
 - Fix `example_consumer.rb.erb` `#shutdown` and `#revoked` signatures to correct once.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Improve ActiveJob consumer shutdown behaviour.
 - Change default 'max_wait_time' to 1 second.
 - Change default `max_messages` to 100.
+- Move logger listener polling reporting level to debug when no messages.
 
 ## 2.0.0.rc2 (2022-07-19)
 - Fix `example_consumer.rb.erb` `#shutdown` and `#revoked` signatures to correct once.

--- a/lib/karafka/instrumentation/logger_listener.rb
+++ b/lib/karafka/instrumentation/logger_listener.rb
@@ -18,7 +18,7 @@ module Karafka
       # @param event [Dry::Events::Event] event details including payload
       def on_connection_listener_fetch_loop(event)
         listener = event[:caller]
-        info "[#{listener.id}] Polling messages..."
+        debug "[#{listener.id}] Polling messages..."
       end
 
       # Logs about messages that we've received from Kafka
@@ -28,7 +28,13 @@ module Karafka
         listener = event[:caller]
         time = event[:time]
         messages_count = event[:messages_buffer].size
-        info "[#{listener.id}] Polled #{messages_count} messages in #{time}ms"
+
+        message = "[#{listener.id}] Polled #{messages_count} messages in #{time}ms"
+
+        # We don't want the "polled 0" in dev as it would spam the log
+        # Instead we publish only info when there was anything we could poll and fail over to the
+        # zero notifications when in debug mode
+        messages_count.zero? ? debug(message) : info(message)
       end
 
       # Prints info about the fact that a given job has started


### PR DESCRIPTION
This will make logger more informative and without the extensive noise.

close https://github.com/karafka/karafka/issues/916