### PR TITLE
add callbacks prior to subscription

### DIFF
--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -364,7 +364,6 @@ module Karafka
         config = ::Rdkafka::Config.new(@subscription_group.kafka)
         config.consumer_rebalance_listener = @rebalance_manager
         consumer = config.consumer
-        consumer.subscribe(*@subscription_group.topics.map(&:name))
         @name = consumer.name
 
         # Register statistics runner for this particular type of callbacks
@@ -389,6 +388,7 @@ module Karafka
           )
         )
 
+        consumer.subscribe(*@subscription_group.topics.map(&:name))
         consumer
       end
 


### PR DESCRIPTION
This fixes theoretical case where subscription would kick in faster than callbacks assignment (never encountered).