### PR TITLE
Fix unintentional headers naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 ## Unreleased
 - [Fix] Few typos around DLQ and Pro DLQ Dispatch original metadata naming.
 
+### Upgrade notes
+
+1. Replace `original-*` references from DLQ dispatched metadata with `original_*`
+
+```ruby
+# DLQ topic consumption
+def consume
+  messages.each do |broken_message|
+    topic = broken_message.metadata['original_topic'] # was original-topic
+    partition = broken_message.metadata['original_partition'] # was original-partition
+    offset = broken_message.metadata['original_offset'] # was original-offset
+
+    Rails.logger.error "This message is broken: #{topic}/#{partition}/#{offset}"
+  end
+end
+```
+
 ## 2.0.16 (2022-11-09)
 - **[Breaking]** Disable the root `manual_offset_management` setting and require it to be configured per topic. This is part of "topic features" configuration extraction for better code organization.
 - **[Feature]** Introduce **Dead Letter Queue** feature and Pro **Enhanced Dead Letter Queue** feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka framework changelog
 
+## Unreleased
+- [Fix] Few typos around DLQ and Pro DLQ Dispatch original metadata naming.
+
 ## 2.0.16 (2022-11-09)
 - **[Breaking]** Disable the root `manual_offset_management` setting and require it to be configured per topic. This is part of "topic features" configuration extraction for better code organization.
 - **[Feature]** Introduce **Dead Letter Queue** feature and Pro **Enhanced Dead Letter Queue** feature
@@ -25,7 +28,6 @@
 - [Fix] Fix for a case where fast consecutive stop signaling could hang the stopping listeners.
 - [Specs] Split specs into regular and pro to simplify how resources are loaded
 - [Specs] Add specs to ensure, that all the Pro components have a proper per-file license (#1099)
-
 
 ### Upgrade notes
 

--- a/lib/karafka/pro/processing/strategies/dlq.rb
+++ b/lib/karafka/pro/processing/strategies/dlq.rb
@@ -68,9 +68,9 @@ module Karafka
               payload: skippable_message.raw_payload,
               key: skippable_message.partition.to_s,
               headers: skippable_message.headers.merge(
-                'original-topic' => topic.name,
-                'original-partition' => skippable_message.partition.to_s,
-                'original-offset' => skippable_message.offset.to_s
+                'original_topic' => topic.name,
+                'original_partition' => skippable_message.partition.to_s,
+                'original_offset' => skippable_message.offset.to_s
               )
             )
 

--- a/spec/integrations/pro/consumption/strategies/aj_dlq_lrj_mom/with_non_recoverable_slow_jobs_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj_dlq_lrj_mom/with_non_recoverable_slow_jobs_error_spec.rb
@@ -27,7 +27,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original-offset'].to_i
+      DT[1] << message.headers['original_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/aj_dlq_mom/with_non_recoverable_job_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj_dlq_mom/with_non_recoverable_job_error_spec.rb
@@ -27,7 +27,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original-offset'].to_i
+      DT[1] << message.headers['original_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/details_dispatch_transfer_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/details_dispatch_transfer_spec.rb
@@ -47,7 +47,7 @@ end
 
   assert_equal dlq_message.raw_payload, elements[i]
   assert_equal dlq_message.headers["test#{i}"], (i + 1).to_s
-  assert_equal dlq_message.headers['original-topic'], DT.topic
-  assert_equal dlq_message.headers['original-partition'], 0.to_s
-  assert_equal dlq_message.headers['original-offset'], i.to_s
+  assert_equal dlq_message.headers['original_topic'], DT.topic
+  assert_equal dlq_message.headers['original_partition'], 0.to_s
+  assert_equal dlq_message.headers['original_offset'], i.to_s
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/manual_dispatch_to_dlq_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/manual_dispatch_to_dlq_spec.rb
@@ -49,6 +49,6 @@ assert_equal DT[:broken].size, 1, DT.data
 broken = DT[:broken].first
 
 assert_equal elements[0], broken.raw_payload, DT.data
-assert_equal broken.headers['original-topic'], DT.topic
-assert_equal broken.headers['original-partition'].to_i, 0
-assert_equal broken.headers['original-offset'].to_i, 0
+assert_equal broken.headers['original_topic'], DT.topic
+assert_equal broken.headers['original_partition'].to_i, 0
+assert_equal broken.headers['original_offset'].to_i, 0

--- a/spec/integrations/pro/consumption/strategies/dlq/multi_partition_source_target_flow_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/multi_partition_source_target_flow_spec.rb
@@ -23,7 +23,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT["broken-#{message.partition}"] << message.headers['original-partition']
+      DT["broken-#{message.partition}"] << message.headers['original_partition']
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/original_offset_tracking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/original_offset_tracking_spec.rb
@@ -21,7 +21,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[:broken] << message.headers['original-offset']
+      DT[:broken] << message.headers['original_offset']
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq_lrj/fast_with_non_recoverable_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_lrj/fast_with_non_recoverable_errors_spec.rb
@@ -23,7 +23,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << [message.headers['original-offset'].to_i, message.offset]
+      DT[1] << [message.headers['original_offset'].to_i, message.offset]
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq_lrj/with_non_recoverable_slow_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_lrj/with_non_recoverable_slow_error_spec.rb
@@ -33,7 +33,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original-offset'].to_i
+      DT[1] << message.headers['original_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq_lrj_mom/with_non_recoverable_slow_no_marking_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_lrj_mom/with_non_recoverable_slow_no_marking_error_spec.rb
@@ -38,7 +38,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original-offset'].to_i
+      DT[1] << message.headers['original_offset'].to_i
     end
   end
 end


### PR DESCRIPTION
This PR replaces `-` with `_` in the headers details on the Pro DLQ dispatch.