### PR TITLE
Optimized LRJ VP revoked awareness + small concurrency improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [Improvement] Remove double loading of Karafka via Rails railtie.
 - [Fix] Fix invalid class references in YARD docs.
 - [Fix] prevent parallel closing of many clients.
+- [Fix] fix a case where information about revocation for a combination of LRJ + VP would not be dispatched until all VP work is done.
 
 ## 2.0.17 (2022-11-10)
 - [Fix] Few typos around DLQ and Pro DLQ Dispatch original metadata naming.

--- a/lib/karafka/connection/listener.rb
+++ b/lib/karafka/connection/listener.rb
@@ -71,7 +71,7 @@ module Karafka
         return if @stopped
 
         # We want to make sure that we never close two librdkafka clients at the same time. I'm not
-        # particulary fond of it's shutdown API being fully thread-safe
+        # particularly fond of it's shutdown API being fully thread-safe
         MUTEX.synchronize do
           @mutex.synchronize do
             @stopped = true

--- a/lib/karafka/connection/listener.rb
+++ b/lib/karafka/connection/listener.rb
@@ -14,6 +14,11 @@ module Karafka
       # @return [String] id of this listener
       attr_reader :id
 
+      # Mutex for things we do not want to do in parallel even in different consumer groups
+      MUTEX = Mutex.new
+
+      private_constant :MUTEX
+
       # @param consumer_group_status [Karafka::Connection::ConsumerGroupStatus]
       # @param subscription_group [Karafka::Routing::SubscriptionGroup]
       # @param jobs_queue [Karafka::Processing::JobsQueue] queue where we should push work
@@ -65,11 +70,15 @@ module Karafka
       def shutdown
         return if @stopped
 
-        @mutex.synchronize do
-          @stopped = true
-          @executors.clear
-          @coordinators.reset
-          @client.stop
+        # We want to make sure that we never close two librdkafka clients at the same time. I'm not
+        # particulary fond of it's shutdown API being fully thread-safe
+        MUTEX.synchronize do
+          @mutex.synchronize do
+            @stopped = true
+            @executors.clear
+            @coordinators.reset
+            @client.stop
+          end
         end
       end
 

--- a/lib/karafka/pro/processing/coordinator.rb
+++ b/lib/karafka/pro/processing/coordinator.rb
@@ -86,7 +86,6 @@ module Karafka
         # Runs once when a partition is revoked
         def on_revoked
           @flow_lock.synchronize do
-            return unless finished?
             return if @on_revoked_invoked
 
             @on_revoked_invoked = true

--- a/lib/karafka/pro/processing/coordinator.rb
+++ b/lib/karafka/pro/processing/coordinator.rb
@@ -20,10 +20,8 @@ module Karafka
         # @param args [Object] anything the base coordinator accepts
         def initialize(*args)
           super
-          @on_enqueued_invoked = false
-          @on_started_invoked = false
-          @on_finished_invoked = false
-          @on_revoked_invoked = false
+
+          @executed = []
           @flow_lock = Mutex.new
         end
 
@@ -34,9 +32,7 @@ module Karafka
           super
 
           @mutex.synchronize do
-            @on_enqueued_invoked = false
-            @on_started_invoked = false
-            @on_finished_invoked = false
+            @executed.clear
             @last_message = messages.last
           end
         end
@@ -50,9 +46,7 @@ module Karafka
         # enqueued
         def on_enqueued
           @flow_lock.synchronize do
-            return if @on_enqueued_invoked
-
-            @on_enqueued_invoked = true
+            return unless executable?(:on_enqueued)
 
             yield(@last_message)
           end
@@ -61,9 +55,7 @@ module Karafka
         # Runs given code only once per all the coordinated jobs upon starting first of them
         def on_started
           @flow_lock.synchronize do
-            return if @on_started_invoked
-
-            @on_started_invoked = true
+            return unless executable?(:on_started)
 
             yield(@last_message)
           end
@@ -75,23 +67,35 @@ module Karafka
         def on_finished
           @flow_lock.synchronize do
             return unless finished?
-            return if @on_finished_invoked
-
-            @on_finished_invoked = true
+            return unless executable?(:on_finished)
 
             yield(@last_message)
           end
         end
 
-        # Runs once when a partition is revoked
+        # Runs once after a partition is revoked
         def on_revoked
           @flow_lock.synchronize do
-            return if @on_revoked_invoked
-
-            @on_revoked_invoked = true
+            return unless executable?(:on_revoked)
 
             yield(@last_message)
           end
+        end
+
+        private
+
+        # Checks if given action is executable once. If it is and true is returned, this method
+        # will return false next time it is used.
+        #
+        # @param action [Symbol] what action we want to perform
+        # @return [Boolean] true if we can
+        # @note This method needs to run behind a mutex.
+        def executable?(action)
+          return false if @executed.include?(action)
+
+          @executed << action
+
+          true
         end
       end
     end

--- a/spec/integrations/pro/consumption/strategies/lrj/starved_revocation_on_rebalance_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/starved_revocation_on_rebalance_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# When running lrj, on revocation Karafka should change the revocation state even when there are
+# no available slots for processing
+
+setup_karafka do |config|
+  config.max_messages = 5
+  config.license.token = pro_license_token
+  config.concurrency = 2
+end
+
+create_topic(name: DT.topic, partitions: 2)
+
+DT[:started] = Set.new
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    until revoked?
+      sleep(0.1)
+      DT[:started] << object_id
+    end
+
+    DT[:revoked] << true
+  end
+end
+
+draw_routes do
+  consumer_group DT.consumer_group do
+    topic DT.topic do
+      consumer Consumer
+      long_running_job true
+    end
+  end
+end
+
+produce(DT.topic, '0', partition: 0)
+produce(DT.topic, '1', partition: 1)
+
+start_karafka_and_wait_until do
+  if DT[:started].size >= 2
+    if DT[:rebalanced].empty?
+      consumer = setup_rdkafka_consumer
+      consumer.subscribe(DT.topic)
+      consumer.poll(1_000)
+      consumer.close
+      DT[:rebalanced] << true
+    end
+
+    DT[:revoked].size >= 2
+  else
+    false
+  end
+end
+
+# No spec needed. If revocation would not happen as expected while all the threads are occupied,
+# This would hang forever.


### PR DESCRIPTION
This PR improves time needed for LRJ VP to switch to revoked and adds some extra concurrency security in the jobs queue.