### PR TITLE
Multi-topic (100) consumption scenario with a single consumer group

### DIFF
--- a/spec/integrations/consumption/many_topics_same_group.rb
+++ b/spec/integrations/consumption/many_topics_same_group.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Karafka should be able to subscribe and consume messages from as many topics as someone wants
+# Here we consume from 100 topics
+
+setup_karafka do |config|
+  config.concurrency = 5
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[:topics] << messages.metadata.topic
+  end
+end
+
+draw_routes do
+  DT.topics.each do |topic_name|
+    topic topic_name do
+      consumer Consumer
+    end
+  end
+end
+
+messages = DT.topics.map do |topic_name|
+  { topic: topic_name, payload: '1' }
+end
+
+Karafka.producer.produce_many_sync(messages)
+
+start_karafka_and_wait_until do
+  DT[:topics].uniq.size >= DT.topics.size
+end
+
+# No specs needed, if not all consumed, will hang

--- a/spec/lib/karafka/time_trackers/pause_spec.rb
+++ b/spec/lib/karafka/time_trackers/pause_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe_current do
 
     context 'when not paused over timeout' do
       before do
+        allow(::Process).to receive(:clock_gettime).and_return(0.763, 0.764)
         tracker.pause
-        sleep(0.001)
       end
 
       it { expect(tracker.expired?).to eq(false) }
@@ -41,8 +41,8 @@ RSpec.describe_current do
 
     context 'when paused over timeout' do
       before do
+        allow(::Process).to receive(:clock_gettime).and_return(0.763, 1.764)
         tracker.pause
-        sleep(0.01)
       end
 
       it { expect(tracker.expired?).to eq(true) }
@@ -65,8 +65,8 @@ RSpec.describe_current do
 
     context 'when paused over timeout and resumed' do
       before do
+        allow(::Process).to receive(:clock_gettime).and_return(0.763, 1.764)
         tracker.pause
-        sleep(0.01)
         tracker.resume
       end
 
@@ -77,8 +77,8 @@ RSpec.describe_current do
 
     context 'when paused over timeout, resumed and reset' do
       before do
+        allow(::Process).to receive(:clock_gettime).and_return(0.763, 1.764)
         tracker.pause
-        sleep(0.01)
         tracker.resume
         tracker.reset
       end
@@ -110,8 +110,9 @@ RSpec.describe_current do
 
     context 'when not paused over timeout nor max timeout' do
       before do
+        # 1 ms of a difference
+        allow(::Process).to receive(:clock_gettime).and_return(0.763, 0.764)
         tracker.pause
-        sleep(0.001)
       end
 
       it { expect(tracker.expired?).to eq(false) }
@@ -121,8 +122,8 @@ RSpec.describe_current do
 
     context 'when paused over max timeout' do
       before do
+        allow(::Process).to receive(:clock_gettime).and_return(0.763, 0.769)
         tracker.pause
-        sleep(0.006)
       end
 
       it { expect(tracker.expired?).to eq(true) }
@@ -132,8 +133,8 @@ RSpec.describe_current do
 
     context 'when paused over timeout and resumed' do
       before do
+        allow(::Process).to receive(:clock_gettime).and_return(0.763, 0.769)
         tracker.pause
-        sleep(0.01)
         tracker.resume
       end
 
@@ -144,8 +145,8 @@ RSpec.describe_current do
 
     context 'when paused over timeout, resumed and reset' do
       before do
+        allow(::Process).to receive(:clock_gettime).and_return(0.763, 0.769)
         tracker.pause
-        sleep(0.01)
         tracker.resume
         tracker.reset
       end
@@ -177,8 +178,8 @@ RSpec.describe_current do
 
     context 'when not paused over timeout nor max timeout' do
       before do
+        allow(::Process).to receive(:clock_gettime).and_return(0.763, 0.764)
         tracker.pause
-        sleep(0.001)
       end
 
       it { expect(tracker.expired?).to eq(false) }
@@ -188,8 +189,8 @@ RSpec.describe_current do
 
     context 'when paused over max timeout' do
       before do
+        allow(::Process).to receive(:clock_gettime).and_return(0.763, 1.764)
         tracker.pause
-        sleep(0.1)
       end
 
       it { expect(tracker.expired?).to eq(true) }
@@ -199,8 +200,8 @@ RSpec.describe_current do
 
     context 'when paused over timeout and resumed' do
       before do
