### PR TITLE
DLQ dispatch instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Split specs into regular and pro to simplify how resources are loaded
 - Introduce Dead Letter Queue feature and Pro Enhanced Dead Letter Queue feature
 - Fix LRJ enqueuing pause increases the coordinator counter (#115)
+- Auto-create topics in the integration specs based on the defined routing
 
 ### Upgrade notes
 

--- a/bin/integrations
+++ b/bin/integrations
@@ -23,8 +23,9 @@ ROOT_PATH = Pathname.new(File.expand_path(File.join(File.dirname(__FILE__), '../
 # How many child processes with integration specs do we want to run in parallel
 # When the value is high, there's a problem with thread allocation on Github CI, that is why
 # we limit it. Locally we can run a lot of those, as many of them have sleeps and do not use a lot
-# of CPU
-CONCURRENCY = ENV.key?('CI') ? 4 : Etc.nprocessors * 3
+# of CPU. Locally we also cannot go beyond certain limit due to how often and how many topics we
+# create in Kafka. With an overloaded system, we start getting timeouts.
+CONCURRENCY = ENV.key?('CI') ? 4 : Etc.nprocessors * 2
 
 # How may bytes do we want to keep from the stdout in the buffer for when we need to print it
 MAX_BUFFER_OUTPUT = 51_200

--- a/lib/karafka/admin.rb
+++ b/lib/karafka/admin.rb
@@ -21,7 +21,7 @@ module Karafka
         with_admin do |admin|
           admin.create_topic(name, partitions, replication_factor, topic_config)
 
-          sleep(0.1) until topics_names.include?(name)
+          sleep(0.2) until topics_names.include?(name)
         end
       end
 
@@ -32,7 +32,7 @@ module Karafka
         with_admin do |admin|
           admin.delete_topic(name)
 
-          sleep(0.1) while topics_names.include?(name)
+          sleep(0.2) while topics_names.include?(name)
         end
       end
 

--- a/lib/karafka/instrumentation/logger_listener.rb
+++ b/lib/karafka/instrumentation/logger_listener.rb
@@ -111,6 +111,19 @@ module Karafka
         info 'Stopped Karafka server'
       end
 
+      # Logs info when we have dispatched a message the the DLQ
+      #
+      # @param _event [Dry::Events::Event] event details including payload
+      def on_dead_letter_queue_dispatched(event)
+        message = event[:message]
+        offset = message.offset
+        topic = event[:caller].topic.name
+        dlq_topic = event[:caller].topic.dead_letter_queue.topic
+        partition = message.partition
+
+        info "Dispatched message #{offset} from #{topic}/#{partition} to DQL topic: #{dlq_topic}"
+      end
+
       # There are many types of errors that can occur in many places, but we provide a single
       # handler for all of them to simplify error instrumentation.
       # @param event [Dry::Events::Event] event details including payload

--- a/lib/karafka/instrumentation/logger_listener.rb
+++ b/lib/karafka/instrumentation/logger_listener.rb
@@ -113,7 +113,7 @@ module Karafka
 
       # Logs info when we have dispatched a message the the DLQ
       #
-      # @param _event [Dry::Events::Event] event details including payload
+      # @param event [Dry::Events::Event] event details including payload
       def on_dead_letter_queue_dispatched(event)
         message = event[:message]
         offset = message.offset

--- a/lib/karafka/instrumentation/notifications.rb
+++ b/lib/karafka/instrumentation/notifications.rb
@@ -32,6 +32,8 @@ module Karafka
         connection.listener.fetch_loop
         connection.listener.fetch_loop.received
 
+        dead_letter_queue.dispatched
+
         worker.process
         worker.processed
         worker.completed

--- a/lib/karafka/pro/processing/strategies/aj_dlq_mom.rb
+++ b/lib/karafka/pro/processing/strategies/aj_dlq_mom.rb
@@ -45,7 +45,7 @@ module Karafka
               else
                 coordinator.pause_tracker.reset
                 skippable_message = find_skippable_message
-                copy_skippable_message_to_dlq(skippable_message)
+                dispatch_skippable_message_to_dlq(skippable_message)
                 # We can commit the offset here because we know that we skip it "forever" and
                 # since AJ consumer commits the offset after each job, we also know that the
                 # previous job was successful

--- a/lib/karafka/pro/processing/strategies/dlq_lrj.rb
+++ b/lib/karafka/pro/processing/strategies/dlq_lrj.rb
@@ -46,7 +46,7 @@ module Karafka
                 skippable_message = find_skippable_message
 
                 unless revoked?
-                  copy_skippable_message_to_dlq(skippable_message)
+                  dispatch_skippable_message_to_dlq(skippable_message)
                   mark_as_consumed(skippable_message)
                 end
 

--- a/lib/karafka/pro/processing/strategies/dlq_lrj_mom.rb
+++ b/lib/karafka/pro/processing/strategies/dlq_lrj_mom.rb
@@ -45,7 +45,7 @@ module Karafka
                 skippable_message = find_skippable_message
 
                 unless revoked?
-                  copy_skippable_message_to_dlq(skippable_message)
+                  dispatch_skippable_message_to_dlq(skippable_message)
                   seek(coordinator.seek_offset)
                 end
 

--- a/lib/karafka/pro/processing/strategies/dlq_mom.rb
+++ b/lib/karafka/pro/processing/strategies/dlq_mom.rb
@@ -46,7 +46,7 @@ module Karafka
                 # We reset the pause to indicate we will now consider it as "ok".
                 coordinator.pause_tracker.reset
                 skippable_message = find_skippable_message
-                copy_skippable_message_to_dlq(skippable_message)
+                dispatch_skippable_message_to_dlq(skippable_message)
                 pause(coordinator.seek_offset)
               end
             end

--- a/lib/karafka/processing/strategies/dlq_mom.rb
+++ b/lib/karafka/processing/strategies/dlq_mom.rb
@@ -30,7 +30,7 @@ module Karafka
             coordinator.pause_tracker.reset
 
             skippable_message = find_skippable_message
-            copy_skippable_message_to_dlq(skippable_message)
+            dispatch_skippable_message_to_dlq(skippable_message)
 
             # We pause to backoff once just in case.
             pause(coordinator.seek_offset)

--- a/spec/integrations/consumption/from_non_existing_topic_spec.rb
+++ b/spec/integrations/consumption/from_non_existing_topic_spec.rb
@@ -4,8 +4,6 @@
 
 setup_karafka
 
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::BaseConsumer
   def consume
     DT[0] << 1

--- a/spec/integrations/consumption/strategies/default/multi_topic_ping_pong_spec.rb
+++ b/spec/integrations/consumption/strategies/default/multi_topic_ping_pong_spec.rb
@@ -6,9 +6,6 @@ setup_karafka do |config|
   config.max_wait_time = 100
 end
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 produce(DT.topic, 0.to_json)
 
 class Consumer1 < Karafka::BaseConsumer

--- a/spec/integrations/consumption/strategies/dlq/dispatch_instrumentation_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/dispatch_instrumentation_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# When DLQ delegation happens, Karafka should emit appropriate event.
+
+setup_karafka(allow_errors: %w[consumer.consume.error])
+
+create_topic(name: DT.topics[0])
+create_topic(name: DT.topics[1])
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    raise StandardError
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    dead_letter_queue(topic: DT.topics[1], max_retries: 0)
+  end
+end
+
+Karafka.monitor.subscribe('dead_letter_queue.dispatched') do |event|
+  DT[:events] << 1
+end
+
+elements = DT.uuids(100)
+produce_many(DT.topic, elements)
+
+start_karafka_and_wait_until do
+  DT[:events].size.positive?
+end
+
+# No need for specs, if event was dispatched, we will stop, otherwise hangs.

--- a/spec/integrations/consumption/strategies/dlq/dispatch_instrumentation_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/dispatch_instrumentation_spec.rb
@@ -21,6 +21,7 @@ draw_routes do
 end
 
 Karafka.monitor.subscribe('dead_letter_queue.dispatched') do |event|
+  assert !event[:message].nil?
   DT[:events] << 1
 end
 

--- a/spec/integrations/consumption/strategies/dlq/dispatch_instrumentation_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/dispatch_instrumentation_spec.rb
@@ -4,9 +4,6 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error])
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::BaseConsumer
   def consume
     raise StandardError

--- a/spec/integrations/consumption/strategies/dlq/multi_partition_target_flow_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/multi_partition_target_flow_spec.rb
@@ -6,7 +6,6 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error])
 
