### PR TITLE
Prevent multiple LRJ from blocking polling on pausing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Karafka framework changelog
 
-## Unreleased
+## 2.0.6 (Unreleased)
 - Improve client closing.
+- Fix for: Multiple LRJ topics fetched concurrently block ability for LRJ to kick in (#1002)
+- Introduce a pre-enqueue sync execution layer to prevent starvation cases for LRJ
 
 ## 2.0.5 (2022-08-23)
 - Fix unnecessary double new line in the `karafka.rb` template for Ruby on Rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka (2.0.5)
+    karafka (2.0.6)
       karafka-core (>= 2.0.2, < 3.0.0)
       rdkafka (>= 0.12)
       thor (>= 0.20)

--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -29,7 +29,10 @@ module Karafka
     # @note This should not be used by the end users as it is part of the lifecycle of things and
     #   not as part of the public api. This can act as a hook when creating non-blocking
     #   consumers and doing other advanced stuff
-    def on_before_consume; end
+    def on_before_consume
+      messages.metadata.processed_at = Time.now
+      messages.metadata.freeze
+    end
 
     # Executes the default consumer flow.
     #

--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -15,10 +15,18 @@ module Karafka
     # @return [Waterdrop::Producer] producer instance
     attr_accessor :producer
 
-    # Can be used to run preparation code
+    # Can be used to run preparation code prior to the job being enqueued
     #
     # @private
-    # @note This should not be used by the end users as it is part of the lifecycle of things but
+    # @note This should not be used by the end users as it is part of the lifecycle of things and
+    #   not as a part of the public api. This should not perform any extensive operations as it is
+    #   blocking and running in the listener thread.
+    def on_before_enqueue; end
+
+    # Can be used to run preparation code in the worker
+    #
+    # @private
+    # @note This should not be used by the end users as it is part of the lifecycle of things and
     #   not as part of the public api. This can act as a hook when creating non-blocking
     #   consumers and doing other advanced stuff
     def on_before_consume; end

--- a/lib/karafka/messages/builders/batch_metadata.rb
+++ b/lib/karafka/messages/builders/batch_metadata.rb
@@ -28,9 +28,8 @@ module Karafka
               created_at: messages.last.timestamp,
               # When this batch was built and scheduled for execution
               scheduled_at: scheduled_at,
-              # We build the batch metadata when we pick up the job in the worker, thus we can use
-              # current time here
-              processed_at: Time.now
+              # This needs to be set to a correct value prior to processing starting
+              processed_at: nil
             )
           end
         end

--- a/lib/karafka/messages/builders/messages.rb
+++ b/lib/karafka/messages/builders/messages.rb
@@ -14,11 +14,13 @@ module Karafka
           # @param received_at [Time] moment in time when the messages were received
           # @return [Karafka::Messages::Messages] messages batch object
           def call(messages, topic, received_at)