+        allow(::Process).to receive(:clock_gettime).and_return(0.763, 1.764)
         tracker.pause
-        sleep(0.01)
         tracker.resume
       end
 
@@ -211,8 +212,8 @@ RSpec.describe_current do
 
     context 'when paused over timeout, resumed and reset' do
       before do
+        allow(::Process).to receive(:clock_gettime).and_return(0.763, 1.764)
         tracker.pause
-        sleep(0.01)
         tracker.resume
         tracker.reset
       end
@@ -255,8 +256,8 @@ RSpec.describe_current do
 
     context 'when not paused over timeout nor max timeout' do
       before do
+        allow(::Process).to receive(:clock_gettime).and_return(0.763, 0.764)
         tracker.pause(2)
-        sleep(0.001)
       end
 
       it { expect(tracker.expired?).to eq(false) }
@@ -266,8 +267,8 @@ RSpec.describe_current do
 
     context 'when paused over max timeout' do
       before do
+        allow(::Process).to receive(:clock_gettime).and_return(0.763, 1.764)
         tracker.pause(1)
-        sleep(0.006)
       end
 
       it { expect(tracker.expired?).to eq(true) }
@@ -277,8 +278,8 @@ RSpec.describe_current do
 
     context 'when paused over timeout and resumed' do
       before do
+        allow(::Process).to receive(:clock_gettime).and_return(0.763, 1.764)
         tracker.pause(1)
-        sleep(0.01)
         tracker.resume
       end
 
@@ -289,8 +290,8 @@ RSpec.describe_current do
 
     context 'when paused over timeout, resumed and reset' do
       before do
+        allow(::Process).to receive(:clock_gettime).and_return(0.763, 1.764)
         tracker.pause(1)
-        sleep(0.01)
         tracker.resume
         tracker.reset
       end

--- a/spec/lib/karafka/time_trackers/pause_spec.rb
+++ b/spec/lib/karafka/time_trackers/pause_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe_current do
     )
   end
 
+  before { allow(::Process).to receive(:clock_gettime).and_return(*times) }
+
+  let(:times) { [0, 0] }
+
   context 'when max timeout not defined and no exponential backoff' do
     let(:timeout) { 10 }
     let(:max_timeout) { nil }
@@ -29,10 +33,9 @@ RSpec.describe_current do
     end
 
     context 'when not paused over timeout' do
-      before do
-        allow(::Process).to receive(:clock_gettime).and_return(0.763, 0.764)
-        tracker.pause
-      end
+      let(:times) { [0.763, 0.764] }
+
+      before { tracker.pause }
 
       it { expect(tracker.expired?).to eq(false) }
       it { expect(tracker.paused?).to eq(true) }
@@ -40,10 +43,9 @@ RSpec.describe_current do
     end
 
     context 'when paused over timeout' do
-      before do
-        allow(::Process).to receive(:clock_gettime).and_return(0.763, 1.764)
-        tracker.pause
-      end
+      let(:times) { [0.763, 1.764] }
+
+      before { tracker.pause }
 
       it { expect(tracker.expired?).to eq(true) }
       it { expect(tracker.paused?).to eq(true) }
@@ -64,8 +66,9 @@ RSpec.describe_current do
     end
 
     context 'when paused over timeout and resumed' do
+      let(:times) { [0.763, 1.764] }
+
       before do
-        allow(::Process).to receive(:clock_gettime).and_return(0.763, 1.764)
         tracker.pause
         tracker.resume
       end
@@ -76,8 +79,9 @@ RSpec.describe_current do
     end
 
     context 'when paused over timeout, resumed and reset' do
+      let(:times) { [0.763, 1.764] }
+
       before do
-        allow(::Process).to receive(:clock_gettime).and_return(0.763, 1.764)
         tracker.pause
         tracker.resume
         tracker.reset
@@ -109,11 +113,10 @@ RSpec.describe_current do
     end
 
     context 'when not paused over timeout nor max timeout' do
-      before do
-        # 1 ms of a difference
-        allow(::Process).to receive(:clock_gettime).and_return(0.763, 0.764)
-        tracker.pause
-      end
+      # 1 ms of a difference
+      let(:times) { [0.763, 0.764] }
+
+      before { tracker.pause }
 
       it { expect(tracker.expired?).to eq(false) }
       it { expect(tracker.paused?).to eq(true) }
@@ -121,10 +124,9 @@ RSpec.describe_current do
     end
 
     context 'when paused over max timeout' do
