### PR TITLE
Improve potential double closing edge case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka framework changelog
 
+## Unreleased
+- Improve client closing.
+
 ## 2.0.5 (2022-08-23)
 - Fix unnecessary double new line in the `karafka.rb` template for Ruby on Rails
 - Fix a case where a manually paused partition would not be processed after rebalance (#988)

--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -275,15 +275,15 @@ module Karafka
 
       # Commits the stored offsets in a sync way and closes the consumer.
       def close
-        # Once client is closed, we should not close it again
-        # This could only happen in case of a race-condition when forceful shutdown happens
-        # and triggers this from a different thread
-        return if @closed
-
         @mutex.synchronize do
-          internal_commit_offsets(async: false)
+          # Once client is closed, we should not close it again
+          # This could only happen in case of a race-condition when forceful shutdown happens
+          # and triggers this from a different thread
+          return if @closed
 
           @closed = true
+
+          internal_commit_offsets(async: false)
 
           # Remove callbacks runners that were registered
           ::Karafka::Instrumentation.statistics_callbacks.delete(@subscription_group.id)


### PR DESCRIPTION
This PR moves check on client being closed to a mutex. This ensures we do not close twice on forceful shutdown.