### PR TITLE
Compensate for first request unpredictability

### DIFF
--- a/bin/integrations
+++ b/bin/integrations
@@ -24,7 +24,7 @@ ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../
 # When the value is high, there's a problem with thread allocation on Github CI, tht is why
 # we limit it. Locally we can run a lot of those, as many of them have sleeps and do not use a lot
 # of CPU
-CONCURRENCY = ENV.key?('CI') ? 4 : Etc.nprocessors * 2
+CONCURRENCY = ENV.key?('CI') ? 5 : Etc.nprocessors * 2
 
 # How may bytes do we want to keep from the stdout in the buffer for when we need to print it
 MAX_BUFFER_OUTPUT = 51_200

--- a/spec/integrations/rebalancing/exceeding_max_poll_with_late_commit_spec.rb
+++ b/spec/integrations/rebalancing/exceeding_max_poll_with_late_commit_spec.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 # When processing beyond the poll interval, with slower offset commit, we will restart processing
+# and there should be duplicated messages.
 
 setup_karafka(
   # Allow max poll interval error as it is expected to be reported in this spec
   allow_errors: %w[connection.client.poll.error]
 ) do |config|
   config.max_messages = 5
-  # We set it here that way not too wait too long on stuff
+  # We set it here, that way we won't too wait too long on stuff
   config.kafka[:'max.poll.interval.ms'] = 10_000
   config.kafka[:'session.timeout.ms'] = 10_000
   config.kafka[:'auto.commit.interval.ms'] = 60_000
@@ -23,7 +24,7 @@ class Consumer < Karafka::BaseConsumer
       mark_as_consumed message
     end
 
-    sleep(15)
+    sleep(15) if messages.count > 1
   end
 end
 
@@ -32,7 +33,7 @@ draw_routes(Consumer)
 produce_many(DT.topic, DT.uuids(100))
 
 start_karafka_and_wait_until do
-  DT[:done].size >= 2
+  DT[:done].size >= 10
 end
 
-assert_equal 1, DT[:done].uniq.size
+assert DT[:done].size != DT[:done].uniq.size


### PR DESCRIPTION
This PR improves the stability of one of the specs and increases CI concurrency (let's see if it will run faster).

This spec could fail (ref: https://github.com/karafka/karafka/actions/runs/3257845234/jobs/5349431095) in case we would fetch more than one message during initial poll, and this can happen.
