### PR TITLE
Optimize shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - **[Feature]** Support quiet mode via `TSTP` signal. When used, Karafka will finish processing current messages, run `shutdown` jobs, and switch to a quiet mode where no new work is being accepted. At the same time, it will keep the consumer group quiet, and thus no rebalance will be triggered. This can be particularly useful during deployments.
 - [Improvement] Trigger `#revoked` for jobs in case revocation would happen during shutdown when jobs are still running. This should ensure, we get a notion of revocation for Pro LRJ jobs even when revocation happening upon shutdown (#1150).
+- [Improvement] Stabilize the shutdown procedure for consumer groups with many subscription groups that have non-aligned processing cost per batch.
 - [Fix] Fix invalid class references in YARD docs.
 - [Fix] prevent parallel closing of many clients.
 

--- a/lib/karafka/app.rb
+++ b/lib/karafka/app.rb
@@ -14,11 +14,12 @@ module Karafka
           .builder
       end
 
-      # @return [Array<Karafka::Routing::SubscriptionGroup>] active subscription groups
+      # @return [Hash] active subscription groups grouped based on consumer group in a hash
       def subscription_groups
         consumer_groups
           .active
-          .flat_map(&:subscription_groups)
+          .map { |consumer_group| [consumer_group, consumer_group.subscription_groups] }
+          .to_h
       end
 
       # Just a nicer name for the consumer groups

--- a/lib/karafka/connection/consumer_group_status.rb
+++ b/lib/karafka/connection/consumer_group_status.rb
@@ -23,9 +23,15 @@ module Karafka
         @active_size.positive?
       end
 
-      # Decrements number of working listeners in the gorup by one until there's none
+      # Decrements number of working listeners in the group by one until there's none
       def finish
-        @mutex.synchronize { @active_size -= 1 }
+        @mutex.synchronize do
+          @active_size -= 1
+
+          return if @active_size >= 0
+
+          raise Errors::InvalidConsumerGroupStatusError, @active_size
+        end
       end
     end
   end

--- a/lib/karafka/connection/consumer_group_status.rb
+++ b/lib/karafka/connection/consumer_group_status.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Karafka
+  module Connection
+    # This object represents a collective status of execution of group of listeners running inside
+    # of one consumer group but potentially in separate subscription groups.
+    #
+    # There are cases when we do not want to close a given client when others from the same
+    # consumer group are running because it can cause instabilities due to early shutdown of some
+    # of the clients out of same consumer group.
+    #
+    # Here we can track it and only shutdown listeners when all work in a group is done.
+    class ConsumerGroupStatus
+      # @param group_size [Integer] number of separate subscription groups in a consumer group
+      def initialize(group_size)
+        @mutex = Mutex.new
+        @active_size = group_size
+      end
+
+      # @return [Boolean] Are there any listeners that are still doing any type of work. If not,
+      #   it means a consumer group is safe to be shutdown fully.
+      def working?
+        @active_size.positive?
+      end
+
+      # Decrements number of working listeners in the gorup by one until there's none
+      def finish
+        @mutex.synchronize { @active_size -= 1 }
+      end
+    end
+  end
+end

--- a/lib/karafka/connection/listeners_batch.rb
+++ b/lib/karafka/connection/listeners_batch.rb
@@ -9,8 +9,18 @@ module Karafka
       # @param jobs_queue [JobsQueue]
       # @return [ListenersBatch]
       def initialize(jobs_queue)
-        @batch = App.subscription_groups.map do |subscription_group|
-          Connection::Listener.new(subscription_group, jobs_queue)
+        @batch = App.subscription_groups.flat_map do |_consumer_group, subscription_groups|
+          consumer_group_status = Connection::ConsumerGroupStatus.new(
+            subscription_groups.size
+          )
+
+          subscription_groups.map do |subscription_group|
+            Connection::Listener.new(
+              consumer_group_status,
+              subscription_group,
+              jobs_queue
+            )
+          end
         end
       end
 

--- a/lib/karafka/errors.rb
+++ b/lib/karafka/errors.rb
@@ -45,6 +45,9 @@ module Karafka
     InvalidCoordinatorStateError = Class.new(BaseError)
 
     # This should never happen. Please open an issue if it does.
+    InvalidConsumerGroupStatusError = Class.new(BaseError)
+
+    # This should never happen. Please open an issue if it does.
     StrategyNotFoundError = Class.new(BaseError)
 
     # This should never happen. Please open an issue if it does.

--- a/spec/integrations/consumption/strategies/default/of_many_topics_with_different_settings_spec.rb
+++ b/spec/integrations/consumption/strategies/default/of_many_topics_with_different_settings_spec.rb
@@ -38,7 +38,7 @@ start_karafka_and_wait_until do
 end
 
 # Ensure we have 10 subscription groups as expected when non-homogeneous settings are used
-assert_equal 10, Karafka::App.subscription_groups.size
+assert_equal 10, Karafka::App.subscription_groups.values.flatten.size
 # All workers should be in use
 assert_equal 10, DT.data.keys.size
 # All workers consumers should consume same number of messages

--- a/spec/integrations/consumption/with_mixed_performance_in_subscription_group_spec.rb
+++ b/spec/integrations/consumption/with_mixed_performance_in_subscription_group_spec.rb
@@ -19,12 +19,14 @@ setup_karafka do |config|
   config.concurrency = 10
 end
 
-POLL = Concurrent::Array.new(8) { |i| i }.reverse
+POLL = Concurrent::Array.new(6) { |i| i }
+POLL << 9
+POLL.reverse!
 
 class Consumer < Karafka::BaseConsumer
   def consume
     DT[:clients] << client.object_id
-    sleep POLL.pop || 8
+    sleep POLL.pop || 2
   end
 end
 

--- a/spec/integrations/consumption/with_mixed_performance_in_subscription_group_spec.rb
+++ b/spec/integrations/consumption/with_mixed_performance_in_subscription_group_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# When running work of a single consumer group from many subscription groups, upon shutdown we
+# should not experience any rebalance problems as the shutdown should happen after all the work
+# is done.
+
+require 'stringio'
+
+strio = StringIO.new
+
+proper_stdout = $stdout
+proper_stderr = $stderr
+
+$stdout = strio
+$stderr = strio
+
+setup_karafka do |config|
+  config.logger = Logger.new(strio)
+  config.concurrency = 10
+end
+
+POLL = Concurrent::Array.new(10) { |i| i }.reverse
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[:clients] << client.object_id
+    sleep POLL.pop || 10
+  end
+end
+
+draw_routes do
+  DT.topics.first(10).each_slice(2) do |topics|
+    slice_uuid = SecureRandom.uuid
+
+    subscription_group slice_uuid do
+      topics.each do |topic_name|
+        topic topic_name do
+          consumer Consumer
+        end
+      end
+    end
+  end
+end
+
+messages = DT.topics.first(10).map do |topic_name|
+  { topic: topic_name, payload: '1' }
+end
+
+Karafka.producer.produce_many_sync(messages)
+
+start_karafka_and_wait_until do
+  DT[:clients].uniq.count >= 5 && sleep(5)
+end
+
+$stdout = proper_stdout
+$stderr = proper_stderr
+
+assert_equal false, strio.string.include?('Timed out'), strio.string

--- a/spec/integrations/consumption/with_mixed_performance_in_subscription_group_spec.rb
+++ b/spec/integrations/consumption/with_mixed_performance_in_subscription_group_spec.rb
@@ -19,12 +19,12 @@ setup_karafka do |config|
   config.concurrency = 10
 end
 
-POLL = Concurrent::Array.new(10) { |i| i }.reverse
+POLL = Concurrent::Array.new(8) { |i| i }.reverse
 
 class Consumer < Karafka::BaseConsumer
   def consume
     DT[:clients] << client.object_id
-    sleep POLL.pop || 10
+    sleep POLL.pop || 8
   end
 end
 

--- a/spec/integrations/routing/routing_with_anonymous_subscription_group_spec.rb
+++ b/spec/integrations/routing/routing_with_anonymous_subscription_group_spec.rb
@@ -24,7 +24,7 @@ end
 
 assert_equal 1, Karafka::App.routes.size
 assert_equal 1, Karafka::App.consumer_groups.size
-assert_equal 3, Karafka::App.subscription_groups.size
+assert_equal 3, Karafka::App.subscription_groups.values.flatten.size
 assert_equal 3, Karafka::App.consumer_groups.first.topics.size
 assert_equal 'topic1', Karafka::App.consumer_groups.first.topics.first.name
 assert_equal 'topic2', Karafka::App.consumer_groups.first.topics[1].name
@@ -32,9 +32,9 @@ assert_equal 'topic3', Karafka::App.consumer_groups.first.topics[2].name
 
 groups = []
 
-groups << Karafka::App.subscription_groups.first.topics.first.subscription_group
-groups << Karafka::App.subscription_groups[1].topics.first.subscription_group
-groups << Karafka::App.subscription_groups[2].topics.first.subscription_group
+groups << Karafka::App.subscription_groups.values.flatten.first.topics.first.subscription_group
+groups << Karafka::App.subscription_groups.values.flatten[1].topics.first.subscription_group
+groups << Karafka::App.subscription_groups.values.flatten[2].topics.first.subscription_group
 
 # All anonymous groups need to be unique
 assert_equal groups, groups.uniq

--- a/spec/integrations/routing/routing_with_subscription_groups_arg_based_spec.rb
+++ b/spec/integrations/routing/routing_with_subscription_groups_arg_based_spec.rb
@@ -20,13 +20,15 @@ draw_routes do
   end
 end
 
+subscription_groups = Karafka::App.subscription_groups.values.flatten
+
 assert_equal 1, Karafka::App.routes.size
 assert_equal 1, Karafka::App.consumer_groups.size
-assert_equal 3, Karafka::App.subscription_groups.size
+assert_equal 3, subscription_groups.size
 assert_equal 3, Karafka::App.consumer_groups.first.topics.size
 assert_equal 'topic1', Karafka::App.consumer_groups.first.topics.first.name
 assert_equal 'topic2', Karafka::App.consumer_groups.first.topics[1].name
 assert_equal 'topic3', Karafka::App.consumer_groups.first.topics[2].name
-assert_equal 'group1', Karafka::App.subscription_groups.first.topics.first.subscription_group
-assert_equal nil, Karafka::App.subscription_groups[1].topics.first.subscription_group
-assert_equal 'group2', Karafka::App.subscription_groups[2].topics.first.subscription_group
+assert_equal 'group1', subscription_groups.first.topics.first.subscription_group
+assert_equal nil, subscription_groups[1].topics.first.subscription_group
+assert_equal 'group2', subscription_groups[2].topics.first.subscription_group

--- a/spec/integrations/routing/routing_with_subscription_groups_block_based_spec.rb
+++ b/spec/integrations/routing/routing_with_subscription_groups_block_based_spec.rb
@@ -22,13 +22,15 @@ draw_routes do
   end
 end
 
+subscription_groups = Karafka::App.subscription_groups.values.flatten
+
 assert_equal 1, Karafka::App.routes.size
 assert_equal 1, Karafka::App.consumer_groups.size
-assert_equal 3, Karafka::App.subscription_groups.size
+assert_equal 3, subscription_groups.size
 assert_equal 3, Karafka::App.consumer_groups.first.topics.size
 assert_equal 'topic1', Karafka::App.consumer_groups.first.topics.first.name
 assert_equal 'topic2', Karafka::App.consumer_groups.first.topics[1].name
 assert_equal 'topic3', Karafka::App.consumer_groups.first.topics[2].name
-assert_equal 'group1', Karafka::App.subscription_groups.first.topics.first.subscription_group
-assert_equal nil, Karafka::App.subscription_groups[1].topics.first.subscription_group
-assert_equal 'group2', Karafka::App.subscription_groups[2].topics.first.subscription_group
+assert_equal 'group1', subscription_groups.first.topics.first.subscription_group
+assert_equal nil, subscription_groups[1].topics.first.subscription_group
+assert_equal 'group2', subscription_groups[2].topics.first.subscription_group

--- a/spec/lib/karafka/connection/consumer_group_status_spec.rb
+++ b/spec/lib/karafka/connection/consumer_group_status_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:status) { described_class.new(2) }
+
+  context 'when all work is done' do
+    before { 2.times { status.finish } }
+
+    it { expect(status.working?).to eq(false) }
+  end
+
+  context 'when we tried to finish too much work' do
+    before { 2.times { status.finish } }
+
+    let(:expected_error) { Karafka::Errors::InvalidConsumerGroupStatusError }
+
+    it { expect { status.finish }.to raise_error(expected_error) }
+  end
+
+  context 'when we finished some of the work' do
+    before { status.finish }
+
+    it { expect(status.working?).to eq(true) }
+  end
+end