-create_topic(name: DT.topics[0])
 create_topic(name: DT.topics[1], partitions: 10)
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/consumption/strategies/dlq/with_error_handling_pipeline_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/with_error_handling_pipeline_spec.rb
@@ -4,8 +4,6 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error])
 
-5.times { |i| create_topic(name: DT.topics[i]) }
-
 class Consumer < Karafka::BaseConsumer
   def consume
     raise StandardError

--- a/spec/integrations/consumption/strategies/dlq/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/with_non_recoverable_error_with_retries_spec.rb
@@ -5,9 +5,6 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error])
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/consumption/strategies/dlq/with_non_recoverable_error_without_retries_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/with_non_recoverable_error_without_retries_spec.rb
@@ -5,9 +5,6 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error])
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/consumption/strategies/dlq/with_non_recoverable_first_message_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/with_non_recoverable_first_message_spec.rb
@@ -5,9 +5,6 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error])
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/consumption/strategies/dlq/with_non_recoverable_last_message_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/with_non_recoverable_last_message_spec.rb
@@ -5,9 +5,6 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error])
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/consumption/strategies/dlq/with_recoverable_error_on_retry_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/with_recoverable_error_on_retry_spec.rb
@@ -5,9 +5,6 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error])
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/consumption/strategies/dlq/without_any_errors_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/without_any_errors_spec.rb
@@ -4,9 +4,6 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error])
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/consumption/strategies/dlq/without_intermediate_marking_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/without_intermediate_marking_spec.rb
@@ -9,9 +9,6 @@ setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.max_messages = 6
 end
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/consumption/strategies/dlq_mom/multi_partition_target_flow_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/multi_partition_target_flow_spec.rb
@@ -4,7 +4,6 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error])
 
