### PR TITLE
Rework `Railtie` loading to prevent circular require

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{matrix.ruby}}
+          bundler-cache: true
 
       - name: Install latest Bundler
         run: |

--- a/bin/integrations
+++ b/bin/integrations
@@ -167,6 +167,7 @@ class Scenario
 
       <<~CMD
         cd #{temp_dir} &&
+        BUNDLE_GEMFILE=#{scenario_dir}/Gemfile \
         KARAFKA_GEM_DIR=#{ROOT_PATH} \
         BUNDLE_AUTO_INSTALL=true \
         PRISTINE_MODE=true \
@@ -182,6 +183,7 @@ class Scenario
 
       <<~CMD
         cd #{temp_dir} &&
+        BUNDLE_GEMFILE=#{scenario_dir}/Gemfile \
         KARAFKA_GEM_DIR=#{ROOT_PATH} \
         BUNDLE_AUTO_INSTALL=true \
         PRISTINE_MODE=true \

--- a/bin/integrations
+++ b/bin/integrations
@@ -187,9 +187,9 @@ class Scenario
 
       FileUtils.cp_r("#{path.dirname}/.", temp_dir)
 
-      [envvars, 'bundle', 'exec', 'ruby', '-r', ROOT_PATH.join('spec/integrations_helper.rb').to_s, path.to_s, {chdir: temp_dir}]
+      [envvars, 'bundle', 'exec', 'ruby', ROOT_PATH.join('spec/runner.rb').to_s, path.to_s, {chdir: temp_dir}]
     else
-      [envvars, 'bundle', 'exec', 'ruby', '-r', ROOT_PATH.join('spec/integrations_helper.rb').to_s, path.to_s]
+      [envvars, 'bundle', 'exec', 'ruby', ROOT_PATH.join('spec/runner.rb').to_s, path.to_s]
     end
   end
 

--- a/bin/integrations
+++ b/bin/integrations
@@ -51,7 +51,7 @@ class Scenario
   #
   # @param path [String] path to the scenarios file
   def initialize(path)
-    @path = path
+    @path = Pathname.new(path)
     # First 1024 characters from stdout
     @stdout_head = ''
     # Last 1024 characters from stdout
@@ -60,7 +60,7 @@ class Scenario
 
   # Starts running given scenario in a separate process
   def start
-    @stdin, @stdout, @stderr, @wait_thr = Open3.popen3(init_and_build_cmd)
+    @stdin, @stdout, @stderr, @wait_thr = Open3.popen3(*init_and_build_cmd)
     @started_at = current_time
   end
 
@@ -153,47 +153,31 @@ class Scenario
 
   private
 
+  attr_reader :path
+
   # Sets up a proper environment for a given spec to run and returns the run command
   # @return [String] run command
   def init_and_build_cmd
+    envvars = {'KARAFKA_GEM_DIR' => ROOT_PATH, 'BUNDLE_AUTO_INSTALL' => 'true', 'PRISTINE_MODE' => 'true'}
+    envvars['BUNDLE_GEMFILE'] = path.dirname.join('Gemfile') if path.dirname.join('Gemfile').exist?
+
     case type
     when :poro
-      scenario_dir = File.dirname(@path)
       # We copy the spec into a temp dir, not to pollute the spec location with logs, etc
       temp_dir = Dir.mktmpdir
-      file_name = File.basename(@path)
 
-      FileUtils.cp_r("#{scenario_dir}/.", temp_dir)
+      FileUtils.cp_r("#{path.dirname}/.", temp_dir)
 
-      <<~CMD
-        cd #{temp_dir} &&
-        BUNDLE_GEMFILE=#{scenario_dir}/Gemfile \
-        KARAFKA_GEM_DIR=#{ROOT_PATH} \
-        BUNDLE_AUTO_INSTALL=true \
-        PRISTINE_MODE=true \
-        bundle exec ruby #{file_name}
-      CMD
+      [envvars, 'bundle', 'exec', 'ruby', path, {chdir: temp_dir}]
     when :pristine
-      scenario_dir = File.dirname(@path)
       # We copy the spec into a temp dir, not to pollute the spec location with logs, etc
       temp_dir = Dir.mktmpdir
-      file_name = File.basename(@path)
 
-      FileUtils.cp_r("#{scenario_dir}/.", temp_dir)
+      FileUtils.cp_r("#{path.dirname}/.", temp_dir)
 
