### PR TITLE
More specs and key option usage for Active Job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Move logger listener polling reporting level to debug when no messages (#916).
 - Improve stability on aggressive rebalancing (multiple rebalances in a short period).
 - Improve specs stability.
+- Allow using `:key` and `:partition_key` for Enhanced Active Job partitioning.
 
 ## 2.0.0.rc2 (2022-07-19)
 - Fix `example_consumer.rb.erb` `#shutdown` and `#revoked` signatures to correct once.

--- a/config/errors.yml
+++ b/config/errors.yml
@@ -46,6 +46,7 @@ en:
       missing: needs to be present
       dispatch_method_format: needs to be either :produce_async or :produce_sync
       partitioner_format: 'needs to respond to #call'
+      partition_key_type_format: 'needs to be either :key or :partition_key'
 
     test:
       missing: needs to be present

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
          integrations_01_03:3:1,\
          integrations_02_03:3:1,\
          integrations_03_03:3:1,\
+         integrations_04_03:3:1,\
          integrations_00_10:10:1,\
          integrations_01_10:10:1,\
          benchmarks_00_01:1:1,\

--- a/lib/karafka/pro/active_job/dispatcher.rb
+++ b/lib/karafka/pro/active_job/dispatcher.rb
@@ -23,7 +23,9 @@ module Karafka
           dispatch_method: :produce_async,
           # We don't create a dummy proc based partitioner as we would have to evaluate it with
           # each job.
-          partitioner: nil
+          partitioner: nil,
+          # Allows for usage of `:key` or `:partition_key`
+          partition_key_type: :key
         }.freeze
 
         private_constant :DEFAULTS
@@ -45,11 +47,12 @@ module Karafka
         # @return [Hash] hash with dispatch details to which we merge topic and payload
         def dispatch_details(job)
           partitioner = fetch_option(job, :partitioner, DEFAULTS)
+          key_type = fetch_option(job, :partition_key_type, DEFAULTS)
 
           return {} unless partitioner
 
           {
-            partition_key: partitioner.call(job)
+            key_type => partitioner.call(job)
           }
         end
       end

--- a/lib/karafka/pro/active_job/job_options_contract.rb
+++ b/lib/karafka/pro/active_job/job_options_contract.rb
@@ -25,6 +25,7 @@ module Karafka
 
         optional(:dispatch_method) { |val| %i[produce_async produce_sync].include?(val) }
         optional(:partitioner) { |val| val.respond_to?(:call) }
+        optional(:partition_key_type) { |val| %i[key partition_key].include?(val) }
       end
     end
   end

--- a/spec/integrations/pro/consumption/long_running_jobs/multiple_batches_processing.rb
+++ b/spec/integrations/pro/consumption/long_running_jobs/multiple_batches_processing.rb
@@ -9,12 +9,23 @@ setup_karafka do |config|
   config.license.token = pro_license_token
 end
 
+# We want to sleep few times but not all the time not to exceed max execution time of specs
+DataCollector[:sleeps] = [
+  true,
+  false,
+  false,
+  false,
+  true,
+  false,
+  true
+]
+
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     # Ensure we exceed max poll interval, if that happens and this would not work async we would
     # be kicked out of the group
     # Sleep from time to time
-    sleep(11) if rand(10) <= 1
+    sleep(11) if DataCollector[:sleeps].pop
 
     messages.each do |message|
       DataCollector[0] << message

--- a/spec/integrations/pro/rails/active_job/ordered_jobs_with_key.rb
+++ b/spec/integrations/pro/rails/active_job/ordered_jobs_with_key.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# When using the pro adapter, we should be able to use partitioner that will allow us to process
+# ActiveJob jobs in their scheduled order using multiple partitions. We should be able to get
+# proper results when using `:key`.
+
+setup_karafka do |config|
+  config.license.token = pro_license_token
+  config.initial_offset = 'latest'
+end
+
+setup_active_job
+
+# This is a special topic with 3 partitions
+TOPIC = 'integrations_02_03'
+
+draw_routes do
+  consumer_group DataCollector.consumer_group do
+    active_job_topic TOPIC
+  end
+end
+
+class Job < ActiveJob::Base
+  queue_as TOPIC
+
+  karafka_options(
+    dispatch_method: :produce_sync,
+    partitioner: ->(job) { job.arguments.first[0] },
+    partition_key_type: :key
+  )
+
+  def perform(value1)
+    DataCollector[0] << value1
+  end
+end
+
+counts = 0
+
+# First loop kicks in before initialization of the connection and we want to publish after, that
+# is why we don't run it on the first run
+Karafka::App.monitor.subscribe('connection.listener.fetch_loop') do
+  counts += 1
+
+  if counts == 5
+    # We dispatch in order per partition, in case it all would go to one without partitioner or
+    # in case it would fail, the order will break
+    2.downto(0) do |partition|
+      3.times do |iteration|
+        Job.perform_later("#{partition}#{iteration}")
+      end
+    end
+  end
+end
+
+start_karafka_and_wait_until do
+  DataCollector[0].size >= 9
+end
+
+groups = DataCollector[0].group_by { |element| element[0] }
+groups.transform_values! { |group| group.map(&:to_i) }
+
+groups.each do |_, values|
+  assert_equal values.sort, values
+end

