### PR TITLE
add lrj shutdown detection scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ We also maintain many [integration specs](https://github.com/karafka/karafka/tre
 1. Add and install Karafka:
 
 ```bash
-bundle add karafka -v 2.0.0.rc3
+bundle add karafka -v 2.0.0.rc4
 
 bundle exec karafka install
 ```

--- a/spec/integrations/pro/shutdown/long_running_jobs/stopping_awareness.rb
+++ b/spec/integrations/pro/shutdown/long_running_jobs/stopping_awareness.rb
@@ -31,6 +31,7 @@ draw_routes do
     topic DataCollector.topic do
       consumer Consumer
       long_running_job true
+      manual_offset_management true
     end
   end
 end

--- a/spec/integrations/pro/shutdown/long_running_jobs/stopping_awareness.rb
+++ b/spec/integrations/pro/shutdown/long_running_jobs/stopping_awareness.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# When running a long running job, we should be able to detect that Karafka is stopping so we can
+# early exit the job.
+
+# Note, that for this to work correctly in regards to offsets, manual offset management need to
+# be turned on.
+
+setup_karafka do |config|
+  config.license.token = pro_license_token
+  config.concurrency = 5
+end
+
+class Consumer < Karafka::Pro::BaseConsumer
+  def consume
+    # We use loop so in case this would not work, it will timeout and raise an error
+    loop do
+      break if Karafka::App.stopping?
+
+      DataCollector[:done] << true
+
+      sleep(0.1)
+    end
+
+    DataCollector[:aware] << true
+  end
+end
+
+draw_routes do
+  consumer_group DataCollector.consumer_group do
+    topic DataCollector.topic do
+      consumer Consumer
+      long_running_job true
+    end
+  end
+end
+
+elements = Array.new(10) { SecureRandom.uuid }
+elements.each { |data| produce(DataCollector.topic, data) }
+
+start_karafka_and_wait_until do
+  DataCollector[:done].size >= 1
+end
+
+assert_equal [true], DataCollector[:aware]


### PR DESCRIPTION
One more scenario to illustrate that when using LRJ we can use the app status detection to early exit the LRJ job.