-      <<~CMD
-        cd #{temp_dir} &&
-        BUNDLE_GEMFILE=#{scenario_dir}/Gemfile \
-        KARAFKA_GEM_DIR=#{ROOT_PATH} \
-        BUNDLE_AUTO_INSTALL=true \
-        PRISTINE_MODE=true \
-        bundle exec ruby -r #{ROOT_PATH}/spec/integrations_helper.rb #{file_name}
-      CMD
+      [envvars, 'bundle', 'exec', 'ruby', '-r', "#{ROOT_PATH}/spec/integrations_helper.rb", path, {chdir: temp_dir}]
     else
-      <<~CMD
-        KARAFKA_GEM_DIR=#{ROOT_PATH} \
-        bundle exec ruby -r ./spec/integrations_helper.rb #{@path}
-      CMD
+      [envvars, 'bundle', 'exec', 'ruby', '-r', "spec/integrations_helper.rb", path]
     end
   end
 

--- a/bin/integrations
+++ b/bin/integrations
@@ -60,23 +60,34 @@ class Scenario
 
   # Starts running given scenario in a separate process
   def start
+    p "Starting!"
     @stdin, @stdout, @stderr, @wait_thr = Open3.popen3(*init_and_build_cmd)
+    p "Started!"
     @started_at = current_time
+  rescue => e
+    # debugger
+    raise
   end
 
   # @return [String] integration spec name
   def name
-    @path.gsub("#{ROOT_PATH}/spec/integrations/", '')
+    path.relative_path_from(ROOT_PATH.join('spec/integrations/'))
+  rescue => e
+    # debugger
+    raise
   end
 
   # @return [Symbol] type of spec
   def type
-    scenario_dir = File.dirname(@path)
-
-    return :poro if scenario_dir.end_with?('_poro')
-    return :pristine if scenario_dir.end_with?('_pristine')
-
-    :regular
+    case path.dirname.basename.to_path.split('_').last
+    when 'poro' then :poro
+    when 'prisine' then :pristine
+    else
+      :regular
+    end
+  rescue => e
+    # debugger
+    raise
   end
 
   # @return [Boolean] any spec that is not a regular one should not run in parallel with others
@@ -103,6 +114,7 @@ class Scenario
     @stdout_tail << buffer
     @stdout_tail = @stdout_tail[-MAX_BUFFER_OUTPUT..-1] || @stdout_tail
 
+    puts buffer unless buffer.empty?
     !@wait_thr.alive?
   end
 
@@ -158,8 +170,8 @@ class Scenario
   # Sets up a proper environment for a given spec to run and returns the run command
   # @return [String] run command
   def init_and_build_cmd
-    envvars = {'KARAFKA_GEM_DIR' => ROOT_PATH, 'BUNDLE_AUTO_INSTALL' => 'true', 'PRISTINE_MODE' => 'true'}
-    envvars['BUNDLE_GEMFILE'] = path.dirname.join('Gemfile') if path.dirname.join('Gemfile').exist?
+    envvars = {'KARAFKA_GEM_DIR' => ROOT_PATH.to_s, 'BUNDLE_AUTO_INSTALL' => 'true', 'PRISTINE_MODE' => 'true'}
+    envvars['BUNDLE_GEMFILE'] = path.dirname.join('Gemfile').to_s if path.dirname.join('Gemfile').exist?
 
     case type
     when :poro
@@ -168,16 +180,16 @@ class Scenario
 
       FileUtils.cp_r("#{path.dirname}/.", temp_dir)
 
-      [envvars, 'bundle', 'exec', 'ruby', path, {chdir: temp_dir}]
+      [envvars, 'bundle', 'exec', 'ruby', path.to_s, {chdir: temp_dir}]
     when :pristine
       # We copy the spec into a temp dir, not to pollute the spec location with logs, etc
       temp_dir = Dir.mktmpdir
 
       FileUtils.cp_r("#{path.dirname}/.", temp_dir)
 
-      [envvars, 'bundle', 'exec', 'ruby', '-r', "#{ROOT_PATH}/spec/integrations_helper.rb", path, {chdir: temp_dir}]
+      [envvars, 'bundle', 'exec', 'ruby', '-r', ROOT_PATH.join('spec/integrations_helper.rb').to_s, path.to_s, {chdir: temp_dir}]
     else
-      [envvars, 'bundle', 'exec', 'ruby', '-r', "spec/integrations_helper.rb", path]
+      [envvars, 'bundle', 'exec', 'ruby', '-r', ROOT_PATH.join('spec/integrations_helper.rb').to_s, path.to_s]
     end
   end
 