--- a/spec/lib/karafka/connection/listener_spec.rb
+++ b/spec/lib/karafka/connection/listener_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe_current do
-  subject(:listener) { described_class.new(subscription_group, jobs_queue) }
+  subject(:listener) { described_class.new(consumer_group_status, subscription_group, jobs_queue) }
 
+  let(:consumer_group_status) { Karafka::Connection::ConsumerGroupStatus.new(1) }
   let(:subscription_group) { build(:routing_subscription_group, topics: [routing_topic]) }
   let(:jobs_queue) { Karafka::Processing::JobsQueue.new }
   let(:client) { Karafka::Connection::Client.new(subscription_group) }

--- a/spec/lib/karafka/connection/listeners_batch_spec.rb
+++ b/spec/lib/karafka/connection/listeners_batch_spec.rb
@@ -4,13 +4,16 @@ RSpec.describe_current do
   subject(:batch) { described_class.new(jobs_queue) }
 
   let(:jobs_queue) { Karafka::Processing::JobsQueue.new }
+  let(:consumer_group) { build(:routing_consumer_group) }
   let(:subscription_group) { build(:routing_subscription_group) }
 
   after { batch.each(&:shutdown) }
 
   describe '#each' do
     before do
-      allow(Karafka::App).to receive(:subscription_groups).and_return([subscription_group])
+      allow(Karafka::App).to receive(:subscription_groups).and_return(
+        consumer_group => [subscription_group]
+      )
     end
 
     it 'expect to yield each listener' do

--- a/spec/lib/karafka/errors_spec.rb
+++ b/spec/lib/karafka/errors_spec.rb
@@ -42,4 +42,10 @@ RSpec.describe_current do
 
     specify { expect(error).to be < described_class::BaseError }
   end
+
+  describe 'InvalidConsumerGroupStatusError' do
+    subject(:error) { described_class::InvalidConsumerGroupStatusError }
+
+    specify { expect(error).to be < described_class::BaseError }
+  end
 end

--- a/spec/lib/karafka/instrumentation/logger_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/logger_listener_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe_current do
 
     let(:payload) { { caller: consumer, message: kafka_message } }
     let(:kafka_message) { create(:messages_message) }
-    let(:message) { 'Dispatched message 1 from test/0 to DLQ topic: dlq' }
+    let(:message) { "Dispatched message #{kafka_message.offset} from test/0 to DLQ topic: dlq" }
     let(:consumer) do
       instance = Class.new(Karafka::BaseConsumer).new
       instance.topic = build(:routing_topic, name: 'test')


### PR DESCRIPTION
This PR optimizes shutdown of a single consumer group with subscription groups in which the processing performance varies.

close https://github.com/karafka/karafka/issues/1154
close https://github.com/karafka/karafka/issues/1148