--- a/spec/integrations/pro/rails/active_job/ordered_jobs_with_partition_key.rb
+++ b/spec/integrations/pro/rails/active_job/ordered_jobs_with_partition_key.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 # When using the pro adapter, we should be able to use partitioner that will allow us to process
-# ActiveJob jobs in their scheduled order using multiple partitions
+# ActiveJob jobs in their scheduled order using multiple partitions. We should be able to get
+# proper results when using `:partition_key`.
 
 setup_karafka do |config|
   config.license.token = pro_license_token
@@ -11,7 +12,7 @@ end
 setup_active_job
 
 # This is a special topic with 3 partitions
-TOPIC = 'integrations_02_03'
+TOPIC = 'integrations_04_03'
 
 draw_routes do
   consumer_group DataCollector.consumer_group do
@@ -24,7 +25,8 @@ class Job < ActiveJob::Base
 
   karafka_options(
     dispatch_method: :produce_sync,
-    partitioner: ->(job) { job.arguments.first[0] }
+    partitioner: ->(job) { job.arguments.first[0] },
+    partition_key_type: :partition_key
   )
 
   def perform(value1)

--- a/spec/integrations/pro/rails/active_job/virtual_partitions/with_partitioning_using_key.rb
+++ b/spec/integrations/pro/rails/active_job/virtual_partitions/with_partitioning_using_key.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# We should be able to mix partition delegation via `:key` with virtual partitions to achieve
+# concurrent Active Job work execution.
+
+setup_karafka do |config|
+  config.license.token = pro_license_token
+  config.concurrency = 10
+end
+
+setup_active_job
+
+draw_routes do
+  consumer_group DataCollector.consumer_group do
+    active_job_topic DataCollector.topic do
+      virtual_partitioner ->(job) { job.key }
+    end
+  end
+end
+
+class Job < ActiveJob::Base
+  queue_as DataCollector.topic
+
+  karafka_options(
+    dispatch_method: :produce_sync,
+    partitioner: ->(job) { job.arguments.first[0] },
+    partition_key_type: :key
+  )
+
+  def perform(value1)
+    DataCollector[0] << value1
+  end
+end
+
+order_without_vp = []
+
+10.times do
+  2.times do |iteration|
+    order_without_vp << iteration.to_s
+    Job.perform_later(iteration.to_s)
+  end
+end
+
+start_karafka_and_wait_until do
+  DataCollector[0].size >= 20
+end
+
+assert_equal DataCollector[0].size, order_without_vp.size
+
+# Without virtual partitions we should get a consistent order, but with them and concurrent
+# processing, it should not be like that
+assert DataCollector[0] != order_without_vp

--- a/spec/lib/karafka/pro/active_job/dispatcher_spec.rb
+++ b/spec/lib/karafka/pro/active_job/dispatcher_spec.rb
@@ -43,7 +43,28 @@ RSpec.describe_current do
     end
   end
 
-  context 'when we want to dispatch with partitioner' do
+  context 'when we want to dispatch with partitioner using key' do
+    let(:expected_args) do
+      {
+        topic: job.queue_name,
+        payload: serialized_payload,
+        key: job.job_id
+      }
+    end
+
+    before do
+      job_class.karafka_options(partitioner: ->(job) { job.job_id })
+      allow(::Karafka.producer).to receive(:produce_async)
+    end
+
+    it 'expect to use its result alongside other options' do
+      dispatcher.call(job)
+
+      expect(::Karafka.producer).to have_received(:produce_async).with(expected_args)
+    end
+  end
+
+  context 'when we want to dispatch with partitioner using partition_key' do
     let(:expected_args) do
       {
         topic: job.queue_name,
@@ -54,6 +75,7 @@ RSpec.describe_current do
 
     before do
       job_class.karafka_options(partitioner: ->(job) { job.job_id })
+      job_class.karafka_options(partition_key_type: :partition_key)
       allow(::Karafka.producer).to receive(:produce_async)
     end
 

--- a/spec/lib/karafka/pro/active_job/job_options_contract_spec.rb
+++ b/spec/lib/karafka/pro/active_job/job_options_contract_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe_current do
 
   let(:config) do
     {
-      dispatch_method: :produce_sync
+      dispatch_method: :produce_sync,
+      partition_key_type: :key
     }
   end
 
@@ -19,6 +20,18 @@ RSpec.describe_current do
     before { config.delete(:dispatch_method) }
 
     it { expect(contract.call(config)).to be_success }
+  end
+
+  context 'when there is no partition key type' do
+    before { config.delete(:partition_key_type) }
+
+    it { expect(contract.call(config)).to be_success }
+  end
+
+  context 'when partition key type is something unexpected' do
+    before { config[:partition_key_type] = rand.to_s }
+
+    it { expect(contract.call(config)).not_to be_success }
   end
 
   context 'when dispatch method is not valid' do


### PR DESCRIPTION
This PR adds more integration specs and adds option to choose between `:key` and `:partition_key` for AJ partitioning.