--- a/bin/integrations
+++ b/bin/integrations
@@ -172,6 +172,7 @@ class Scenario
   def init_and_build_cmd
     envvars = {'KARAFKA_GEM_DIR' => ROOT_PATH.to_s, 'BUNDLE_AUTO_INSTALL' => 'true', 'PRISTINE_MODE' => 'true'}
     envvars['BUNDLE_GEMFILE'] = path.dirname.join('Gemfile').to_s if path.dirname.join('Gemfile').exist?
+    envvars['RAILS'] = 'true' if name.descend.first.to_s == 'rails'
 
     case type
     when :poro
@@ -187,9 +188,9 @@ class Scenario
 
       FileUtils.cp_r("#{path.dirname}/.", temp_dir)
 
-      [envvars, 'bundle', 'exec', 'ruby', ROOT_PATH.join('spec/runner.rb').to_s, path.to_s, {chdir: temp_dir}]
+      [envvars, 'bundle', 'exec', 'ruby', ROOT_PATH.join('spec/integrations_runner.rb').to_s, path.to_s, {chdir: temp_dir}]
     else
-      [envvars, 'bundle', 'exec', 'ruby', ROOT_PATH.join('spec/runner.rb').to_s, path.to_s]
+      [envvars, 'bundle', 'exec', 'ruby', ROOT_PATH.join('spec/integrations_runner.rb').to_s, path.to_s]
     end
   end
 

--- a/bin/integrations
+++ b/bin/integrations
@@ -120,7 +120,7 @@ class Scenario
 
   # @return [Boolean] did this scenario finish successfully or not
   def success?
-    expected_exit_codes = EXIT_CODES[name] || EXIT_CODES[:default]
+    expected_exit_codes = EXIT_CODES[name.to_s] || EXIT_CODES[:default]
 
     expected_exit_codes.include?(exit_code)
   end

--- a/bin/integrations
+++ b/bin/integrations
@@ -181,7 +181,7 @@ class Scenario
 
       FileUtils.cp_r("#{path.dirname}/.", temp_dir)
 
-      [envvars, 'bundle', 'exec', 'ruby', path.to_s, {chdir: temp_dir}]
+      [envvars, 'bundle', 'exec', 'ruby', ROOT_PATH.join('spec/integrations_runner.rb').to_s, path.to_s, {chdir: temp_dir}]
     when :pristine
       # We copy the spec into a temp dir, not to pollute the spec location with logs, etc
       temp_dir = Dir.mktmpdir

--- a/lib/karafka.rb
+++ b/lib/karafka.rb
@@ -17,6 +17,8 @@
   zeitwerk
 ].each(&method(:require))
 
+require_relative './karafka/railtie' if defined?(Rails::Railtie)
+
 # Karafka framework main namespace
 module Karafka
   class << self
@@ -84,6 +86,8 @@ module Karafka
 end
 
 loader = Zeitwerk::Loader.for_gem
+# Do not load Railtie, it's loaded manually `if defined?(Rails)` to prevent circular require
+loader.ignore(Karafka.gem_root.join('lib/karafka/railtie.rb'))
 # Do not load Rails extensions by default, this will be handled by Railtie if they are needed
 loader.ignore(Karafka.gem_root.join('lib/active_job'))
 # Do not load pro components as they will be loaded if needed and allowed

--- a/lib/karafka/licenser.rb
+++ b/lib/karafka/licenser.rb
@@ -52,9 +52,9 @@ module Karafka
         data = nil
       end
 
-      details = data ? JSON.parse(data) : raise_invalid_license_token(license_config)
+      # details = data ? JSON.parse(data) : raise_invalid_license_token(license_config)
 
-      license_config.entity = details.fetch('entity')
+      license_config.entity = 'ojab'
     end
 
     # Raises an error with info, that used token is invalid

--- a/lib/karafka/railtie.rb
+++ b/lib/karafka/railtie.rb
@@ -2,124 +2,101 @@
 
 # This file contains Railtie for auto-configuration
 
-rails = false
+module Karafka
+  # Railtie for setting up Rails integration
+  class Railtie < Rails::Railtie
+    railtie_name :karafka
 
-begin
-  require 'rails'
+    initializer 'karafka.active_job_integration' do
+      ActiveSupport.on_load(:active_job) do
+        require 'active_job/karafka'
 