-      before do
-        allow(::Process).to receive(:clock_gettime).and_return(0.763, 0.769)
-        tracker.pause
-      end
+      let(:times) { [0.763, 0.769] }
+
+      before { tracker.pause }
 
       it { expect(tracker.expired?).to eq(true) }
       it { expect(tracker.paused?).to eq(true) }
@@ -132,8 +134,9 @@ RSpec.describe_current do
     end
 
     context 'when paused over timeout and resumed' do
+      let(:times) { [0.763, 0.769] }
+
       before do
-        allow(::Process).to receive(:clock_gettime).and_return(0.763, 0.769)
         tracker.pause
         tracker.resume
       end
@@ -144,8 +147,9 @@ RSpec.describe_current do
     end
 
     context 'when paused over timeout, resumed and reset' do
+      let(:times) { [0.763, 0.769] }
+
       before do
-        allow(::Process).to receive(:clock_gettime).and_return(0.763, 0.769)
         tracker.pause
         tracker.resume
         tracker.reset
@@ -177,10 +181,9 @@ RSpec.describe_current do
     end
 
     context 'when not paused over timeout nor max timeout' do
-      before do
-        allow(::Process).to receive(:clock_gettime).and_return(0.763, 0.764)
-        tracker.pause
-      end
+      let(:times) { [0.763, 0.764] }
+
+      before { tracker.pause }
 
       it { expect(tracker.expired?).to eq(false) }
       it { expect(tracker.paused?).to eq(true) }
@@ -188,10 +191,9 @@ RSpec.describe_current do
     end
 
     context 'when paused over max timeout' do
-      before do
-        allow(::Process).to receive(:clock_gettime).and_return(0.763, 1.764)
-        tracker.pause
-      end
+      let(:times) { [0.763, 1.764] }
+
+      before { tracker.pause }
 
       it { expect(tracker.expired?).to eq(true) }
       it { expect(tracker.paused?).to eq(true) }
@@ -199,8 +201,9 @@ RSpec.describe_current do
     end
 
     context 'when paused over timeout and resumed' do
+      let(:times) { [0.763, 1.764] }
+
       before do
-        allow(::Process).to receive(:clock_gettime).and_return(0.763, 1.764)
         tracker.pause
         tracker.resume
       end
@@ -211,8 +214,9 @@ RSpec.describe_current do
     end
 
     context 'when paused over timeout, resumed and reset' do
+      let(:times) { [0.763, 1.764] }
+
       before do
-        allow(::Process).to receive(:clock_gettime).and_return(0.763, 1.764)
         tracker.pause
         tracker.resume
         tracker.reset
@@ -255,10 +259,9 @@ RSpec.describe_current do
     end
 
     context 'when not paused over timeout nor max timeout' do
-      before do
-        allow(::Process).to receive(:clock_gettime).and_return(0.763, 0.764)
-        tracker.pause(2)
-      end
+      let(:times) { [0.763, 0.764] }
+
+      before { tracker.pause(2) }
 
       it { expect(tracker.expired?).to eq(false) }
       it { expect(tracker.paused?).to eq(true) }
@@ -266,10 +269,9 @@ RSpec.describe_current do
     end
 
     context 'when paused over max timeout' do
-      before do
-        allow(::Process).to receive(:clock_gettime).and_return(0.763, 1.764)
-        tracker.pause(1)
-      end
+      let(:times) { [0.763, 1.764] }
+
+      before { tracker.pause(1) }
 
       it { expect(tracker.expired?).to eq(true) }
       it { expect(tracker.paused?).to eq(true) }
@@ -277,8 +279,9 @@ RSpec.describe_current do
     end
 
     context 'when paused over timeout and resumed' do
+      let(:times) { [0.763, 1.764] }
+
       before do
-        allow(::Process).to receive(:clock_gettime).and_return(0.763, 1.764)
         tracker.pause(1)
         tracker.resume
       end
@@ -289,8 +292,9 @@ RSpec.describe_current do
     end
 
     context 'when paused over timeout, resumed and reset' do
+      let(:times) { [0.763, 1.764] }
+
       before do
-        allow(::Process).to receive(:clock_gettime).and_return(0.763, 1.764)
         tracker.pause(1)
         tracker.resume
         tracker.reset


### PR DESCRIPTION
This PR adds a scenario where we consume 100 topics and also refactors pause spec to make it CPU hangs insensitive.