### PR TITLE
Spec to show partitioning for VP based on message key and random

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
          integrations_18_02:2:1,\
          integrations_19_02:2:1,\
          integrations_20_02:2:1,\
+         integrations_21_02:2:1,\
          integrations_00_03:3:1,\
          integrations_01_03:3:1,\
          integrations_02_03:3:1,\

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
          integrations_17_02:2:1,\
          integrations_18_02:2:1,\
          integrations_19_02:2:1,\
+         integrations_20_02:2:1,\
          integrations_00_03:3:1,\
          integrations_01_03:3:1,\
          integrations_02_03:3:1,\

--- a/spec/integrations/pro/consumption/virtual_partitions/distributing_work_randomly.rb
+++ b/spec/integrations/pro/consumption/virtual_partitions/distributing_work_randomly.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Karafka should support possibility of distributing work randomly when using virtual partitions
+# Note that even when using random distribution, messages from different partitions will never
+# mix within a batch.
+
+TOPIC = 'integrations_21_02'
+
+setup_karafka do |config|
+  config.license.token = pro_license_token
+  config.concurrency = 5
+  config.max_messages = 20
+  config.initial_offset = 'latest'
+end
+
+class Consumer < Karafka::Pro::BaseConsumer
+  def consume
+    DataCollector[object_id].push(*messages)
+  end
+end
+
+draw_routes do
+  consumer_group DataCollector.consumer_group do
+    topic TOPIC do
+      consumer Consumer
+      virtual_partitioner ->(_) { rand(Karafka::App.config.concurrency) }
+    end
+  end
+end
+
+start_karafka_and_wait_until do
+  produce(TOPIC, '1', key: %w[a b c d].sample)
+  produce(TOPIC, '1', key: %w[a b c d].sample)
+
+  DataCollector.data.values.map(&:count).sum >= 1_000
+end
+
+# Two partitions, 5 jobs per each
+assert_equal 10, DataCollector.data.size

--- a/spec/integrations/pro/consumption/virtual_partitions/distributing_work_using_message_keys.rb
+++ b/spec/integrations/pro/consumption/virtual_partitions/distributing_work_using_message_keys.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Karafka should support possibility of using message keys to distribute work
+# We have two partitions but virtual partitioner should allow us to distribute this work across
+# four threads concurrently.
+
+# Note that you can get different combinations of messages for different batches fetched.
+# The fact that the first time messages with key `a` were together with `c`, does not mean, that
+# it will always be the same. The distribution combination is unique for the batch. One thing you
+# can be sure, is that if you have messages with key `c`, they will always go to one of the
+# virtual consumers. Virtual consumer instance is **not** warrantied.
+
+TOPIC = 'integrations_20_02'
+
+setup_karafka do |config|
+  config.license.token = pro_license_token
+  config.concurrency = 10
+  config.max_messages = 5
+  config.initial_offset = 'latest'
+end
+
+class Consumer < Karafka::Pro::BaseConsumer
+  def consume
+    DataCollector[0].push(*messages)
+    DataCollector[:objects_ids] << object_id
+  end
+end
+
+draw_routes do
+  consumer_group DataCollector.consumer_group do
+    topic TOPIC do
+      consumer Consumer
+      virtual_partitioner ->(message) { message.key }
+    end
+  end
+end
+
+start_karafka_and_wait_until do
+  produce(TOPIC, '1', key: %w[a b c d].sample)
+  produce(TOPIC, '1', key: %w[a b c d].sample)
+
+  DataCollector[0].size >= 200
+end
+
+assert_equal 4, DataCollector[:objects_ids].uniq.size
+
+# Messages must be order
+DataCollector[0].group_by(&:key).values.each do |messages|
+  previous = nil
+
+  messages.each do |message|
+    unless previous
+      previous = message
+      next
+    end
+
+    assert previous.offset < message.offset
+  end
+end

--- a/spec/integrations/pro/consumption/virtual_partitions/distributing_work_using_message_keys.rb
+++ b/spec/integrations/pro/consumption/virtual_partitions/distributing_work_using_message_keys.rb
@@ -45,7 +45,7 @@ end
 assert_equal 4, DataCollector[:objects_ids].uniq.size
 
 # Messages must be order
-DataCollector[0].group_by(&:key).values.each do |messages|
+DataCollector[0].group_by(&:key).each_value do |messages|
   previous = nil
 
   messages.each do |message|


### PR DESCRIPTION
This spec shows that we can partition messages using VP and message keys that were used to partition data via Kafka.