### PR TITLE
Check headers key format + add more specs

### DIFF
--- a/spec/integrations/consumption/of_messages_with_headers.rb
+++ b/spec/integrations/consumption/of_messages_with_headers.rb
@@ -27,5 +27,5 @@ assert_equal 10, DataCollector[0].size
 
 DataCollector[0].each do |element|
   assert_equal element[0], element[1].fetch('value')
-  assert element[1].keys.all? { |key| key.is_a?(String) }
+  assert(element[1].keys.all? { |key| key.is_a?(String) })
 end

--- a/spec/integrations/consumption/of_messages_with_headers.rb
+++ b/spec/integrations/consumption/of_messages_with_headers.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-# Karafka should be able to work with messages that have headers
+# Karafka should be able to work with messages that have headers and all headers should have string
+# keys
 
 setup_karafka
 
@@ -26,4 +27,5 @@ assert_equal 10, DataCollector[0].size
 
 DataCollector[0].each do |element|
   assert_equal element[0], element[1].fetch('value')
+  assert element[1].keys.all? { |key| key.is_a?(String) }
 end

--- a/spec/integrations/pro/consumption/virtual_partitions/with_parallel_errors.rb
+++ b/spec/integrations/pro/consumption/virtual_partitions/with_parallel_errors.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# When Karafka consumes in the VP mode and many errors happen in many of the processing units,
+# we we should continue and we should restart the processing from the first offset on a batch.
+
+class Listener
+  def on_error_occurred(event)
+    DataCollector[:errors] << event
+  end
+end
+
+Karafka.monitor.subscribe(Listener.new)
+
+setup_karafka(allow_errors: true) do |config|
+  config.license.token = pro_license_token
+  config.concurrency = 10
+end
+
+class Consumer < Karafka::Pro::BaseConsumer
+  def consume
+    unless @raised
+      @raised = true
+      raise StandardError
+    end
+
+    messages.each do |message|
+      DataCollector[0] << message
+    end
+  end
+end
+
+draw_routes do
+  consumer_group DataCollector.consumer_group do
+    topic DataCollector.topic do
+      consumer Consumer
+      virtual_partitioner ->(msg) { msg.raw_payload }
+    end
+  end
+end
+
+elements = Array.new(100) { SecureRandom.uuid }
+elements.each { |data| produce(DataCollector.topic, data) }
+
+start_karafka_and_wait_until do
+  DataCollector[0].size >= 100
+end
+
+assert_equal 10, DataCollector[:errors].size
+
+previous = nil
+
+# Check that no messages are skipped
+DataCollector[0].flatten.map(&:offset).sort.uniq.each do |offset|
+  unless previous
+    previous = offset
+    next
+  end
+
+  assert_equal previous + 1, offset
+
+  previous = offset
+end


### PR DESCRIPTION
This change adds one more check to make sure headers keys are strings.

ref https://github.com/appsignal/rdkafka-ruby/issues/204