### PR TITLE
optimize specs and shutdown referenec removal

### DIFF
--- a/lib/karafka/connection/listener.rb
+++ b/lib/karafka/connection/listener.rb
@@ -65,6 +65,8 @@ module Karafka
 
         @mutex.synchronize do
           @stopped = true
+          @executors.clear
+          @coordinators.reset
           @client.commit_offsets!
           @client.stop
         end

--- a/spec/integrations/consumption/reaching_max_messages_count.rb
+++ b/spec/integrations/consumption/reaching_max_messages_count.rb
@@ -13,7 +13,7 @@ end
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DataCollector[:data] << message
+      DataCollector[:data] << message.offset
     end
 
     sleep(0.2)

--- a/spec/integrations/consumption/reaching_max_wait_time.rb
+++ b/spec/integrations/consumption/reaching_max_wait_time.rb
@@ -13,7 +13,7 @@ end
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DataCollector[:data] << message
+      DataCollector[:data] << message.offset
     end
 
     sleep(0.2)

--- a/spec/integrations/consumption/with_lazy_payload_deserialization.rb
+++ b/spec/integrations/consumption/with_lazy_payload_deserialization.rb
@@ -37,3 +37,5 @@ end
 
 assert_equal 100, DataCollector[0].size
 assert_equal 50, DataCollector[0].count(&:deserialized?)
+
+DataCollector.clear

--- a/spec/integrations/offset_management/messages_and_metadata_details.rb
+++ b/spec/integrations/offset_management/messages_and_metadata_details.rb
@@ -34,3 +34,5 @@ DataCollector[0].each_with_index do |message, index|
   assert_equal nil, message.key
   assert_equal false, message.deserialized?
 end
+
+DataCollector.clear

--- a/spec/integrations/offset_management/with_sync_marking.rb
+++ b/spec/integrations/offset_management/with_sync_marking.rb
@@ -8,7 +8,7 @@ class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
       mark_as_consumed!(message)
-      DataCollector[0] << message
+      DataCollector[0] << message.offset
     end
   rescue StandardError
     exit! 5

--- a/spec/integrations/pausing/pause_early_and_skip_via_marking.rb
+++ b/spec/integrations/pausing/pause_early_and_skip_via_marking.rb
@@ -56,3 +56,5 @@ sleep(0.1) until sum >= 20
 end
 
 assert_equal 20, sum
+
+consumer.close

--- a/spec/integrations/pro/consumption/long_running_jobs/multiple_batches_processing.rb
+++ b/spec/integrations/pro/consumption/long_running_jobs/multiple_batches_processing.rb
@@ -28,7 +28,7 @@ class Consumer < Karafka::Pro::BaseConsumer
     sleep(11) if DataCollector[:sleeps].pop
 
     messages.each do |message|
-      DataCollector[0] << message
+      DataCollector[0] << message.offset
     end
 
     5.times { produce(DataCollector.topic, '1') }
@@ -52,7 +52,7 @@ end
 
 previous = nil
 
-DataCollector[0].map(&:offset).each do |offset|
+DataCollector[0].each do |offset|
   unless previous
     previous = offset
     next

--- a/spec/integrations/pro/consumption/long_running_jobs/with_continuous_error.rb
+++ b/spec/integrations/pro/consumption/long_running_jobs/with_continuous_error.rb
@@ -20,7 +20,7 @@ class Consumer < Karafka::Pro::BaseConsumer
   def consume
     raise StandardError if rand(2).zero?
 
-    messages.each { |message| DataCollector[0] << message }
+    messages.each { |message| DataCollector[0] << message.offset }
 
     sleep 2
 
@@ -45,7 +45,7 @@ end
 
 previous = nil
 
-DataCollector[0].map(&:offset).each do |offset|
+DataCollector[0].each do |offset|
   unless previous
     previous = offset
     next

