### PR TITLE
flush spec log sync and spec stability

### DIFF
--- a/spec/integrations/pro/rails/active_job/virtual_partitions/with_partitioning_using_key_spec.rb
+++ b/spec/integrations/pro/rails/active_job/virtual_partitions/with_partitioning_using_key_spec.rb
@@ -36,7 +36,7 @@ end
 
 order_without_vp = []
 
-10.times do
+100.times do
   2.times do |iteration|
     order_without_vp << iteration.to_s
     Job.perform_later(iteration.to_s)
@@ -44,7 +44,7 @@ order_without_vp = []
 end
 
 start_karafka_and_wait_until do
-  DT[0].size >= 20
+  DT[0].size >= 200
 end
 
 assert_equal DT[0].size, order_without_vp.size

--- a/spec/integrations_helper.rb
+++ b/spec/integrations_helper.rb
@@ -17,6 +17,9 @@ require_relative './support/data_collector'
 
 Thread.abort_on_exception = true
 
+# Make sure all logs are always flushed
+STDOUT.sync = true
+
 # Alias data collector for shorter referencing
 DT = DataCollector
 
@@ -75,7 +78,7 @@ def setup_karafka(allow_errors: false)
     next if allow_errors.is_a?(Array) && allow_errors.include?(event[:type])
 
     # Print error event details in case we are going to exit
-    puts event
+    Karafka.logger.fatal event
 
     # This sleep buys us some time before exit so logs are flushed
     sleep(0.5)

--- a/spec/integrations_helper.rb
+++ b/spec/integrations_helper.rb
@@ -18,7 +18,7 @@ require_relative './support/data_collector'
 Thread.abort_on_exception = true
 
 # Make sure all logs are always flushed
-STDOUT.sync = true
+$stdout.sync = true
 
 # Alias data collector for shorter referencing
 DT = DataCollector


### PR DESCRIPTION
This PR ensures that we always flush logs sync. This way when we extract details for error reporting, all the lines are always there.