### PR TITLE
Fix a indefinite manual pause after rebalance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Karafka framework changelog
 
-## Unreleased
+## 2.0.5 (Unreleased)
 - Fix unnecessary double new line in the `karafka.rb` template for Ruby on Rails
+- Fix a case where a manually paused partition would not be processed after rebalance (#988)
 
 ## 2.0.4 (2022-08-19)
 - Fix hanging topic creation (#964)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka (2.0.4)
+    karafka (2.0.5)
       karafka-core (>= 2.0.2, < 3.0.0)
       rdkafka (>= 0.12)
       thor (>= 0.20)

--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -70,10 +70,15 @@ module Karafka
       end
     end
 
-    # Trigger method for running on shutdown.
+    # Trigger method for running on partition revocation.
     #
     # @private
     def on_revoked
+      # We need to always un-pause the processing in case we have lost a given partition.
+      # Otherwise the underlying librdkafka would not know we may want to continue processing and
+      # the pause could in theory last forever
+      resume
+
       coordinator.revoke
 
       Karafka.monitor.instrument('consumer.revoked', caller: self) do

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '2.0.4'
+  VERSION = '2.0.5'
 end

--- a/spec/integrations/pausing/with_pause_and_resume_after_reclaim.rb
+++ b/spec/integrations/pausing/with_pause_and_resume_after_reclaim.rb
@@ -34,13 +34,11 @@ end
 draw_routes(Consumer)
 
 Thread.new do
-  begin
-    loop do
-      produce(DT.topic, '1', partition: [0, 1].sample)
-      sleep(0.1)
-    end
+  loop do
+    produce(DT.topic, '1', partition: [0, 1].sample)
+    sleep(0.1)
   rescue WaterDrop::Errors::ProducerClosedError
-    nil
+    break
   end
 end
 
@@ -71,3 +69,5 @@ end
 lost_partition = DT[:jumped][0]
 
 assert !DT[lost_partition].include?(DT[:jumped][1])
+
+other.join

--- a/spec/integrations/pausing/with_pause_and_resume_after_reclaim.rb
+++ b/spec/integrations/pausing/with_pause_and_resume_after_reclaim.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# We can pause and after revocation and re-claim we should continue processing like pause did
+# not happen. We should not keep the pause after a rebalance.
+#
+# Messages that were consumed by another process should not be re-consumed.
+
+setup_karafka do |config|
+  config.max_messages = 5
+end
+
+create_topic(partitions: 2, name: DT.topic)
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    partition = messages.metadata.partition
+
+    if !DT[:paused].include?(partition) && @second
+      pause(messages.last.offset + 1, 100_000)
+
+      DT[:paused] << partition
+
+      return
+    end
+
+    messages.each do |message|
+      DT[partition] << message.offset
+    end
+
+    @second = true
+  end
+end
+
+draw_routes(Consumer)
+
+Thread.new do
+  begin
+    loop do
+      produce(DT.topic, '1', partition: [0, 1].sample)
+      sleep(0.1)
+    end
+  rescue WaterDrop::Errors::ProducerClosedError
+    nil
+  end
+end
+
+consumer = setup_rdkafka_consumer
+
+other = Thread.new do
+  sleep(10)
+
+  consumer.subscribe(DT.topic)
+
+  consumer.each do |message|
+    DT[:jumped] << [message.partition, message.offset]
+    sleep 10
+    consumer.store_offset(message)
+    break
+  end
+
+  consumer.commit(nil, false)
+
+  consumer.close
+end
+
+start_karafka_and_wait_until do
+  DT[0].size >= 100 &&
+    DT[1].size >= 100
+end
+
+lost_partition = DT[:jumped][0]
+
+assert !DT[lost_partition].include?(DT[:jumped][1])

--- a/spec/integrations/pro/rebalancing/revoke_continuity.rb
+++ b/spec/integrations/pro/rebalancing/revoke_continuity.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+# When Karafka Pro looses a given partition but later gets it back, it should pick it up from the
+# last offset committed without any problems
+
+setup_karafka do |config|
+  config.license.token = pro_license_token
+  config.concurrency = 4
+end
+
+create_topic(partitions: 2)
+
+class Consumer < Karafka::Pro::BaseConsumer
+  def consume
+    partition = messages.metadata.partition
+
+    messages.each do |message|
+      # We store offsets only until revoked
+      return unless mark_as_consumed!(message)
+
+      DT[partition] << message.offset
+    end
+
+    return if @marked
+
+    # For partition we have lost this will run twice
+    DT[:partitions] << partition
+    @marked = true
+  end
+end
+
+draw_routes do
+  consumer_group DT.consumer_group do
+    topic DT.topic do
+      consumer Consumer
+    end
+  end
+end
+
+Thread.new do
+  loop do
+    2.times do
+      produce(DT.topic, '1', partition: 0)
+      produce(DT.topic, '1', partition: 1)
+    end
+
+    sleep(0.5)
+  rescue StandardError
+    nil
+  end
+end
+
+# We need a second producer to trigger a rebalance
+consumer = setup_rdkafka_consumer
+
+other = Thread.new do
+  sleep(10)
+
+  consumer.subscribe(DT.topic)
+
+  consumer.each do |message|
+    DT[:jumped] << message
+    consumer.store_offset(message)
+    break
+  end
+
+  consumer.commit(nil, false)
+
+  consumer.close
+end
+
+start_karafka_and_wait_until do
+  other.join && DT[:partitions].size >= 3
+end
+
+revoked_partition = DT[:jumped].first.partition
+jumped_offset = DT[:jumped].first.offset
+
+assert_equal 1, DT[:jumped].size
+
+# This single one should have been consumed by a different process
+assert_equal false, DT.data[revoked_partition].include?(jumped_offset)
+
+# We should have all the others in proper order and without any other missing
+previous = nil
+
+DT.data[revoked_partition].each do |offset|
+  unless previous
+    previous = offset
+    next
+  end
+
+  previous = jumped_offset if previous + 1 == jumped_offset
+
+  assert_equal previous + 1, offset
+
+  previous = offset
+end

--- a/spec/integrations/pro/rebalancing/virtual_partitions/rebalance_continuity.rb
+++ b/spec/integrations/pro/rebalancing/virtual_partitions/rebalance_continuity.rb
@@ -18,7 +18,6 @@ class Consumer < Karafka::Pro::BaseConsumer
       DT[0] << message.raw_payload
     end
 
-
     # This will ensure we can move forward
     mark_as_consumed(messages.first)
   end

--- a/spec/integrations/pro/rebalancing/with_static_membership_reconnect.rb
+++ b/spec/integrations/pro/rebalancing/with_static_membership_reconnect.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+# Karafka process when stopped and started and configured with static membership should pick up
+# the assigned work. It should not be reassigned to a different process.
+# Karafka should maintain all the ordering and should not have duplicated.
+
+require 'securerandom'
+
+setup_karafka do |config|
+  config.license.token = pro_license_token
+  config.initial_offset = 'latest'
+  config.kafka[:'group.instance.id'] = SecureRandom.uuid
+end
+
+create_topic(partitions: 2)
+
+class Consumer < Karafka::Pro::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[:process2] << [message.raw_payload.to_i, message.partition]
+    end
+  end
+
+  def shutdown
+    DT[:process2] << :stop
+  end
+end
+
+draw_routes(Consumer)
+
+# @note We use external messages producer here, as the one from Karafka will be closed upon first
+# process shutdown.
+PRODUCER = ::WaterDrop::Producer.new do |producer_config|
+  producer_config.kafka = Karafka::App.config.kafka.dup
+  producer_config.logger = Karafka::App.config.logger
+  producer_config.max_wait_timeout = 120
+end
+
+Thread.new do
+  nr = 0
+
+  loop do
+    2.times do |i|
+      PRODUCER.produce_sync(
+        topic: DT.topic,
+        payload: nr.to_s,
+        partition: i
+      )
+    end
+
+    nr += 1
+
+    sleep(0.1)
+  end
+end
+
+# Give it some time to start sending messages
+sleep(2)
+
+# First we start the first producer, so the one that we want to track activity of, gets only
+# one partition assigned, so we don't have to worry about figuring out which partition it got
+other = Thread.new do
+  consumer = setup_rdkafka_consumer(
+    'group.instance.id': SecureRandom.uuid,
+    'auto.offset.reset': 'latest'
+  )
+
+  consumer.subscribe(DT.topic)
+
+  consumer.each do |message|
+    DT[:process1] << [message.payload.to_i, message.partition]
+
+    break if DT.data.key?(:terminate)
+  end
+
+  consumer.close
+end
+
+# Give it some time to start before starting Karafka main process
+sleep 5
+
+start_karafka_and_wait_until do
+  DT[:process2].size >= 20
+end
+
+# Wait to make sure, that the process 1 does not get the partitions back
+sleep 5
+
+# After stopping start once again
+
+start_karafka_and_wait_until do
+  DT[:process2].size >= 100
+end
+
+# Give it some time, so we allow (potentially) to assing all messages to process 1
+sleep 5
+
+# Close the first consumer instance
+DT[:terminate] = true
+
+other.join
+
+# Initially the first started producer should get some data from both partitions before the first
+# rebalance
+assert_equal [0, 1], DT[:process1].map(&:last).uniq.sort
+
+# Second process should have been stopped two times
+stops_count = DT[:process2].count { |message| message == :stop }
+assert_equal 2, stops_count
+
+process2_messages = DT[:process2].select { |message| message.is_a?(Array) }
+
+# Second process should have only one partition as joined later with static membership
+assert_equal 1, process2_messages.map(&:last).uniq.size
+
+# After getting back to the consumption, we should get all the messages with a continuity
+previous = nil
+
+process2_messages.each do |message|
+  unless previous
+    previous = message
+    next
+  end
+
+  assert_equal previous.first + 1, message.first
+
+  previous = message
+end
+
+# After the stop, none of the messages should be fetched by the process 1 when process 2 was not
+# consuming
+after = DT[:process2].index(:stop)
+post_rebalance_messages = DT
+                          .data[:process2]
+                          .select
+                          .with_index { |_, index| index > after }
+                          .select { |message| message.is_a?(Array) }
+
+assert (DT[:process1] & post_rebalance_messages).empty?


### PR DESCRIPTION
close https://github.com/karafka/karafka/issues/988

This spec also adds an integration case for this case.

We do not run this for LRJ as LRJ will automatically resume after finishing (via resume when success or short pause when failed)