### PR TITLE
optimize specs supervision

### DIFF
--- a/bin/integrations
+++ b/bin/integrations
@@ -47,6 +47,8 @@ class Scenario
   # @param path [String] path to the scenarios file
   def initialize(path)
     @path = path
+    # First 1024 characters from stdout
+    @stdout_head = ''
     # Last 1024 characters from stdout
     @stdout_tail = ''
   end
@@ -75,8 +77,6 @@ class Scenario
   def finished?
     # If the thread is running too long, kill it
     if current_time - @started_at > MAX_RUN_TIME
-      @wait_thr.kill
-
       begin
         Process.kill('TERM', pid)
       # It may finish right after we want to kill it, that's why we ignore this
@@ -88,6 +88,7 @@ class Scenario
     # to stdout. Otherwise after reaching the buffer size, it would hang
     buffer = ''
     @stdout.read_nonblock(MAX_BUFFER_OUTPUT, buffer, exception: false)
+    @stdout_head = buffer if @stdout_head.empty?
     @stdout_tail << buffer
     @stdout_tail = @stdout_tail[-MAX_BUFFER_OUTPUT..-1] || @stdout_tail
 
@@ -112,6 +113,11 @@ class Scenario
     @wait_thr.value&.exitstatus || 123
   end
 
+  # @return [String] exit status of the process
+  def exit_status
+    @wait_thr.value.to_s
+  end
+
   # Prints a status report when scenario is finished and stdout if it failed
   def report
     if success?
@@ -123,7 +129,11 @@ class Scenario
 
       puts
       puts "\e[#{31}m#{'[FAILED]'}\e[0m #{name}"
+      puts "Time taken: #{current_time - @started_at} seconds"
       puts "Exit code: #{exit_code}"
+      puts "Exit status: #{exit_status}"
+      puts @stdout_head
+      puts '...'
       puts @stdout_tail
       puts buffer
       puts


### PR DESCRIPTION
Sending process kill after time exceeded means we do not have to deal with killing the thread. Without killing it, once the process is dead we will anyhow get the outcome value, and the exit code with details will be preserved.

It also prints better info upon failures.