### PR TITLE
caching bundler breaks integrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{matrix.ruby}}
-          bundler-cache: true
 
       - name: Install latest Bundler
         run: |


### PR DESCRIPTION
Caching the integrations spec bundler makes it impossible to install deps in integrations