--- a/spec/integrations/pro/consumption/virtual_partitions/different_coordinator_different_partitions.rb
+++ b/spec/integrations/pro/consumption/virtual_partitions/different_coordinator_different_partitions.rb
@@ -13,7 +13,7 @@ end
 
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
-    messages.each { |message| DataCollector[:messages] << message }
+    messages.each { |message| DataCollector[:messages] << message.offset }
 
     DataCollector[:coordinators_ids] << coordinator.object_id
   end

--- a/spec/integrations/pro/consumption/virtual_partitions/distributing_work_randomly.rb
+++ b/spec/integrations/pro/consumption/virtual_partitions/distributing_work_randomly.rb
@@ -15,7 +15,9 @@ end
 
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
-    DataCollector[object_id].push(*messages)
+    messages.each do |message|
+      DataCollector[object_id] << message.offset
+    end
   end
 end
 

--- a/spec/integrations/pro/consumption/virtual_partitions/from_earliest.rb
+++ b/spec/integrations/pro/consumption/virtual_partitions/from_earliest.rb
@@ -12,7 +12,7 @@ end
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     messages.each do |message|
-      DataCollector[object_id] << message
+      DataCollector[object_id] << message.offset
     end
   end
 end
@@ -45,15 +45,15 @@ assert average >= 8
 assert average <= 12
 
 # All data within partitions should be in order
-DataCollector.data.each do |_object_id, messages|
-  previous_message = nil
+DataCollector.data.each do |_object_id, offsets|
+  previous_offset = nil
 
-  messages.each do |message|
-    unless previous_message
-      previous_message = message
+  offsets.each do |offset|
+    unless previous_offset
+      previous_offset = offset
       next
     end
 
-    assert previous_message.offset < message.offset
+    assert previous_offset < offset
   end
 end

--- a/spec/integrations/pro/consumption/virtual_partitions/many_batches_same_key.rb
+++ b/spec/integrations/pro/consumption/virtual_partitions/many_batches_same_key.rb
@@ -11,7 +11,7 @@ end
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     messages.each do |message|
-      DataCollector[object_id] << message
+      DataCollector[object_id] << message.offset
     end
   end
 end

--- a/spec/integrations/pro/consumption/virtual_partitions/many_distributed_batches_end_order.rb
+++ b/spec/integrations/pro/consumption/virtual_partitions/many_distributed_batches_end_order.rb
@@ -16,7 +16,9 @@ end
 
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
-    DataCollector[:batches].last.push(*messages)
+    messages.each do |message|
+      DataCollector[:batches].last << [message.offset]
+    end
   end
 end
 
@@ -42,13 +44,13 @@ end
 
 # Sort messages from each of the batches
 DataCollector[:batches].map! do |batch|
-  batch.sort_by!(&:offset)
+  batch.sort_by!(&:first)
 end
 
 previous = nil
 
 # They need to be in order one batch after another
-DataCollector[:batches].flatten.map(&:offset).each do |offset|
+DataCollector[:batches].flatten.each do |offset|
   unless previous
     previous = offset
     next

--- a/spec/integrations/pro/consumption/virtual_partitions/shared_coordinator.rb
+++ b/spec/integrations/pro/consumption/virtual_partitions/shared_coordinator.rb
@@ -10,7 +10,7 @@ end
 
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
-    messages.each { |message| DataCollector[:messages] << message }
+    messages.each { |message| DataCollector[:messages] << message.offset }
 
     DataCollector[:coordinators_ids] << coordinator.object_id
   end

--- a/spec/integrations/pro/consumption/virtual_partitions/with_manual_offset_management.rb
+++ b/spec/integrations/pro/consumption/virtual_partitions/with_manual_offset_management.rb
@@ -12,7 +12,7 @@ class Consumer < Karafka::Pro::BaseConsumer
   def consume
     messages.each do |message|
       mark_as_consumed(message) if [true, false].sample
-      DataCollector[object_id] << message
+      DataCollector[object_id] << message.offset
     end
   end
 end
@@ -46,15 +46,15 @@ assert average >= 8
 assert average <= 12
 
 # All data within partitions should be in order
