### PR TITLE
Fix integration spec type detection

### DIFF
--- a/bin/integrations
+++ b/bin/integrations
@@ -81,7 +81,7 @@ class Scenario
 
   # @return [Boolean] any spec that is not a regular one should not run in parallel with others
   def linear?
-    !type == :regular
+    type != :regular
   end
 
   # @return [Boolean] did this scenario finished or is it still running

--- a/spec/integrations/pro/rebalancing/long_running_jobs/revoke_mark_as_consumed_sync_enough_threads.rb
+++ b/spec/integrations/pro/rebalancing/long_running_jobs/revoke_mark_as_consumed_sync_enough_threads.rb
@@ -50,13 +50,15 @@ produce_many(DT.topic, DT.uuids(10), partition: 1)
 # We need a second producer to trigger a rebalance
 consumer = setup_rdkafka_consumer
 
-Thread.new do
+other = Thread.new do
   sleep(10)
 
   consumer.subscribe(DT.topic)
 
   consumer.each do |message|
     DT[:revoked_data] << message.partition
+
+    break
   end
 end
 
@@ -67,6 +69,7 @@ start_karafka_and_wait_until do
   ) && DT[:revoked_data].size >= 1
 end
 
+other.join
 consumer.close
 
 revoked_partition = DT[:revoked_data].first


### PR DESCRIPTION
This PR fixes an accidental bug where the spec executor would consider all specs as regular, running non-parallel in parallel.

this caused the:

https://github.com/karafka/karafka/actions/runs/3104736813/jobs/5029554905