### PR TITLE
close client after use in specs

### DIFF
--- a/spec/lib/karafka/connection/listener_spec.rb
+++ b/spec/lib/karafka/connection/listener_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe_current do
     allow(client).to receive(:batch_poll).and_return([])
   end
 
+  after { client.stop }
+
   context 'when all goes well' do
     before do
       allow(client).to receive(:commit_offsets)


### PR DESCRIPTION
rdkafka client should always be closed after usage to prevent spec crashes