-create_topic(name: DT.topics[0])
 create_topic(name: DT.topics[1], partitions: 10)
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/consumption/strategies/dlq_mom/with_error_handling_pipeline_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_error_handling_pipeline_spec.rb
@@ -4,8 +4,6 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error])
 
-5.times { |i| create_topic(name: DT.topics[i]) }
-
 class Consumer < Karafka::BaseConsumer
   def consume
     raise StandardError

--- a/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_error_with_retries_spec.rb
@@ -4,9 +4,6 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error])
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_error_without_retries_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_error_without_retries_spec.rb
@@ -4,9 +4,6 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error])
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_first_message_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_first_message_spec.rb
@@ -4,9 +4,6 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error])
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_last_message_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_last_message_spec.rb
@@ -4,9 +4,6 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error])
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/consumption/strategies/dlq_mom/with_recoverable_error_on_retry_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_recoverable_error_on_retry_spec.rb
@@ -4,9 +4,6 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error])
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/consumption/strategies/dlq_mom/without_any_errors_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/without_any_errors_spec.rb
@@ -4,9 +4,6 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error])
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/consumption/strategies/dlq_mom/without_intermediate_marking_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/without_intermediate_marking_spec.rb
@@ -7,9 +7,6 @@ setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.max_messages = 6
 end
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/consumption/with_separate_subscription_groups_spec.rb
+++ b/spec/integrations/consumption/with_separate_subscription_groups_spec.rb
@@ -20,8 +20,6 @@ draw_routes do
         consumer Consumer
       end
     end
-
-    create_topic(name: topic_name)
   end
 end
 

--- a/spec/integrations/instrumentation/error_callback_multiple_subscription_groups_spec.rb
+++ b/spec/integrations/instrumentation/error_callback_multiple_subscription_groups_spec.rb
@@ -9,7 +9,7 @@ setup_karafka(allow_errors: true) do |config|
   config.kafka = { 'bootstrap.servers': '127.0.0.1:9090' }
 end
 
-draw_routes do
+draw_routes(nil, false) do
   consumer_group DT.consumer_groups.first do
     topic DT.topic do
       consumer Class.new

--- a/spec/integrations/instrumentation/error_callback_multiple_subscription_groups_spec.rb
+++ b/spec/integrations/instrumentation/error_callback_multiple_subscription_groups_spec.rb
@@ -9,7 +9,7 @@ setup_karafka(allow_errors: true) do |config|
   config.kafka = { 'bootstrap.servers': '127.0.0.1:9090' }
 end
 
-draw_routes(nil, false) do
+draw_routes(nil, create_topics: false) do
   consumer_group DT.consumer_groups.first do
     topic DT.topic do
       consumer Class.new

--- a/spec/integrations/instrumentation/error_callback_subscription_spec.rb
+++ b/spec/integrations/instrumentation/error_callback_subscription_spec.rb
@@ -7,7 +7,7 @@ setup_karafka(allow_errors: true) do |config|
   config.kafka = { 'bootstrap.servers': '127.0.0.1:9090' }
 end
 