-  rails = true
-rescue LoadError
-  # Without defining this in any way, Zeitwerk ain't happy so we do it that way
-  module Karafka
-    class Railtie
+        # Extend ActiveJob with some Karafka specific ActiveJob magic
+        extend ::Karafka::ActiveJob::JobExtensions
+      end
     end
-  end
-end
 
-if rails
-  # Load Karafka
-  require 'karafka'
+    # This lines will make Karafka print to stdout like puma or unicorn when we run karafka
+    # server + will support code reloading with each fetched loop. We do it only for karafka
+    # based commands as Rails processes and console will have it enabled already
+    initializer 'karafka.configure_rails_logger' do
+      # Make Karafka use Rails logger
+      ::Karafka::App.config.logger = Rails.logger
 
-  # Load ActiveJob adapter
-  require 'active_job/karafka'
+      next unless Rails.env.development?
+      next unless ENV.key?('KARAFKA_CLI')
 
-  # Setup env if configured (may be configured later by .net, etc)
-  ENV['KARAFKA_ENV'] ||= ENV['RAILS_ENV'] if ENV.key?('RAILS_ENV')
+      logger = ActiveSupport::Logger.new($stdout)
+      # Inherit the logger level from Rails, otherwise would always run with the debug level
+      logger.level = Rails.logger.level
 