+            # We cannot freeze the batch metadata because it is altered with the processed_at time
+            # prior to the consumption. It is being frozen there
             metadata = BatchMetadata.call(
               messages,
               topic,
               received_at
-            ).freeze
+            )
 
             Karafka::Messages::Messages.new(
               messages,

--- a/lib/karafka/pro/base_consumer.rb
+++ b/lib/karafka/pro/base_consumer.rb
@@ -33,7 +33,7 @@ module Karafka
         return unless topic.long_running_job?
 
         # This ensures, that when running LRJ with VP, things operate as expected
-        coordinator.on_started do |first_group_message|
+        coordinator.on_enqueued do |first_group_message|
           # Pause at the first message in a batch. That way in case of a crash, we will not loose
           # any messages
           pause(first_group_message.offset, MAX_PAUSE_TIME)

--- a/lib/karafka/pro/base_consumer.rb
+++ b/lib/karafka/pro/base_consumer.rb
@@ -23,9 +23,13 @@ module Karafka
 
       private_constant :MAX_PAUSE_TIME
 
-      # Pauses processing of a given partition until we're done with the processing
+      # Pauses processing of a given partition until we're done with the processing.
       # This ensures, that we can easily poll not reaching the `max.poll.interval`
-      def on_before_consume
+      # @note This needs to happen in the listener thread, because we cannot wait on this being
+      #   executed in the workers. Workers may be already running some LRJ jobs that are blocking
+      #   all the threads until finished, yet unless we pause the incoming partitions information,
+      #   we may be kicked out of the consumer group due to not polling often enough
+      def on_before_enqueue
         return unless topic.long_running_job?
 
         # This ensures, that when running LRJ with VP, things operate as expected

--- a/lib/karafka/pro/processing/coordinator.rb
+++ b/lib/karafka/pro/processing/coordinator.rb
@@ -18,6 +18,7 @@ module Karafka
         # @param args [Object] anything the base coordinator accepts
         def initialize(*args)
           super
+          @on_enqueued_invoked = false
           @on_started_invoked = false
           @on_finished_invoked = false
           @flow_lock = Mutex.new
@@ -40,6 +41,16 @@ module Karafka
         # @return [Boolean] is the coordinated work finished or not
         def finished?
           @running_jobs.zero?
+        end
+
+        def on_enqueued
+          @flow_lock.synchronize do
+            return if @on_enqueued_invoked
+
+            @on_enqueued_invoked = true
+
+            yield(@first_message, @last_message)
+          end
         end
 
         # Runs given code only once per all the coordinated jobs upon starting first of them

--- a/lib/karafka/pro/processing/coordinator.rb
+++ b/lib/karafka/pro/processing/coordinator.rb
@@ -31,6 +31,7 @@ module Karafka
           super
 
           @mutex.synchronize do
+            @on_enqueued_invoked = false
             @on_started_invoked = false
             @on_finished_invoked = false
             @first_message = messages.first
@@ -43,6 +44,8 @@ module Karafka
           @running_jobs.zero?
         end
 
+        # Runs synchronized code once for a collective of virtual partitions prior to work being
+        # enqueued
         def on_enqueued
           @flow_lock.synchronize do
             return if @on_enqueued_invoked

--- a/lib/karafka/pro/processing/jobs/consume_non_blocking.rb
+++ b/lib/karafka/pro/processing/jobs/consume_non_blocking.rb
@@ -26,6 +26,7 @@ module Karafka
         #   management. This layer of the framework knows nothing about Kafka messages consumption.
         class ConsumeNonBlocking < ::Karafka::Processing::Jobs::Consume
           # Makes this job non-blocking from the start
+          # @param args [Array] any arguments accepted by `::Karafka::Processing::Jobs::Consume`
           def initialize(*args)
             super
             @non_blocking = true

--- a/lib/karafka/pro/processing/jobs/consume_non_blocking.rb
+++ b/lib/karafka/pro/processing/jobs/consume_non_blocking.rb
@@ -25,8 +25,8 @@ module Karafka
         # @note It needs to be working with a proper consumer that will handle the partition
         #   management. This layer of the framework knows nothing about Kafka messages consumption.
         class ConsumeNonBlocking < ::Karafka::Processing::Jobs::Consume
-          # Releases the blocking lock after it is done with the preparation phase for this job
-          def before_call
+          # Makes this job non-blocking from the start
+          def initialize(*args)
             super
             @non_blocking = true
           end

--- a/lib/karafka/processing/executor.rb
+++ b/lib/karafka/processing/executor.rb
@@ -37,14 +37,17 @@ module Karafka
         @topic = topic
       end
 
-      # Builds the consumer instance, builds messages batch and sets all that is needed to run the
-      # user consumption logic
+      # Allows us to prepare the consumer in the listener thread prior to the job being send to
+      # the queue. It also allows to run some code that is time sensitive and cannot wait in the
+      # queue as it could cause starvation.
       #
       # @param messages [Array<Karafka::Messages::Message>]
-      # @param received_at [Time] the moment we've received the batch (actually the moment we've)
-      #   enqueued it, but good enough
       # @param coordinator [Karafka::Processing::Coordinator] coordinator for processing management
-      def before_consume(messages, received_at, coordinator)
+      def before_enqueue(messages, coordinator)
+        # the moment we've received the batch or actually the moment we've enqueued it,
+        # but good enough
+        @enqueued_at = Time.now
+
         # Recreate consumer with each batch if persistence is not enabled
         # We reload the consumers with each batch instead of relying on some external signals
         # when needed for consistency. That way devs may have it on or off and not in this
@@ -57,9 +60,14 @@ module Karafka
         consumer.messages = Messages::Builders::Messages.call(
           messages,
           @topic,
-          received_at
+          @enqueued_at
         )
 
+        consumer.on_before_enqueue
+      end
+
+      # Runs setup and warmup code in the worker prior to running the consumption
+      def before_consume
         consumer.on_before_consume
       end
 

--- a/lib/karafka/processing/executor.rb
+++ b/lib/karafka/processing/executor.rb
@@ -66,7 +66,7 @@ module Karafka
         consumer.on_before_enqueue
       end
 
-      # Runs setup and warmup code in the worker prior to running the consumption
+      # Runs setup and warm-up code in the worker prior to running the consumption
       def before_consume
         consumer.on_before_consume
       end

--- a/lib/karafka/processing/jobs/base.rb
+++ b/lib/karafka/processing/jobs/base.rb
@@ -22,6 +22,10 @@ module Karafka
           @non_blocking = false
         end
 
+        # When redefined can run any code prior to the job being enqueued
+        # @note This will run in the listener thread and not in the worker
+        def before_enqueue; end
+
         # When redefined can run any code that should run before executing the proper code
         def before_call; end
 

--- a/lib/karafka/processing/jobs/consume.rb
+++ b/lib/karafka/processing/jobs/consume.rb
@@ -18,13 +18,16 @@ module Karafka
           @executor = executor
           @messages = messages
           @coordinator = coordinator
-          @created_at = Time.now
           super()
+        end
+
+        def before_enqueue
+          executor.before_enqueue(@messages, @coordinator)
         end
 
         # Runs the before consumption preparations on the executor
         def before_call
-          executor.before_consume(@messages, @created_at, @coordinator)
+          executor.before_consume
         end
 
         # Runs the given executor

--- a/lib/karafka/processing/jobs/consume.rb
+++ b/lib/karafka/processing/jobs/consume.rb
@@ -21,6 +21,8 @@ module Karafka
           super()
         end
 
+        # Runs all the preparation code on the executor that needs to happen before the job is
+        # enqueued.
         def before_enqueue
           executor.before_enqueue(@messages, @coordinator)
         end

--- a/lib/karafka/processing/worker.rb
+++ b/lib/karafka/processing/worker.rb
@@ -49,7 +49,6 @@ module Karafka
         instrument_details = { caller: self, job: job, jobs_queue: @jobs_queue }
 
         if job
-
           Karafka.monitor.instrument('worker.process', instrument_details)
 
           Karafka.monitor.instrument('worker.processed', instrument_details) do

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '2.0.5'
+  VERSION = '2.0.6'
 end

--- a/spec/integrations/lags/processing_not_enough_threads.rb
+++ b/spec/integrations/lags/processing_not_enough_threads.rb
@@ -35,6 +35,4 @@ end
 
 max_lag = DT[:processing_lags].max
 
-p max_lag
-
 assert (200..300).cover?(max_lag)

--- a/spec/integrations/lags/processing_not_enough_threads.rb
+++ b/spec/integrations/lags/processing_not_enough_threads.rb
@@ -35,4 +35,6 @@ end
 
 max_lag = DT[:processing_lags].max
 
+p max_lag
+
 assert (200..300).cover?(max_lag)

--- a/spec/integrations/pro/consumption/long_running_jobs/no_revocation_on_low_concurrency.rb
+++ b/spec/integrations/pro/consumption/long_running_jobs/no_revocation_on_low_concurrency.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# When running LRJ with low concurrency and many LRJ topics, we should not be kicked out of the
+# consumer group after reaching the interval. Pausing should happen prior to processing and it
+# should ensure that all new LRJ topics and partitions assigned are paused even when there are no
+# available workers to do the work.
+
+setup_karafka do |config|
+  config.max_messages = 1
+  # We set it here that way not too wait too long on stuff
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+  config.license.token = pro_license_token
+  config.concurrency = 1
+end
+
+class Consumer < Karafka::Pro::BaseConsumer
+  def consume
+    sleep(15)
+
+    DT[:work] << messages.metadata.topic
+  end
+
+  def revoked
+    DT[:revoked] << true
+  end
+end
+
+draw_routes do
+  consumer_group DT.consumer_group do
+    topic DT.topics[0] do
+      consumer Consumer
+      long_running_job true
+    end
+
+    topic DT.topics[1] do
+      consumer Consumer
+      long_running_job true
+    end
+  end
+end
+
+5.times { produce(DT.topics[0], '1') }
+5.times { produce(DT.topics[1], '1') }
+
+start_karafka_and_wait_until do
+  DT[:work].uniq.size >= 2
+end
+
+# There should be no forced revocation as we should not reach the max poll
+assert DT[:revoked].empty?

--- a/spec/lib/karafka/messages/builders/batch_metadata_spec.rb
+++ b/spec/lib/karafka/messages/builders/batch_metadata_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe_current do
     it { expect(result.scheduled_at).to eq(scheduled_at) }
 
     it 'expect to have processed_at set to nil, since not yet picked up' do
-      expect(result.processed_at).to eq(now)
+      expect(result.processed_at).to eq(nil)
     end
 
     context 'when processed_at is assigned to the build metadata' do

--- a/spec/lib/karafka/pro/active_job/consumer_spec.rb
+++ b/spec/lib/karafka/pro/active_job/consumer_spec.rb
@@ -32,12 +32,12 @@ RSpec.describe_current do
 
   it { expect(described_class).to be < Karafka::Pro::BaseConsumer }
 
-  describe '#on_before_consume behaviour' do
+  describe '#on_before_enqueue behaviour' do
     before { allow(consumer).to receive(:pause) }
 
     context 'when it is not a lrj' do
       it 'expect not to pause' do
-        consumer.on_before_consume
+        consumer.on_before_enqueue
 
         expect(consumer).not_to have_received(:pause)
       end
@@ -50,7 +50,7 @@ RSpec.describe_current do
       end
 
       it 'expect to pause forever on our first message' do
-        consumer.on_before_consume
+        consumer.on_before_enqueue
 
         expect(consumer).to have_received(:pause).with(message1.offset, 1_000_000_000_000)
       end

--- a/spec/lib/karafka/pro/processing/coordinator_spec.rb
+++ b/spec/lib/karafka/pro/processing/coordinator_spec.rb
@@ -3,17 +3,77 @@
 require 'karafka/pro/processing/coordinator'
 
 RSpec.describe_current do
+  subject(:coordinator) { described_class.new(pause_tracker) }
+
+  let(:pause_tracker) { build(:time_trackers_pause) }
+  let(:first_message) { build(:messages_message) }
+  let(:last_message) { build(:messages_message) }
+  let(:messages) { [first_message, last_message] }
+
   it { expect(described_class).to be < Karafka::Processing::Coordinator }
 
+  before { coordinator.start(messages) }
+
   describe '#finished?' do
-    pending
+    context 'when no jobs are running' do
+      it { expect(coordinator.finished?).to eq(true) }
+    end
+
+    context 'when there are running jobs' do
+      before { coordinator.increment }
+
+      it { expect(coordinator.finished?).to eq(false) }
+    end
+  end
+
+  describe '#on_enqueued' do
+    context 'when executed for the first time' do
+      it 'expect to run with first and last message info' do
+        args = [first_message, last_message]
+        expect { |block| coordinator.on_enqueued(&block) }.to yield_with_args(*args)
+      end
+    end
+
+    context 'when executed already once' do
+      before { coordinator.on_enqueued {} }
+
+      it 'expect not to run again' do
+        expect { |block| coordinator.on_enqueued(&block) }.not_to yield_control
+      end
+    end
   end
 
   describe '#on_started' do
-    pending
+    context 'when executed for the first time' do
+      it 'expect to run with first and last message info' do
+        args = [first_message, last_message]
+        expect { |block| coordinator.on_started(&block) }.to yield_with_args(*args)
+      end
+    end
+
+    context 'when executed already once' do
+      before { coordinator.on_started {} }
+
+      it 'expect not to run again' do
+        expect { |block| coordinator.on_started(&block) }.not_to yield_control
+      end
+    end
   end
 
   describe '#on_finished' do
-    pending
+    context 'when executed for the first time' do
+      it 'expect to run with first and last message info' do
+        args = [first_message, last_message]
+        expect { |block| coordinator.on_finished(&block) }.to yield_with_args(*args)
+      end
+    end
+
+    context 'when executed already once' do
+      before { coordinator.on_finished {} }
+
+      it 'expect not to run again' do
+        expect { |block| coordinator.on_finished(&block) }.not_to yield_control
+      end
+    end
   end
 end

--- a/spec/lib/karafka/pro/processing/jobs/consume_non_blocking_spec.rb
+++ b/spec/lib/karafka/pro/processing/jobs/consume_non_blocking_spec.rb
@@ -10,22 +10,18 @@ RSpec.describe_current do
   let(:coordinator) { build(:processing_coordinator) }
   let(:time_now) { Time.now }
 
-  it { expect(job.non_blocking?).to eq(false) }
+  it { expect(job.non_blocking?).to eq(true) }
   it { expect(described_class).to be < ::Karafka::Processing::Jobs::Consume }
 
-  describe '#before_call' do
+  describe '#before_enqueue' do
     before do
       allow(Time).to receive(:now).and_return(time_now)
-      allow(executor).to receive(:before_consume)
+      allow(executor).to receive(:before_enqueue)
     end
 
-    it 'expect to run before_consume on the executor with time and messages' do
-      job.before_call
-      expect(executor).to have_received(:before_consume).with(messages, time_now, coordinator)
-    end
-
-    it 'expect to mark this job as non blocking after it is done with preparation' do
-      expect { job.before_call }.to change(job, :non_blocking?).from(false).to(true)
+    it 'expect to run before_enqueue on the executor with time and messages' do
+      job.before_enqueue
+      expect(executor).to have_received(:before_enqueue).with(messages, coordinator)
     end
   end
 end

--- a/spec/lib/karafka/processing/jobs/consume_spec.rb
+++ b/spec/lib/karafka/processing/jobs/consume_spec.rb
@@ -6,19 +6,28 @@ RSpec.describe_current do
   let(:executor) { build(:processing_executor) }
   let(:messages) { [rand] }
   let(:coordinator) { build(:processing_coordinator) }
-  let(:time_now) { Time.now }
 
   it { expect(job.non_blocking?).to eq(false) }
 
-  describe '#before_consume' do
+  describe '#before_enqueue' do
     before do
-      allow(Time).to receive(:now).and_return(time_now)
+      allow(executor).to receive(:before_enqueue)
+      job.before_enqueue
+    end
+
+    it 'expect to run before_enqueue on the executor with time and messages' do
+      expect(executor).to have_received(:before_enqueue).with(messages, coordinator)
+    end
+  end
+
+  describe '#before_call' do
+    before do
       allow(executor).to receive(:before_consume)
       job.before_call
     end
 
-    it 'expect to run before_consume on the executor with time and messages' do
-      expect(executor).to have_received(:before_consume).with(messages, time_now, coordinator)
+    it 'expect to run before_consume on the executor' do
+      expect(executor).to have_received(:before_consume).with(no_args)
     end
   end
 


### PR DESCRIPTION
close https://github.com/karafka/karafka/issues/1002

This PR ensures that even when having multiple LRJ topics with multiple partitions in the same consumer group, they are not starved because of low concurrency. This could cause polling to be blocked.

No public API changes.