### PR TITLE
Improve error notifications on key polling errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka framework changelog
 
+## Unreleased
+- Report early on errors related to network and on max poll interval being exceeded to indicate critical problems that will be retries but may mean some underlying problems in the system. 
+
 ## 2.0.10 (2022-09-23)
 - Improve error recovery by delegating the recovery to the existing `librdkafka` instance.
 

--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -188,6 +188,7 @@ module Karafka
         tpl = topic_partition_list(topic, partition) || @paused_tpls[topic][partition]
 
         return unless tpl
+
         # If we did not have it, it means we never paused this partition, thus no resume should
         # happen in the first place
         return unless @paused_tpls[topic].delete(partition)

--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -317,7 +317,7 @@ module Karafka
         Rdkafka::Consumer::TopicPartitionList.new({ topic => [rdkafka_partition] })
       end
 
-      # Performs a single poll operation.
+      # Performs a single poll operation and handles retries and error
       #
       # @param timeout [Integer] timeout for a single poll
       # @return [Rdkafka::Consumer::Message, nil] fetched message or nil if nothing polled
@@ -330,19 +330,38 @@ module Karafka
 
         @kafka.poll(timeout)
       rescue ::Rdkafka::RdkafkaError => e
-        # Most of the errors can be safely ignored as librdkafka will recover from them
-        # @see https://github.com/edenhill/librdkafka/issues/1987#issuecomment-422008750
-        # @see https://github.com/edenhill/librdkafka/wiki/Error-handling
-        if time_poll.attempts > MAX_POLL_RETRIES || !time_poll.retryable?
+        early_report = false
+
+        # There are retryable issues on which we want to report fast as they are source of
+        # problems and can mean some bigger system instabilities
+        # Those are mainly network issues and exceeding the max poll interval
+        # We want to report early on max poll interval exceeding because it may mean that the
+        # underlying processing is taking too much time and it is not LRJ
+        case e.code
+        when :max_poll_exceeded # -147
+          early_report = true
+        when :network_exception # 13
+          early_report = true
+        when :transport # -195
+          early_report = true
+        end
+
+        retryable = time_poll.attempts <= MAX_POLL_RETRIES && time_poll.retryable?
+
+        if early_report || !retryable
           Karafka.monitor.instrument(
             'error.occurred',
             caller: self,
             error: e,
             type: 'connection.client.poll.error'
           )
-
-          raise
         end
+
+        raise unless retryable
+
+        # Most of the errors can be safely ignored as librdkafka will recover from them
+        # @see https://github.com/edenhill/librdkafka/issues/1987#issuecomment-422008750
+        # @see https://github.com/edenhill/librdkafka/wiki/Error-handling
 
         time_poll.checkpoint
         time_poll.backoff

--- a/spec/integrations/rebalancing/exceeding_max_poll_interval.rb
+++ b/spec/integrations/rebalancing/exceeding_max_poll_interval.rb
@@ -5,7 +5,10 @@
 #
 # The revocation job should kick in with a proper revoked state.
 
-setup_karafka do |config|
+setup_karafka(
+  # Allow max poll interval error as it is expected to be reported in this spec
+  allow_errors: %w[connection.client.poll.error]
+) do |config|
   config.max_messages = 5
   # We set it here that way not too wait too long on stuff
   config.kafka[:'max.poll.interval.ms'] = 10_000


### PR DESCRIPTION
I gave it a second, though, and I think we need to make one change to the reporting of network / critical logic errors here:

while we can and should still retry them, on those errors, we should early notify them before retries. The reasoning is that network and other criticals indicate severe system problems, and max poll interval exceeding means severe business logic problems (slow processing).

This code does not change how the retry engine works but it provides early important errors notifications.