-draw_routes(Class.new)
+draw_routes(Class.new, false)
 
 error_events = []
 

--- a/spec/integrations/instrumentation/error_callback_subscription_spec.rb
+++ b/spec/integrations/instrumentation/error_callback_subscription_spec.rb
@@ -7,7 +7,7 @@ setup_karafka(allow_errors: true) do |config|
   config.kafka = { 'bootstrap.servers': '127.0.0.1:9090' }
 end
 
-draw_routes(Class.new, false)
+draw_routes(Class.new, create_topics: false)
 
 error_events = []
 

--- a/spec/integrations/instrumentation/statistics_callback_on_client_change_spec.rb
+++ b/spec/integrations/instrumentation/statistics_callback_on_client_change_spec.rb
@@ -5,7 +5,7 @@
 
 setup_karafka(allow_errors: true)
 
-draw_routes(Class.new)
+draw_routes(Class.new, false)
 
 stats_events = []
 

--- a/spec/integrations/instrumentation/statistics_callback_on_client_change_spec.rb
+++ b/spec/integrations/instrumentation/statistics_callback_on_client_change_spec.rb
@@ -5,7 +5,7 @@
 
 setup_karafka(allow_errors: true)
 
-draw_routes(Class.new, false)
+draw_routes(Class.new, create_topics: false)
 
 stats_events = []
 

--- a/spec/integrations/pro/consumption/strategies/aj_dlq_lrj_mom/with_non_recoverable_slow_jobs_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj_dlq_lrj_mom/with_non_recoverable_slow_jobs_error_spec.rb
@@ -24,9 +24,6 @@ setup_karafka(allow_errors: true) do |config|
   config.kafka[:'session.timeout.ms'] = 10_000
 end
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class DlqConsumer < Karafka::Pro::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/pro/consumption/strategies/aj_dlq_mom/with_non_recoverable_job_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj_dlq_mom/with_non_recoverable_job_error_spec.rb
@@ -24,9 +24,6 @@ setup_karafka(allow_errors: true) do |config|
   config.kafka[:'session.timeout.ms'] = 10_000
 end
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class DlqConsumer < Karafka::Pro::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/pro/consumption/strategies/dlq/dispatch_instrumentation_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/dispatch_instrumentation_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# When DLQ delegation happens, Karafka should emit appropriate event.
+
+setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
+  config.license.token = pro_license_token
+end
+
+create_topic(name: DT.topics[0])
+create_topic(name: DT.topics[1])
+
+class Consumer < Karafka::Pro::BaseConsumer
+  def consume
+    raise StandardError
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    dead_letter_queue(topic: DT.topics[1], max_retries: 0)
+  end
+end
+
+Karafka.monitor.subscribe('dead_letter_queue.dispatched') do |event|
+  DT[:events] << 1
+end
+
+elements = DT.uuids(100)
+produce_many(DT.topic, elements)
+
+start_karafka_and_wait_until do
+  DT[:events].size.positive?
+end
+
+# No need for specs, if event was dispatched, we will stop, otherwise hangs.

--- a/spec/integrations/pro/consumption/strategies/dlq/dispatch_instrumentation_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/dispatch_instrumentation_spec.rb
@@ -6,9 +6,6 @@ setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.license.token = pro_license_token
 end
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     raise StandardError

--- a/spec/integrations/pro/consumption/strategies/dlq/dispatch_instrumentation_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/dispatch_instrumentation_spec.rb
@@ -23,6 +23,7 @@ draw_routes do
 end
 
 Karafka.monitor.subscribe('dead_letter_queue.dispatched') do |event|
+  assert !event[:message].nil?
   DT[:events] << 1
 end
 

--- a/spec/integrations/pro/consumption/strategies/dlq/multi_partition_target_flow_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/multi_partition_target_flow_spec.rb
@@ -7,7 +7,6 @@ setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.license.token = pro_license_token
 end
 
-create_topic(name: DT.topics[0])
 create_topic(name: DT.topics[1], partitions: 10)
 
 class Consumer < Karafka::Pro::BaseConsumer

--- a/spec/integrations/pro/consumption/strategies/dlq/original_offset_tracking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/original_offset_tracking_spec.rb
@@ -6,9 +6,6 @@ setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.license.token = pro_license_token
 end
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/pro/consumption/strategies/dlq/with_error_handling_pipeline_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/with_error_handling_pipeline_spec.rb
@@ -6,8 +6,6 @@ setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.license.token = pro_license_token
 end
 
-5.times { |i| create_topic(name: DT.topics[i]) }
-
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     raise StandardError