-DataCollector.data.each do |_object_id, messages|
-  previous_message = nil
+DataCollector.data.each do |_object_id, offsets|
+  previous_offset = nil
 
-  messages.each do |message|
-    unless previous_message
-      previous_message = message
+  offsets.each do |offset|
+    unless previous_offset
+      previous_offset = offset
       next
     end
 
-    assert previous_message.offset < message.offset
+    assert previous_offset < offset
   end
 end

--- a/spec/integrations/pro/consumption/virtual_partitions/with_manual_offset_management_error.rb
+++ b/spec/integrations/pro/consumption/virtual_partitions/with_manual_offset_management_error.rb
@@ -14,7 +14,7 @@ end
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     messages.each do |message|
-      DataCollector[:messages] << message
+      DataCollector[:messages] << message.raw_payload
     end
 
     MUTEX.synchronize do
@@ -46,4 +46,4 @@ end
 
 # We should restart over and over again so same messages should come
 assert DataCollector.data[:messages].size >= 200
-assert_equal 100, DataCollector.data[:messages].map(&:raw_payload).uniq.size
+assert_equal 100, DataCollector.data[:messages].uniq.size

--- a/spec/integrations/pro/consumption/virtual_partitions/with_parallel_errors.rb
+++ b/spec/integrations/pro/consumption/virtual_partitions/with_parallel_errors.rb
@@ -24,7 +24,7 @@ class Consumer < Karafka::Pro::BaseConsumer
     end
 
     messages.each do |message|
-      DataCollector[0] << message
+      DataCollector[0] << message.offset
     end
   end
 end
@@ -50,7 +50,7 @@ assert_equal 10, DataCollector[:errors].size
 previous = nil
 
 # Check that no messages are skipped
-DataCollector[0].flatten.map(&:offset).sort.uniq.each do |offset|
+DataCollector[0].flatten.sort.uniq.each do |offset|
   unless previous
     previous = offset
     next

--- a/spec/integrations/pro/rebalancing/long_running_jobs/constant_rebalance_continuity.rb
+++ b/spec/integrations/pro/rebalancing/long_running_jobs/constant_rebalance_continuity.rb
@@ -16,7 +16,7 @@ class Consumer < Karafka::Pro::BaseConsumer
     sleep 5
 
     messages.each do |message|
-      DataCollector[:messages] << message
+      DataCollector[:offsets] << message.offset
 
       return unless mark_as_consumed!(message)
     end
@@ -65,7 +65,7 @@ end
 previous = nil
 
 # They need to be in order one batch after another
-DataCollector[:messages].map(&:offset).uniq.each do |offset|
+DataCollector[:offsets].uniq.each do |offset|
   unless previous
     previous = offset
     next

--- a/spec/integrations/pro/rebalancing/long_running_jobs/coordinator_replacement_after_rebalance.rb
+++ b/spec/integrations/pro/rebalancing/long_running_jobs/coordinator_replacement_after_rebalance.rb
@@ -49,7 +49,7 @@ other = Thread.new do
   consumer.subscribe(TOPIC)
 
   consumer.each do |message|
-    DataCollector[:jumped] << message
+    DataCollector[:jumped] << message.partition
     sleep 10
     consumer.store_offset(message)
     break
@@ -68,7 +68,7 @@ start_karafka_and_wait_until do
     )
 end
 
-taken_partition = DataCollector[:jumped].first.partition
+taken_partition = DataCollector[:jumped].first
 non_taken = taken_partition == 1 ? 0 : 1
 
 assert_equal 2, DataCollector.data[taken_partition].uniq.size

--- a/spec/integrations/pro/rebalancing/long_running_jobs/revoke_continuity.rb
+++ b/spec/integrations/pro/rebalancing/long_running_jobs/revoke_continuity.rb
@@ -62,7 +62,7 @@ other = Thread.new do
   consumer.subscribe(TOPIC)
 
   consumer.each do |message|
-    DataCollector[:jumped] << message
+    DataCollector[:jumped] << [message.partition, message.offset]
     consumer.store_offset(message)
     break
   end
