### PR TITLE
Point to correct location of Commercial license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -12,6 +12,6 @@ and their usage requires commercial license agreement.
 By sending a pull request to the pro components, you are agreeing to transfer the copyright of your
 code to Maciej Mensfeld.
 
-You can find the commercial license in LICENSE-COM.
+You can find the commercial license in LICENSE-COMM.
 
 Please see https://karafka.io for purchasing options.


### PR DESCRIPTION
I'm not sure the mechanics of changing licenses. It may be that it would be preferable to rename the commercial license file instead.

Can you believe that people read the license? ;)