### PR TITLE
add missing ssl.providers attribute

### DIFF
--- a/lib/karafka/setup/attributes_map.rb
+++ b/lib/karafka/setup/attributes_map.rb
@@ -128,6 +128,7 @@ module Karafka
         ssl.key.pem
         ssl.keystore.location
         ssl.keystore.password
+        ssl.providers
         ssl.sigalgs.list
         ssl_ca
         ssl_certificate
@@ -259,6 +260,7 @@ module Karafka
         ssl.key.pem
         ssl.keystore.location
         ssl.keystore.password
+        ssl.providers
         ssl.sigalgs.list
         ssl_ca
         ssl_certificate


### PR DESCRIPTION
New `ssl.providers` attribute was introduced upstream in this change https://github.com/edenhill/librdkafka/commit/3709caa91391cb115848ef9946ad228aa56ea476