@@ -76,8 +76,8 @@ start_karafka_and_wait_until do
   other.join && DataCollector[:partitions].size >= 3
 end
 
-revoked_partition = DataCollector[:jumped].first.partition
-jumped_offset = DataCollector[:jumped].first.offset
+revoked_partition = DataCollector[:jumped].first.first
+jumped_offset = DataCollector[:jumped].first.last
 
 assert_equal 1, DataCollector[:jumped].size
 

--- a/spec/integrations/pro/rebalancing/long_running_jobs/revoked_detection.rb
+++ b/spec/integrations/pro/rebalancing/long_running_jobs/revoked_detection.rb
@@ -46,7 +46,7 @@ Thread.new do
   sleep(10)
 
   consumer.subscribe(TOPIC)
-  consumer.each {}
+  consumer.poll(1_000)
 end
 
 Thread.new do

--- a/spec/integrations/pro/rebalancing/virtual_partitions/coordinator_replacement_after_rebalance.rb
+++ b/spec/integrations/pro/rebalancing/virtual_partitions/coordinator_replacement_after_rebalance.rb
@@ -49,7 +49,7 @@ other = Thread.new do
   consumer.subscribe(TOPIC)
 
   consumer.each do |message|
-    DataCollector[:jumped] << message
+    DataCollector[:jumped] << message.partition
     sleep 10
     consumer.store_offset(message)
     break
@@ -68,7 +68,7 @@ start_karafka_and_wait_until do
     )
 end
 
-taken_partition = DataCollector[:jumped].first.partition
+taken_partition = DataCollector[:jumped].first
 non_taken = taken_partition == 1 ? 0 : 1
 
 assert_equal 2, DataCollector.data[taken_partition].uniq.size

--- a/spec/integrations/pro/shutdown/virtual_partitions/shutdown_on_all_consumers.rb
+++ b/spec/integrations/pro/shutdown/virtual_partitions/shutdown_on_all_consumers.rb
@@ -10,7 +10,7 @@ end
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     messages.each do |message|
-      DataCollector[:messages] << message
+      DataCollector[:messages] << message.offset
     end
 
     DataCollector[:consume_ids] << object_id

--- a/spec/integrations/rebalancing/constant_rebalance_continuity.rb
+++ b/spec/integrations/rebalancing/constant_rebalance_continuity.rb
@@ -13,7 +13,7 @@ end
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DataCollector[:messages] << message
+      DataCollector[:messages] << message.offset
 
       return unless mark_as_consumed!(message)
     end
@@ -55,7 +55,7 @@ end
 previous = nil
 
 # They need to be in order one batch after another
-DataCollector[:messages].map(&:offset).uniq.each do |offset|
+DataCollector[:messages].uniq.each do |offset|
   unless previous
     previous = offset
     next

--- a/spec/integrations/rebalancing/without_using_revoked_partition_data.rb
+++ b/spec/integrations/rebalancing/without_using_revoked_partition_data.rb
@@ -136,3 +136,5 @@ process2.each do |_, messages|
       previous = current
     end
 end
+
+DataCollector.clear

--- a/spec/support/data_collector.rb
+++ b/spec/support/data_collector.rb
@@ -50,6 +50,11 @@ class DataCollector
     def []=(key, value)
       data[key] = value
     end
+
+    # Removes all the data from the collector
+    def clear
+      instance.clear
+    end
   end
 
   # Creates a collector
@@ -67,5 +72,13 @@ class DataCollector
   # @return [String] first consumer group
   def consumer_group
     topics.first
+  end
+
+  # Removes all the data from the collector
+  # This may be needed if be buffer rdkafka messages for GC to figure things out
+  def clear
+    @topics.clear
+    @consumer_groups.clear
+    @data.clear
   end
 end


### PR DESCRIPTION
This PR optimizes specs message aggregation, removes resources from listeners upon shutdown and makes sure we close consumer in specs so GC won't go crazy.