### PR TITLE
Make Enhaned Active Job work with Virtual Partitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.0.0 (Unreleased)
 - Update licenser to use a gem based approach based on `karafka/pro/license`.
+- Do not mark intermediate jobs as consumed when Karafka runs Enhanced Active Job with Virtual Partitions.
 
 ## 2.0.0.rc5 (2022-08-01)
 - Improve specs stability

--- a/lib/karafka/pro/active_job/consumer.rb
+++ b/lib/karafka/pro/active_job/consumer.rb
@@ -33,6 +33,10 @@ module Karafka
               ::ActiveSupport::JSON.decode(message.raw_payload)
             )
 
+            # We cannot mark jobs as done after each if there are virtual partitions. Otherwise
+            # this could create random markings
+            next if topic.virtual_partitioner?
+
             mark_as_consumed(message)
           end
         end

--- a/spec/integrations/pro/rails/active_job/virtual_partitions/with_error_on_next_job.rb
+++ b/spec/integrations/pro/rails/active_job/virtual_partitions/with_error_on_next_job.rb
@@ -42,5 +42,5 @@ start_karafka_and_wait_until do
 end
 
 # If we would mark as consumed
-assert_equal 2, DataCollector[0].count { |nr| nr == 94 }
+assert_equal 2, (DataCollector[0].count { |nr| nr == 94 })
 assert_equal DataCollector[0].uniq.sort, (0..99).to_a

--- a/spec/integrations/pro/rails/active_job/virtual_partitions/with_error_on_next_job.rb
+++ b/spec/integrations/pro/rails/active_job/virtual_partitions/with_error_on_next_job.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# When we have an vp and not the first job fails, it should use regular Karafka retry policies
+# for parallel jobs. In general it should not mark intermediate jobs as consumed.
+
+setup_karafka(allow_errors: true) do |config|
+  config.license.token = pro_license_token
+  config.concurrency = 1
+  config.max_messages = 60
+  config.max_wait_time = 2_000
+end
+
+setup_active_job
+
+draw_routes do
+  consumer_group DataCollector.consumer_group do
+    active_job_topic DataCollector.topic do
+      virtual_partitioner ->(_) { [true, false].sample }
+    end
+  end
+end
+
+class Job < ActiveJob::Base
+  queue_as DataCollector.topic
+
+  def perform(number)
+    if number == 95 && !DataCollector[0].include?(number)
+      DataCollector[0] << number
+      raise StandardError
+    end
+
+    DataCollector[0] << number
+
+    sleep 0.1
+  end
+end
+
+100.times { |i| Job.perform_later(i) }
+
+start_karafka_and_wait_until do
+  DataCollector[0].uniq.sort.size >= 100
+end
+
+# If we would mark as consumed
+assert_equal 2, DataCollector[0].count { |nr| nr == 94 }
+assert_equal DataCollector[0].uniq.sort, (0..99).to_a

--- a/spec/lib/karafka/pro/active_job/consumer_spec.rb
+++ b/spec/lib/karafka/pro/active_job/consumer_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe_current do
         allow(ActiveJob::Base).to receive(:execute).with(payload1)
         allow(ActiveJob::Base).to receive(:execute).with(payload2)
 
-        topic.virtual_partitioner = ->(_) { }
+        topic.virtual_partitioner = ->(_) {}
       end
 
       it 'expect to decode them and run active job executor' do

--- a/spec/lib/karafka/pro/active_job/consumer_spec.rb
+++ b/spec/lib/karafka/pro/active_job/consumer_spec.rb
@@ -84,6 +84,32 @@ RSpec.describe_current do
       end
     end
 
+    context 'when messages are available to the consumer and it is virtual partition' do
+      before do
+        consumer.messages = messages
+
+        allow(client).to receive(:mark_as_consumed)
+
+        allow(ActiveJob::Base).to receive(:execute).with(payload1)
+        allow(ActiveJob::Base).to receive(:execute).with(payload2)
+
+        topic.virtual_partitioner = ->(_) { }
+      end
+
+      it 'expect to decode them and run active job executor' do
+        consumer.consume
+
+        expect(ActiveJob::Base).to have_received(:execute).with(payload1)
+        expect(ActiveJob::Base).to have_received(:execute).with(payload2)
+      end
+
+      it 'expect not to mark each message during consumption' do
+        consumer.consume
+
+        expect(client).not_to have_received(:mark_as_consumed)
+      end
+    end
+
     context 'when messages are available but partition got revoked prior to processing' do
       before do
         consumer.messages = messages


### PR DESCRIPTION
This PR skips marking as consumed when Active Job is used with VP due to VP limitations.