### PR TITLE
v2.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Karafka framework changelog
 
-## Unreleased
+## 2.0.13 (2022-10-14)
 - Early exit upon attempts to commit current or earlier offset twice.
 - Add more integration specs covering edge cases.
 - Strip non producer related config when default producer is initialized (#776)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka (2.0.12)
+    karafka (2.0.13)
       karafka-core (>= 2.0.2, < 3.0.0)
       rdkafka (>= 0.12)
       thor (>= 0.20)
@@ -30,7 +30,7 @@ GEM
       activesupport (>= 5.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    karafka-core (2.0.2)
+    karafka-core (2.0.3)
       concurrent-ruby (>= 1.1)
     mini_portile2 (2.8.0)
     minitest (5.16.3)

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '2.0.12'
+  VERSION = '2.0.13'
 end


### PR DESCRIPTION
- Early exit upon attempts to commit current or earlier offset twice.
- Add more integration specs covering edge cases.
- Strip non producer related config when default producer is initialized (#776)
