### PR TITLE
Pro loader and Rails logger dev verbose fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2.0.3 (Unreleased)
 - Update boot info on server startup.
 - Update `karafka info` with more descriptive Ruby version info.
+- Fix issue where when used with Rails in development, log would be too verbose.
+- Fix issue where Zeitwerk with Rails would not load Pro components despite license being present.
 
 ## 2.0.2 (2022-08-07)
 - Bypass issue with Rails reload in development by releasing the connection (https://github.com/rails/rails/issues/44183).

--- a/lib/karafka.rb
+++ b/lib/karafka.rb
@@ -85,8 +85,16 @@ end
 loader = Zeitwerk::Loader.for_gem
 # Do not load Rails extensions by default, this will be handled by Railtie if they are needed
 loader.ignore(Karafka.gem_root.join('lib/active_job'))
-# Do not load pro components, this will be handled by license manager
-loader.ignore(Karafka.gem_root.join('lib/karafka/pro'))
+
+begin
+  require 'karafka-license'
+rescue LoadError
+  # Do not load pro components if we cannot load the license
+  # This is a preliminary check so autoload works as expected
+  # Later on the licenser will make sure to setup all the needed components anyhow
+  loader.ignore(Karafka.gem_root.join('lib/karafka/pro'))
+end
+
 # Do not load vendors instrumentation components. Those need to be required manually if needed
 loader.ignore(Karafka.gem_root.join('lib/karafka/instrumentation/vendors'))
 loader.setup

--- a/lib/karafka/pro/loader.rb
+++ b/lib/karafka/pro/loader.rb
@@ -13,11 +13,34 @@ module Karafka
   module Pro
     # Loader requires and loads all the pro components only when they are needed
     class Loader
+      # All the pro components that need to be loaded
+      COMPONENTS = %w[
+        base_consumer
+        performance_tracker
+        processing/scheduler
+        processing/jobs/consume_non_blocking
+        processing/jobs_builder
+        processing/coordinator
+        processing/partitioner
+        contracts/base
+        contracts/consumer_group
+        contracts/consumer_group_topic
+        routing/topic_extensions
+        routing/builder_extensions
+        active_job/consumer
+        active_job/dispatcher
+        active_job/job_options_contract
+      ].freeze
+
+      private_constant :COMPONENTS
+
       class << self
         # Loads all the pro components and configures them wherever it is expected
         # @param config [Karafka::Core::Configurable::Node] app config that we can alter with pro
         #   components
         def setup(config)
+          COMPONENTS.each { |component| require_relative(component) }
+
           reconfigure(config)
 
           load_routing_extensions

--- a/lib/karafka/pro/loader.rb
+++ b/lib/karafka/pro/loader.rb
@@ -13,34 +13,11 @@ module Karafka
   module Pro
     # Loader requires and loads all the pro components only when they are needed
     class Loader
-      # All the pro components that need to be loaded
-      COMPONENTS = %w[
-        base_consumer
-        performance_tracker
-        processing/scheduler
-        processing/jobs/consume_non_blocking
-        processing/jobs_builder
-        processing/coordinator
-        processing/partitioner
-        contracts/base
-        contracts/consumer_group
-        contracts/consumer_group_topic
-        routing/topic_extensions
-        routing/builder_extensions
-        active_job/consumer
-        active_job/dispatcher
-        active_job/job_options_contract
-      ].freeze
-
-      private_constant :COMPONENTS
-
       class << self
         # Loads all the pro components and configures them wherever it is expected
         # @param config [Karafka::Core::Configurable::Node] app config that we can alter with pro
         #   components
         def setup(config)
-          COMPONENTS.each { |component| require_relative(component) }
-
           reconfigure(config)
 
           load_routing_extensions

--- a/lib/karafka/railtie.rb
+++ b/lib/karafka/railtie.rb
@@ -48,9 +48,13 @@ if rails
         next unless Rails.env.development?
         next unless ENV.key?('KARAFKA_CLI')
 
+        logger = ActiveSupport::Logger.new($stdout)
+        # Inherit the logger level from Rails, otherwise would always run with the debug level
+        logger.level = Rails.logger.level
+
         Rails.logger.extend(
           ActiveSupport::Logger.broadcast(
-            ActiveSupport::Logger.new($stdout)
+            logger
           )
         )
       end

--- a/spec/lib/karafka/time_trackers/poll_spec.rb
+++ b/spec/lib/karafka/time_trackers/poll_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe_current do
 
     it { expect(tracker.exceeded?).to eq(false) }
     it { expect(tracker.retryable?).to eq(false) }
-    it { expect(tracker.remaining).to be_within(5).of(185) }
+    it { expect(tracker.remaining).to be_within(10).of(185) }
     it { expect(tracker.attempts).to eq(3) }
 
     context 'when needing to backoff' do

--- a/spec/lib/karafka/time_trackers/poll_spec.rb
+++ b/spec/lib/karafka/time_trackers/poll_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe_current do
     before do
       tracker.start
 
-      sleep 0.199
+      sleep 0.1995
 
       tracker.checkpoint
     end


### PR DESCRIPTION
This PR fixes two issues:
- Too verbose Rails logger when used with logger broadcaster
- Not visible Pro components when discovered via Zeitwerk