--- a/spec/integrations/pro/consumption/strategies/dlq/with_non_recoverable_error_with_one_retry_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/with_non_recoverable_error_with_one_retry_spec.rb
@@ -7,9 +7,6 @@ setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.license.token = pro_license_token
 end
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/pro/consumption/strategies/dlq/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/with_non_recoverable_error_with_retries_spec.rb
@@ -7,9 +7,6 @@ setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.license.token = pro_license_token
 end
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/pro/consumption/strategies/dlq/with_non_recoverable_error_without_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/with_non_recoverable_error_without_retries_spec.rb
@@ -7,9 +7,6 @@ setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.license.token = pro_license_token
 end
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/pro/consumption/strategies/dlq/with_non_recoverable_first_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/with_non_recoverable_first_message_spec.rb
@@ -7,9 +7,6 @@ setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.license.token = pro_license_token
 end
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/pro/consumption/strategies/dlq/with_non_recoverable_last_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/with_non_recoverable_last_message_spec.rb
@@ -7,9 +7,6 @@ setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.license.token = pro_license_token
 end
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/pro/consumption/strategies/dlq/with_recoverable_error_on_retry_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/with_recoverable_error_on_retry_spec.rb
@@ -7,9 +7,6 @@ setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.license.token = pro_license_token
 end
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/pro/consumption/strategies/dlq/without_any_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/without_any_errors_spec.rb
@@ -6,9 +6,6 @@ setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.license.token = pro_license_token
 end
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/pro/consumption/strategies/dlq/without_intermediate_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/without_intermediate_marking_spec.rb
@@ -10,9 +10,6 @@ setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.max_messages = 6
 end
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/pro/consumption/strategies/dlq_lrj/with_non_recoverable_slow_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_lrj/with_non_recoverable_slow_error_spec.rb
@@ -17,9 +17,6 @@ setup_karafka(allow_errors: true) do |config|
   config.kafka[:'session.timeout.ms'] = 10_000
 end
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     sleep 15

--- a/spec/integrations/pro/consumption/strategies/dlq_lrj_mom/with_non_recoverable_slow_no_marking_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_lrj_mom/with_non_recoverable_slow_no_marking_error_spec.rb
@@ -19,9 +19,6 @@ setup_karafka(allow_errors: true) do |config|
   config.kafka[:'session.timeout.ms'] = 10_000
 end
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     @sleep ||= 20

--- a/spec/integrations/pro/consumption/strategies/dlq_mom/multi_partition_target_flow_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_mom/multi_partition_target_flow_spec.rb
@@ -7,7 +7,6 @@ setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.license.token = pro_license_token
 end
 
-create_topic(name: DT.topics[0])
 create_topic(name: DT.topics[1], partitions: 10)
 
 class Consumer < Karafka::Pro::BaseConsumer

--- a/spec/integrations/pro/consumption/strategies/dlq_mom/with_error_handling_pipeline_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_mom/with_error_handling_pipeline_spec.rb
@@ -6,8 +6,6 @@ setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.license.token = pro_license_token
 end
 
-5.times { |i| create_topic(name: DT.topics[i]) }
-
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     raise StandardError

--- a/spec/integrations/pro/consumption/strategies/dlq_mom/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_mom/with_non_recoverable_error_with_retries_spec.rb
@@ -6,9 +6,6 @@ setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.license.token = pro_license_token
 end
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/pro/consumption/strategies/dlq_mom/with_non_recoverable_error_without_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_mom/with_non_recoverable_error_without_retries_spec.rb
@@ -6,9 +6,6 @@ setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.license.token = pro_license_token
 end
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/pro/consumption/strategies/dlq_mom/with_non_recoverable_first_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_mom/with_non_recoverable_first_message_spec.rb
@@ -6,9 +6,6 @@ setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.license.token = pro_license_token
 end
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/pro/consumption/strategies/dlq_mom/with_non_recoverable_last_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_mom/with_non_recoverable_last_message_spec.rb
@@ -6,9 +6,6 @@ setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.license.token = pro_license_token
 end
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/pro/consumption/strategies/dlq_mom/with_recoverable_error_on_retry_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_mom/with_recoverable_error_on_retry_spec.rb
@@ -6,9 +6,6 @@ setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.license.token = pro_license_token
 end
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/pro/consumption/strategies/dlq_mom/without_any_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_mom/without_any_errors_spec.rb
@@ -6,9 +6,6 @@ setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.license.token = pro_license_token
 end
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/pro/consumption/strategies/dlq_mom/without_intermediate_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_mom/without_intermediate_marking_spec.rb
@@ -8,9 +8,6 @@ setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.license.token = pro_license_token
 end
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     messages.each do |message|

