### PR TITLE
Bypass reload! Rails lag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka framework changelog
 
+## 2.0.2 (Unreleased)
+- Bypass issue with Rails reload in development by releasing the connection (https://github.com/rails/rails/issues/44183).
+
 ## 2.0.1 (2022-08-06)
 - Provide `Karafka::Admin` for creation and destruction of topics and fetching cluster info.
 - Update integration specs to always use one-time disposable topics.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka (2.0.1)
+    karafka (2.0.2)
       karafka-core (>= 2.0.2, < 3.0.0)
       rdkafka (>= 0.12)
       thor (>= 0.20)

--- a/lib/karafka/instrumentation/notifications.rb
+++ b/lib/karafka/instrumentation/notifications.rb
@@ -34,6 +34,7 @@ module Karafka
 
         worker.process
         worker.processed
+        worker.completed
 
         statistics.emitted
 

--- a/lib/karafka/processing/worker.rb
+++ b/lib/karafka/processing/worker.rb
@@ -46,8 +46,9 @@ module Karafka
       def process
         job = @jobs_queue.pop
 
+        instrument_details = { caller: self, job: job, jobs_queue: @jobs_queue }
+
         if job
-          instrument_details = { caller: self, job: job, jobs_queue: @jobs_queue }
 
           Karafka.monitor.instrument('worker.process', instrument_details)
 
@@ -82,6 +83,9 @@ module Karafka
       ensure
         # job can be nil when the queue is being closed
         @jobs_queue.complete(job) if job
+
+        # Always publish info, that we completed all the work despite its result
+        Karafka.monitor.instrument('worker.completed', instrument_details)
       end
     end
   end

--- a/lib/karafka/railtie.rb
+++ b/lib/karafka/railtie.rb
@@ -75,7 +75,6 @@ if rails
           # Reload code each time there is a change in the code
           next unless Rails.application.reloaders.any?(&:updated?)
 
-          # Rails.autoloaders.main.reload
           Rails.application.reloader.reload!
         end
 

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '2.0.1'
+  VERSION = '2.0.2'
 end


### PR DESCRIPTION
This PR bypasses: https://github.com/rails/rails/issues/44183

It releases the thread ActiveRecord lock, so the reloader does not have to wait for it.
