### PR TITLE
Extended sleep in one of the specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2.0.5 (Unreleased)
 - Fix unnecessary double new line in the `karafka.rb` template for Ruby on Rails
 - Fix a case where a manually paused partition would not be processed after rebalance (#988)
+- Increase specs stability.
+- Lower concurrency of execution of specs in Github CI.
 
 ## 2.0.4 (2022-08-19)
 - Fix hanging topic creation (#964)

--- a/bin/integrations
+++ b/bin/integrations
@@ -19,7 +19,7 @@ ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../
 # When the value is high, there's a problem with thread allocation on Github CI, tht is why
 # we limit it. Locally we can run a lot of those, as many of them have sleeps and do not use a lot
 # of CPU
-CONCURRENCY = ENV.key?('CI') ? 5 : Etc.nprocessors * 2
+CONCURRENCY = ENV.key?('CI') ? 3 : Etc.nprocessors * 2
 
 # How may bytes do we want to keep from the stdout in the buffer for when we need to print it
 MAX_BUFFER_OUTPUT = 51_200

--- a/spec/integrations/pro/rebalancing/long_running_jobs/continuity_after_error_and_rebalance.rb
+++ b/spec/integrations/pro/rebalancing/long_running_jobs/continuity_after_error_and_rebalance.rb
@@ -38,7 +38,7 @@ other = Thread.new do
 
   consumer.each do |message|
     DT[:jumped] << [message.partition, message.offset]
-    sleep 5
+    sleep 15
     consumer.store_offset(message)
     break
   end

--- a/spec/integrations_helper.rb
+++ b/spec/integrations_helper.rb
@@ -140,7 +140,7 @@ def wait_until
 
     # Stop if it was running for 2 minutes and nothing changed
     # This prevent from hanging in case of specs instability
-    raise StandardError, 'Execution expired' if (Time.now - started_at) > 120
+    raise StandardError, 'Execution expired' if (Time.now - started_at) > 180
 
     sleep(0.01)
   end

--- a/spec/lib/karafka/time_trackers/pause_spec.rb
+++ b/spec/lib/karafka/time_trackers/pause_spec.rb
@@ -224,8 +224,8 @@ RSpec.describe_current do
   end
 
   context 'when we define a custom manual pause time' do
-    let(:timeout) { 100 }
-    let(:max_timeout) { 100 }
+    let(:timeout) { 5000 }
+    let(:max_timeout) { 5000 }
     let(:exponential_backoff) { false }
 
     context 'when pause tracker is created' do


### PR DESCRIPTION
This PR extends sleep in one of the specs to compensate for its instability.

GH CI runners are shared and it seems their CPU is not stable when doing heavy parallel work, thus values are lowered.
