### PR TITLE
increase timeout for admin operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka framework changelog
 
+## Unreleased
+- Fix hanging topic creation (#964)
+
 ## 2.0.3 (2022-08-09)
 - Update boot info on server startup.
 - Update `karafka info` with more descriptive Ruby version info.

--- a/README.md
+++ b/README.md
@@ -89,4 +89,4 @@ Karafka has [Wiki pages](https://github.com/karafka/karafka/wiki) for almost eve
 
 If you have questions about using Karafka, feel free to join our [Slack](https://slack.karafka.io) channel.
 
-Karafka has priority support for technical and architectural questions that is part of the Karafka Pro subscription.
+Karafka has [priority support](https://github.com/karafka/karafka/wiki/Pro-Support) for technical and architectural questions that is part of the Karafka Pro subscription.

--- a/bin/integrations
+++ b/bin/integrations
@@ -28,7 +28,7 @@ MAX_BUFFER_OUTPUT = 51_200
 class Scenario
   # How long a scenario can run before we kill it
   # This is a fail-safe just in case something would hang
-  MAX_RUN_TIME = 3 * 60 # 3 minutes tops
+  MAX_RUN_TIME = 5 * 60 # 5 minutes tops
 
   # There are rare cases where Karafka may force shutdown for some of the integration cases
   # This includes exactly those

--- a/lib/karafka/admin.rb
+++ b/lib/karafka/admin.rb
@@ -9,6 +9,13 @@ module Karafka
   # @note It always uses the primary defined cluster and does not support multi-cluster work.
   #   If you need this, just replace the cluster info for the time you use this
   module Admin
+    # How long we should wait prior to failing a given operation
+    # Most of the time Kafka reacts real time, however in CI and other heavy loaded systems
+    # certain operations can take slightly more, thus the extended wait.
+    MAX_WAIT_TIMEOUT = 5 * 60
+
+    private_constant :MAX_WAIT_TIMEOUT
+
     class << self
       # Creates Kafka topic with given settings
       #
@@ -21,7 +28,7 @@ module Karafka
         with_admin do |admin|
           admin
             .create_topic(name, partitions, replication_factor, topic_config)
-            .wait
+            .wait(max_wait_timeout: MAX_WAIT_TIMEOUT)
         end
       end
 
@@ -32,7 +39,7 @@ module Karafka
         with_admin do |admin|
           admin
             .delete_topic(name)
-            .wait
+            .wait(max_wait_timeout: MAX_WAIT_TIMEOUT)
         end
       end
 


### PR DESCRIPTION
When CI is heavily utilized, Kafka reacts slowly, thus timeout extension.

This PR makes us re-query Kafka to make sure topic exists instead of relying on the wait that sometimes hangs.

close https://github.com/karafka/karafka/issues/964