--- a/spec/integrations/pro/consumption/strategies/lrj/parallel_non_lrj_with_lrj_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/parallel_non_lrj_with_lrj_spec.rb
@@ -11,9 +11,6 @@ setup_karafka do |config|
   config.kafka[:'session.timeout.ms'] = 10_000
 end
 
-create_topic(name: DT.topics[0])
-create_topic(name: DT.topics[1])
-
 class LrjConsumer < Karafka::Pro::BaseConsumer
   def consume
     producer.produce_sync(topic: DT.topics[1], payload: '1')

--- a/spec/integrations/pro/consumption/strategies/vp/consistent_distribution_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/consistent_distribution_spec.rb
@@ -11,8 +11,6 @@ setup_karafka do |config|
   config.initial_offset = 'earliest'
 end
 
-create_topic
-
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     group = Set.new

--- a/spec/integrations/pro/consumption/strategies/vp/with_limited_concurrency_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/with_limited_concurrency_spec.rb
@@ -11,8 +11,6 @@ setup_karafka do |config|
   config.max_wait_time = 1_000
 end
 
-create_topic(name: DT.topics[0])
-
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     times = []

--- a/spec/integrations/pro/consumption/strategies/vp/with_more_vps_than_workers_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/with_more_vps_than_workers_spec.rb
@@ -11,8 +11,6 @@ setup_karafka do |config|
   config.max_wait_time = 2_000
 end
 
-create_topic(name: DT.topics[0])
-
 class Consumer < Karafka::Pro::BaseConsumer
   def consume
     DT[:objects_ids] << object_id

--- a/spec/integrations_helper.rb
+++ b/spec/integrations_helper.rb
@@ -135,7 +135,7 @@ end
 # @param consumer_class [Class, nil] consumer class we want to use if going with defaults
 # @param create_topics [Boolean] should we create the defined topics (true by default)
 # @param block [Proc] block with routes we want to draw if going with complex routes setup
-def draw_routes(consumer_class = nil, create_topics = true, &block)
+def draw_routes(consumer_class = nil, create_topics: true, &block)
   Karafka::App.routes.draw do
     if block
       instance_eval(&block)
@@ -150,8 +150,13 @@ def draw_routes(consumer_class = nil, create_topics = true, &block)
 
   return unless create_topics
 
-  # Code below will auto-create all the routing based topics so we don't have to do it per spec
-  # If a topic is already created for example with more partitions, this will do nothing
+  create_routes_topics
+end
+
+# Creates topics defined in the routes so they are available for the specs
+# Code below will auto-create all the routing based topics so we don't have to do it per spec
+# If a topic is already created for example with more partitions, this will do nothing
+def create_routes_topics
   topics_names = Set.new
 
   Karafka::App.routes.map(&:topics).flatten.each do |topics|

--- a/spec/integrations_helper.rb
+++ b/spec/integrations_helper.rb
@@ -133,8 +133,9 @@ end
 # Sets up default routes (mostly used in integration specs) or allows to configure custom routes
 # by providing a block
 # @param consumer_class [Class, nil] consumer class we want to use if going with defaults
+# @param create_topics [Boolean] should we create the defined topics (true by default)
 # @param block [Proc] block with routes we want to draw if going with complex routes setup
-def draw_routes(consumer_class = nil, &block)
+def draw_routes(consumer_class = nil, create_topics = true, &block)
   Karafka::App.routes.draw do
     if block
       instance_eval(&block)
@@ -146,6 +147,18 @@ def draw_routes(consumer_class = nil, &block)
       end
     end
   end
+
+  return unless create_topics
+
+  # Code below will auto-create all the routing based topics so we don't have to do it per spec
+  # If a topic is already created for example with more partitions, this will do nothing
+  topics_names = Set.new
+
+  Karafka::App.routes.map(&:topics).flatten.each do |topics|
+    topics.each { |topic| topics_names << topic.name }
+  end
+
+  topics_names.each { |topic_name| create_topic(name: topic_name) }
 end
 
 # Waits until block yields true


### PR DESCRIPTION
close https://github.com/karafka/karafka/issues/1112

alongside this PR introduces auto-topics creation based on routes definition. This prevents us from not expected rebalances on first message dispatch auto topic creation.