### PR TITLE
Improve spec stability on a slow ci

### DIFF
--- a/spec/integrations/pro/rails/active_job/virtual_partitions/from_earliest.rb
+++ b/spec/integrations/pro/rails/active_job/virtual_partitions/from_earliest.rb
@@ -24,6 +24,7 @@ class Job < ActiveJob::Base
   queue_as DT.topic
 
   def perform(value)
+    sleep(0.001)
     DT[0] << value
     DT[:threads_ids] << Thread.current.object_id
   end

--- a/spec/integrations/rebalancing/exceeding_max_poll_interval.rb
+++ b/spec/integrations/rebalancing/exceeding_max_poll_interval.rb
@@ -16,18 +16,18 @@ end
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    DT.data[:consume_object_ids] << object_id
+    DT[:consume_object_ids] << object_id
 
     sleep(15)
 
-    DT.data[:markings] << mark_as_consumed!(messages.last)
-    DT.data[:revocations] << revoked?
+    DT[:markings] << mark_as_consumed!(messages.last)
+    DT[:revocations] << revoked?
 
     DT[:done] << true
   end
 
   def revoked
-    DT.data[:revoked_object_ids] << object_id
+    DT[:revoked_object_ids] << object_id
   end
 end
 
@@ -39,9 +39,11 @@ start_karafka_and_wait_until do
   DT[:done].size >= 2
 end
 
-assert_equal 2, DT.data[:consume_object_ids].size
-assert_equal 2, DT.data[:consume_object_ids].uniq.size
-assert_equal 2, DT.data[:revoked_object_ids].size
-assert_equal 2, DT.data[:revoked_object_ids].uniq.size
-assert_equal [false, false], DT.data[:markings]
-assert_equal [true, true], DT.data[:revocations]
+consume_object_ids = DT[:consume_object_ids]
+
+assert (2..3).cover?(consume_object_ids.size)
+assert (2..3).cover?(consume_object_ids.uniq.size)
+assert_equal 2, DT[:revoked_object_ids].size
+assert_equal 2, DT[:revoked_object_ids].uniq.size
+assert_equal [false], DT[:markings].uniq
+assert_equal [true], DT[:revocations].uniq

--- a/spec/integrations/rebalancing/exceeding_max_poll_interval.rb
+++ b/spec/integrations/rebalancing/exceeding_max_poll_interval.rb
@@ -39,10 +39,8 @@ start_karafka_and_wait_until do
   DT[:done].size >= 2
 end
 
-consume_object_ids = DT[:consume_object_ids]
-
-assert (2..3).cover?(consume_object_ids.size)
-assert (2..3).cover?(consume_object_ids.uniq.size)
+assert (2..3).cover?(DT[:consume_object_ids].size)
+assert (2..3).cover?(DT[:consume_object_ids].uniq.size)
 assert_equal 2, DT[:revoked_object_ids].size
 assert_equal 2, DT[:revoked_object_ids].uniq.size
 assert_equal [false], DT[:markings].uniq


### PR DESCRIPTION
This PR improves one spec failing on a slow CI.

Karafka stop can be slow enough for one more poll to happen thus we need to compensate for it.