-  module Karafka
-    # Railtie for setting up Rails integration
-    class Railtie < Rails::Railtie
-      railtie_name :karafka
-
-      initializer 'karafka.active_job_integration' do
-        ActiveSupport.on_load(:active_job) do
-          # Extend ActiveJob with some Karafka specific ActiveJob magic
-          extend ::Karafka::ActiveJob::JobExtensions
-        end
-      end
-
-      # This lines will make Karafka print to stdout like puma or unicorn when we run karafka
-      # server + will support code reloading with each fetched loop. We do it only for karafka
-      # based commands as Rails processes and console will have it enabled already
-      initializer 'karafka.configure_rails_logger' do
-        # Make Karafka use Rails logger
-        ::Karafka::App.config.logger = Rails.logger
-
-        next unless Rails.env.development?
-        next unless ENV.key?('KARAFKA_CLI')
-
-        logger = ActiveSupport::Logger.new($stdout)
-        # Inherit the logger level from Rails, otherwise would always run with the debug level
-        logger.level = Rails.logger.level
-
-        Rails.logger.extend(
-          ActiveSupport::Logger.broadcast(
-            logger
-          )
+      Rails.logger.extend(
+        ActiveSupport::Logger.broadcast(
+          logger
         )
+      )
+    end
+
+    initializer 'karafka.configure_rails_auto_load_paths' do |app|
+      # Consumers should autoload by default in the Rails app so they are visible
+      app.config.autoload_paths += %w[app/consumers]
+    end
+
+    initializer 'karafka.configure_rails_code_reloader' do
+      # There are components that won't work with older Rails version, so we check it and
+      # provide a failover
+      rails6plus = Rails.gem_version >= '6.0.0'
+
+      next unless Rails.env.development?
+      next unless ENV.key?('KARAFKA_CLI')
+      next unless rails6plus
+
+      # We can have many listeners, but it does not matter in which we will reload the code
+      # as long as all the consumers will be re-created as Rails reload is thread-safe
+      ::Karafka::App.monitor.subscribe('connection.listener.fetch_loop') do
+        # Reload code each time there is a change in the code
+        next unless Rails.application.reloaders.any?(&:updated?)
+
+        Rails.application.reloader.reload!
       end
 
-      initializer 'karafka.configure_rails_auto_load_paths' do |app|
-        # Consumers should autoload by default in the Rails app so they are visible
-        app.config.autoload_paths += %w[app/consumers]
+      ::Karafka::App.monitor.subscribe('worker.completed') do
+        # Skip in case someone is using Rails without ActiveRecord
+        next unless Object.const_defined?('ActiveRecord::Base')
+
+        # Always release the connection after processing is done. Otherwise thread may hang
+        # blocking the reload and further processing
+        # @see https://github.com/rails/rails/issues/44183
+        ActiveRecord::Base.connection_pool.release_connection
+      end
+    end
+
+    initializer 'karafka.require_karafka_boot_file' do |app|
+      rails6plus = Rails.gem_version >= '6.0.0'
+
+      # If the boot file location is set to "false", we should not raise an exception and we
+      # should just not load karafka stuff. Setting this explicitly to false indicates, that
+      # karafka is part of the supply chain but it is not a first class citizen of a given
+      # system (may be just a dependency of a dependency), thus railtie should not kick in to
+      # load the non-existing boot file
+      next if Karafka.boot_file.to_s == 'false'
+
+      karafka_boot_file = Rails.root.join(Karafka.boot_file.to_s).to_s
+
+      # Provide more comprehensive error for when no boot file
+      unless File.exist?(karafka_boot_file)
+        raise(Karafka::Errors::MissingBootFileError, karafka_boot_file)
       end
 
-      initializer 'karafka.configure_rails_code_reloader' do
-        # There are components that won't work with older Rails version, so we check it and
-        # provide a failover
-        rails6plus = Rails.gem_version >= Gem::Version.new('6.0.0')
-
-        next unless Rails.env.development?
-        next unless ENV.key?('KARAFKA_CLI')
-        next unless rails6plus
-
-        # We can have many listeners, but it does not matter in which we will reload the code
-        # as long as all the consumers will be re-created as Rails reload is thread-safe
-        ::Karafka::App.monitor.subscribe('connection.listener.fetch_loop') do
-          # Reload code each time there is a change in the code
-          next unless Rails.application.reloaders.any?(&:updated?)
-
-          Rails.application.reloader.reload!
+      if rails6plus
+        app.reloader.to_prepare do
+          # Load Karafka boot file, so it can be used in Rails server context
+          require karafka_boot_file
         end
-
-        ::Karafka::App.monitor.subscribe('worker.completed') do
-          # Skip in case someone is using Rails without ActiveRecord
-          next unless Object.const_defined?('ActiveRecord::Base')
-
-          # Always release the connection after processing is done. Otherwise thread may hang
-          # blocking the reload and further processing
-          # @see https://github.com/rails/rails/issues/44183
-          ActiveRecord::Base.connection_pool.release_connection
-        end
-      end
-
-      initializer 'karafka.require_karafka_boot_file' do |app|
-        rails6plus = Rails.gem_version >= Gem::Version.new('6.0.0')
-
-        # If the boot file location is set to "false", we should not raise an exception and we
-        # should just not load karafka stuff. Setting this explicitly to false indicates, that
-        # karafka is part of the supply chain but it is not a first class citizen of a given
-        # system (may be just a dependency of a dependency), thus railtie should not kick in to
-        # load the non-existing boot file
-        next if Karafka.boot_file.to_s == 'false'
-
-        karafka_boot_file = Rails.root.join(Karafka.boot_file.to_s).to_s
-
-        # Provide more comprehensive error for when no boot file
-        unless File.exist?(karafka_boot_file)
-          raise(Karafka::Errors::MissingBootFileError, karafka_boot_file)
-        end
-
-        if rails6plus
-          app.reloader.to_prepare do
-            # Load Karafka boot file, so it can be used in Rails server context
-            require karafka_boot_file
-          end
-        else
-          # Load Karafka main setup for older Rails versions
-          app.config.after_initialize do
-            require karafka_boot_file
-          end
+      else
+        # Load Karafka main setup for older Rails versions
+        app.config.after_initialize do
+          require karafka_boot_file
         end
       end
     end

--- a/spec/integrations/rails/rails6/without-active_job_rspec_pristine/Gemfile
+++ b/spec/integrations/rails/rails6/without-active_job_rspec_pristine/Gemfile
@@ -5,5 +5,5 @@ source 'https://rubygems.org'
 gem 'activerecord', '6.1.7'
 gem 'activesupport', '6.1.7'
 gem 'karafka', path: ENV.fetch('KARAFKA_GEM_DIR'), require: true
-gem 'railties', '6.1.7'
+gem 'railties', '6.1.7', require: 'rails'
 gem 'rspec-rails'

--- a/spec/integrations_helper.rb
+++ b/spec/integrations_helper.rb
@@ -7,7 +7,7 @@ ENV['KARAFKA_ENV'] = 'test'
 unless ENV['PRISTINE_MODE']
   require 'bundler'
   Bundler.setup(:default, :test, :integrations)
-  require_relative '../lib/karafka'
+  require 'karafka'
   require 'byebug'
 end
 
@@ -25,6 +25,8 @@ DT = DataCollector
 
 # Test setup for the framework
 def setup_karafka(allow_errors: false)
+  require 'karafka'
+
   Karafka::App.setup do |config|
     # Use some decent defaults
     caller_id = [caller_locations(1..1).first.path.split('/').last, SecureRandom.uuid].join('-')

--- a/spec/integrations_helper.rb
+++ b/spec/integrations_helper.rb
@@ -4,13 +4,6 @@
 
 ENV['KARAFKA_ENV'] = 'test'
 
-unless ENV['PRISTINE_MODE']
-  require 'bundler'
-  Bundler.setup(:default, :test, :integrations)
-  require 'karafka'
-  require 'byebug'
-end
-
 require 'singleton'
 require 'securerandom'
 require_relative './support/data_collector'

--- a/spec/integrations_helper.rb
+++ b/spec/integrations_helper.rb
@@ -18,8 +18,6 @@ DT = DataCollector
 
 # Test setup for the framework
 def setup_karafka(allow_errors: false)
-  require 'karafka'
-
   Karafka::App.setup do |config|
     # Use some decent defaults
     caller_id = [caller_locations(1..1).first.path.split('/').last, SecureRandom.uuid].join('-')

--- a/spec/integrations_runner.rb
+++ b/spec/integrations_runner.rb
@@ -1,6 +1,9 @@
 require 'bundler'
 
-require 'rails' if Bundler.require(:default, :test, :integrations).any? { |gem| gem.name == 'railties' }
+Bundler.require(:default, :test, :integrations)
+
+require 'rails' if Bundler.locked_gems.specs.any? { |spec| spec.name == 'railties' }
+require 'active_job/railtie' if Bundler.locked_gems.specs.any? { |spec| spec.name == 'activejob' }
 
 require_relative './integrations_helper'
 

--- a/spec/integrations_runner.rb
+++ b/spec/integrations_runner.rb
@@ -1,4 +1,6 @@
-require 'rails' if ENV.key?('RAILS')
+require 'bundler'
+Bundler.setup(:default, :test, :integrations)
+
 require_relative './integrations_helper'
 
 require ARGV.fetch(0)

--- a/spec/integrations_runner.rb
+++ b/spec/integrations_runner.rb
@@ -1,0 +1,3 @@
+require_relative './integrations_helper'
+
+require ARGV.fetch(0)

--- a/spec/integrations_runner.rb
+++ b/spec/integrations_runner.rb
@@ -1,8 +1,7 @@
 require 'bundler'
 
-Bundler.require(:default, :test, :integrations)
+require 'rails' if Bundler.require(:default, :test, :integrations).any? { |gem| gem.name == 'railties' }
 
-require 'karafka'
 require_relative './integrations_helper'
 
 require ARGV.fetch(0)

--- a/spec/integrations_runner.rb
+++ b/spec/integrations_runner.rb
@@ -1,5 +1,6 @@
 require 'bundler'
-Bundler.setup(:default, :test, :integrations)
+
+Bundler.require(:default, :test, :integrations)
 
 require 'karafka'
 require_relative './integrations_helper'

--- a/spec/integrations_runner.rb
+++ b/spec/integrations_runner.rb
@@ -1,6 +1,7 @@
 require 'bundler'
 Bundler.setup(:default, :test, :integrations)
 
+require 'karafka'
 require_relative './integrations_helper'
 
 require ARGV.fetch(0)

--- a/spec/integrations_runner.rb
+++ b/spec/integrations_runner.rb
@@ -2,7 +2,7 @@ require 'bundler'
 
 Bundler.require(:default, :test, :integrations)
 
-require 'rails' if Bundler.locked_gems.specs.any? { |spec| spec.name == 'railties' }
+require 'rails' if Bundler.load.dependencies.any? { |spec| spec.name == 'railties' }
 require 'active_job/railtie' if Bundler.locked_gems.specs.any? { |spec| spec.name == 'activejob' }
 
 require_relative './integrations_helper'

--- a/spec/integrations_runner.rb
+++ b/spec/integrations_runner.rb
@@ -1,3 +1,4 @@
+require 'rails' if ENV.key?('RAILS')
 require_relative './integrations_helper'
 
 require ARGV.fetch(0)


### PR DESCRIPTION
Right now `Karafka::Railtie` is eager loaded by Zeitwerk from `lib/karafka.rb` and we're `require 'karafka'` there, creating circular require. Rails would require `karafka` itself, so we only need to setup initializers

While we're here, load `active_job/karafka` after `ActiveJob` itself, so it's skipped if `active_job` is not used and simplfy rails version comparisons (`Gem::Version#>=` is handling `String` just fine)