### PR TITLE
1164 skip messages on DLQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka framework changelog
 
 ## Unreleased
+- **[Feature]** Provide ability to skip failing messages without dispatching them to an alternative topic (DLQ).
 - [Improvement] Improve the integration with Ruby on Rails by preventing double-require of components.
 - [Improvement] Improve stability of the shutdown process upon critical errors.
 - [Improvement] Improve stability of the integrations spec suite.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - [Improvement] Improve the integration with Ruby on Rails by preventing double-require of components.
 - [Improvement] Improve stability of the shutdown process upon critical errors.
 - [Improvement] Improve stability of the integrations spec suite.
-- [Fix] Fix an issue where upon fast startup of of multiple subscription groups from the same consumer group a ghost queue would be be created due to issues in `Concurrent::Hash`.
+- [Fix] Fix an issue where upon fast startup of multiple subscription groups from the same consumer group, a ghost queue would be created due to problems in `Concurrent::Hash`.
 
 ## 2.0.18 (2022-11-18)
 - **[Feature]** Support quiet mode via `TSTP` signal. When used, Karafka will finish processing current messages, run `shutdown` jobs, and switch to a quiet mode where no new work is being accepted. At the same time, it will keep the consumer group quiet, and thus no rebalance will be triggered. This can be particularly useful during deployments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Improvement] Improve the integration with Ruby on Rails by preventing double-require of components.
 - [Improvement] Improve stability of the shutdown process upon critical errors.
 - [Improvement] Improve stability of the integrations spec suite.
+- [Fix] Fix an issue where upon fast startup of of multiple subscription groups from the same consumer group a ghost queue would be be created due to issues in `Concurrent::Hash`.
 
 ## 2.0.18 (2022-11-18)
 - **[Feature]** Support quiet mode via `TSTP` signal. When used, Karafka will finish processing current messages, run `shutdown` jobs, and switch to a quiet mode where no new work is being accepted. At the same time, it will keep the consumer group quiet, and thus no rebalance will be triggered. This can be particularly useful during deployments.

--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -313,8 +313,8 @@ module Karafka
 
             @kafka.close
             @buffer.clear
-            # @note We do not clear rebalance manager here as we may still have revocation info here
-            # that we want to consider valid prior to running another reconnection
+            # @note We do not clear rebalance manager here as we may still have revocation info
+            # here that we want to consider valid prior to running another reconnection
           end
         end
       end

--- a/lib/karafka/pro/processing/strategies/aj_dlq_mom.rb
+++ b/lib/karafka/pro/processing/strategies/aj_dlq_mom.rb
@@ -46,7 +46,7 @@ module Karafka
               else
                 coordinator.pause_tracker.reset
                 skippable_message = find_skippable_message
-                dispatch_to_dlq(skippable_message)
+                dispatch_to_dlq(skippable_message) if dispatch_to_dlq?
                 # We can commit the offset here because we know that we skip it "forever" and
                 # since AJ consumer commits the offset after each job, we also know that the
                 # previous job was successful

--- a/lib/karafka/pro/processing/strategies/aj_dlq_mom.rb
+++ b/lib/karafka/pro/processing/strategies/aj_dlq_mom.rb
@@ -21,7 +21,7 @@ module Karafka
         #
         # AJ has manual offset management on by default and the offset management is delegated to
         # the AJ consumer. This means, we cannot mark as consumed always. We can only mark as
-        # consumed when we skip given job upon errors. In all the other scenarions marking as
+        # consumed when we skip given job upon errors. In all the other scenarios marking as
         # consumed needs to happen in the AJ consumer on a per job basis.
         module AjDlqMom
           include DlqMom

--- a/lib/karafka/pro/processing/strategies/dlq.rb
+++ b/lib/karafka/pro/processing/strategies/dlq.rb
@@ -42,7 +42,7 @@ module Karafka
                 # We reset the pause to indicate we will now consider it as "ok".
                 coordinator.pause_tracker.reset
                 skippable_message = find_skippable_message
-                dispatch_to_dlq(skippable_message)
+                dispatch_to_dlq(skippable_message) if dispatch_to_dlq?
                 mark_as_consumed(skippable_message)
                 pause(coordinator.seek_offset)
               end
@@ -59,7 +59,6 @@ module Karafka
 
           # Moves the broken message into a separate queue defined via the settings
           #
-          # @private
           # @param skippable_message [Array<Karafka::Messages::Message>] message we want to
           #   dispatch to DLQ
           def dispatch_to_dlq(skippable_message)
@@ -80,6 +79,13 @@ module Karafka
               caller: self,
               message: skippable_message
             )
+          end
+
+          # @return [Boolean] should we dispatch the message to DLQ or not. When the dispatch topic
+          #   is set to false, we will skip the dispatch, effectively ignoring the broken message
+          #   without taking any action.
+          def dispatch_to_dlq?
+            topic.dead_letter_queue.topic
           end
         end
       end

--- a/lib/karafka/pro/processing/strategies/dlq_lrj.rb
+++ b/lib/karafka/pro/processing/strategies/dlq_lrj.rb
@@ -43,10 +43,9 @@ module Karafka
               else
                 coordinator.pause_tracker.reset
 
-                skippable_message = find_skippable_message
-
                 unless revoked?
-                  dispatch_to_dlq(skippable_message)
+                  skippable_message = find_skippable_message
+                  dispatch_to_dlq(skippable_message) if dispatch_to_dlq?
                   mark_as_consumed(skippable_message)
                 end
 

--- a/lib/karafka/pro/processing/strategies/dlq_lrj_mom.rb
+++ b/lib/karafka/pro/processing/strategies/dlq_lrj_mom.rb
@@ -45,7 +45,7 @@ module Karafka
                 skippable_message = find_skippable_message
 
                 unless revoked?
-                  dispatch_to_dlq(skippable_message)
+                  dispatch_to_dlq(skippable_message) if dispatch_to_dlq?
                   seek(coordinator.seek_offset)
                 end
 

--- a/lib/karafka/pro/processing/strategies/dlq_mom.rb
+++ b/lib/karafka/pro/processing/strategies/dlq_mom.rb
@@ -45,8 +45,12 @@ module Karafka
               else
                 # We reset the pause to indicate we will now consider it as "ok".
                 coordinator.pause_tracker.reset
-                skippable_message = find_skippable_message
-                dispatch_to_dlq(skippable_message)
+
+                if dispatch_to_dlq?
+                  skippable_message = find_skippable_message
+                  dispatch_to_dlq(skippable_message)
+                end
+
                 pause(coordinator.seek_offset)
               end
             end

--- a/lib/karafka/processing/jobs_queue.rb
+++ b/lib/karafka/processing/jobs_queue.rb
@@ -10,6 +10,12 @@ module Karafka
     #
     # We work with the assumption, that partitions data is evenly distributed.
     class JobsQueue
+      # We need a mutex because concurrent map is not fully thread-safe
+      # https://github.com/ruby-concurrency/concurrent-ruby/issues/970
+      MUTEX = Mutex.new
+
+      private_constant :MUTEX
+
       # @return [Karafka::Processing::JobsQueue]
       def initialize
         @queue = Queue.new
@@ -20,8 +26,16 @@ module Karafka
         # scheduled by Ruby hundreds of thousands of times per group.
         # We cannot use a single semaphore as it could potentially block in listeners that should
         # process with their data and also could unlock when a given group needs to remain locked
-        @semaphores = Concurrent::Map.new { |h, k| h[k] = Queue.new }
+        @semaphores = Concurrent::Map.new do |h, k|
+          MUTEX.synchronize do
+            break h[k] if h.key?(k)
+
+            h[k] = Queue.new
+          end
+        end
+
         @in_processing = Hash.new { |h, k| h[k] = [] }
+
         @mutex = Mutex.new
       end
 

--- a/lib/karafka/routing/features/dead_letter_queue/contract.rb
+++ b/lib/karafka/routing/features/dead_letter_queue/contract.rb
@@ -29,6 +29,8 @@ module Karafka
 
             topic = dead_letter_queue[:topic]
 
+            # When topic is set to false, it means we just want to skip dispatch on DLQ
+            next if topic == false
             next if topic.is_a?(String) && Contracts::TOPIC_REGEXP.match?(topic)
 
             [[%i[dead_letter_queue topic], :format]]

--- a/lib/karafka/routing/features/dead_letter_queue/topic.rb
+++ b/lib/karafka/routing/features/dead_letter_queue/topic.rb
@@ -12,7 +12,8 @@ module Karafka
           private_constant :DEFAULT_MAX_RETRIES
 
           # @param max_retries [Integer] after how many retries should we move data to dlq
-          # @param topic [String] where the messages should be moved if failing
+          # @param topic [String, false] where the messages should be moved if failing or false
+          #   if we do not want to move it anywhere and just skip
           # @return [Config] defined config
           def dead_letter_queue(max_retries: DEFAULT_MAX_RETRIES, topic: nil)
             @dead_letter_queue ||= Config.new(

--- a/spec/integrations/pro/consumption/strategies/aj_dlq_lrj_mom/without_dispatch_to_dlq_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj_dlq_lrj_mom/without_dispatch_to_dlq_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Karafka should run the same strategy for AJ DLQ LRJ MOM as for DLQ LRJ MOM.
+#
+# Karafka should NOT dispatch the message to the DLQ topic because it's set to false.
+
+setup_active_job
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 10
+  config.license.token = pro_license_token
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+end
+
+class DlqConsumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[1] << true
+    end
+  end
+end
+
+class Job < ActiveJob::Base
+  queue_as DT.topic
+
+  def perform(value)
+    DT[0] << value
+    sleep(value.to_f / 20)
+    raise StandardError
+  end
+end
+
+Karafka.monitor.subscribe('error.occurred') do |event|
+  next unless event[:type] == 'consumer.consume.error'
+
+  DT[:errors] << 1
+end
+
+draw_routes do
+  consumer_group DT.consumer_group do
+    active_job_topic DT.topic do
+      dead_letter_queue topic: false, max_retries: 4
+      long_running_job true
+      # mom is enabled automatically
+    end
+
+    topic DT.topics[1] do
+      consumer DlqConsumer
+    end
+  end
+end
+
+5.times { |value| Job.perform_later(value) }
+
+start_karafka_and_wait_until do
+  DT[0].size >= 10
+end
+
+assert DT[0].size >= 10
+assert DT[:errors].count >= 10
+assert DT[1].empty?

--- a/spec/integrations/pro/consumption/strategies/aj_dlq_lrj_mom/without_dispatch_to_dlq_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj_dlq_lrj_mom/without_dispatch_to_dlq_spec.rb
@@ -15,7 +15,7 @@ end
 
 class DlqConsumer < Karafka::BaseConsumer
   def consume
-    messages.each do |message|
+    messages.each do
       DT[1] << true
     end
   end

--- a/spec/integrations/pro/consumption/strategies/dlq/without_dispatch_with_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/without_dispatch_with_retries_spec.rb
@@ -10,12 +10,10 @@ end
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    if messages.first.offset.zero?
-      raise StandardError
-    else
-      messages.each do |message|
-        DT[:valid] << message.offset
-      end
+    raise StandardError if messages.first.offset.zero?
+
+    messages.each do |message|
+      DT[:valid] << message.offset
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/without_dispatch_with_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/without_dispatch_with_retries_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# When using the DLQ with topic set to false, Karafka should not dispatch the message further but
+# should apply the DLQ skipping logic anyhow.
+
+setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
+  config.max_messages = 1
+  config.license.token = pro_license_token
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    if messages.first.offset.zero?
+      raise StandardError
+    else
+      messages.each do |message|
+        DT[:valid] << message.offset
+      end
+    end
+  end
+end
+
+class DlqConsumer < Karafka::BaseConsumer
+  def consume
+    DT[:dispatched] << true
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    dead_letter_queue(topic: false, max_retries: 2)
+  end
+
+  # This should never be reached
+  topic DT.topics[1] do
+    consumer DlqConsumer
+  end
+end
+
+Karafka.monitor.subscribe('error.occurred') do |event|
+  next unless event[:type] == 'consumer.consume.error'
+
+  DT[:errors] << 1
+end
+
+produce_many(DT.topic, DT.uuids(5))
+
+start_karafka_and_wait_until do
+  !DT[:valid].empty?
+end
+
+assert_equal 3, DT[:errors].size
+assert_equal [], DT[:dispatched]

--- a/spec/integrations/pro/consumption/strategies/dlq/without_dispatch_without_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/without_dispatch_without_retries_spec.rb
@@ -10,12 +10,10 @@ end
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    if messages.first.offset.zero?
-      raise StandardError
-    else
-      messages.each do |message|
-        DT[:valid] << message.offset
-      end
+    raise StandardError if messages.first.offset.zero?
+
+    messages.each do |message|
+      DT[:valid] << message.offset
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/without_dispatch_without_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/without_dispatch_without_retries_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# When using the DLQ with topic set to false, Karafka should not dispatch the message further but
+# should apply the DLQ skipping logic anyhow.
+
+setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
+  config.max_messages = 1
+  config.license.token = pro_license_token
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    if messages.first.offset.zero?
+      raise StandardError
+    else
+      messages.each do |message|
+        DT[:valid] << message.offset
+      end
+    end
+  end
+end
+
+class DlqConsumer < Karafka::BaseConsumer
+  def consume
+    DT[:dispatched] << true
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    dead_letter_queue(topic: false, max_retries: 0)
+  end
+
+  # This should never be reached
+  topic DT.topics[1] do
+    consumer DlqConsumer
+  end
+end
+
+Karafka.monitor.subscribe('error.occurred') do |event|
+  next unless event[:type] == 'consumer.consume.error'
+
+  DT[:errors] << 1
+end
+
+produce_many(DT.topic, DT.uuids(5))
+
+start_karafka_and_wait_until do
+  !DT[:valid].empty?
+end
+
+assert_equal 1, DT[:errors].size
+assert_equal [], DT[:dispatched]
+assert !DT[:valid].empty?

--- a/spec/integrations/shutdown/on_hanging_listener_and_shutdown_spec.rb
+++ b/spec/integrations/shutdown/on_hanging_listener_and_shutdown_spec.rb
@@ -22,8 +22,6 @@ draw_routes do
   end
 end
 
-occurence = 0
-
 # This will force Karafka fetcher to hang
 Karafka.monitor.subscribe('connection.listener.fetch_loop.received') do
   sleep unless DT[0].empty?

--- a/spec/integrations_helper.rb
+++ b/spec/integrations_helper.rb
@@ -164,6 +164,7 @@ def create_routes_topics
       topics_names << topic.name
 
       next unless topic.dead_letter_queue?
+      next unless topic.dead_letter_queue.topic
 
       topics_names << topic.dead_letter_queue.topic
     end
@@ -237,9 +238,9 @@ AssertionFailedError = Class.new(StandardError)
 #
 # @param expected [Object] what we expect
 # @param received [Object] what we've received
-# @param message [nil, String] message we want to pass upon failure or nil if default should be
-#   used
-def assert_equal(expected, received, message = nil)
+# @param message [String] message we want to pass upon failure. If not present, the data
+#   collector data will be printed
+def assert_equal(expected, received, message = DT)
   return if expected == received
 
   raise AssertionFailedError, message || "#{received} does not equal to #{expected}"
@@ -247,8 +248,9 @@ end
 
 # A shortcut to `assert_equal(true, value)` as often we check if something is true
 # @param received [Boolean] true or false
-# @param message [nil, String] message we want to pass upon failure
-def assert(received, message = nil)
+# @param message [String] message we want to pass upon failure. If not present, the data
+#   collector data will be printed
+def assert(received, message = DT)
   assert_equal(true, received, message)
 end
 

--- a/spec/lib/karafka/routing/features/dead_letter_queue/contract_spec.rb
+++ b/spec/lib/karafka/routing/features/dead_letter_queue/contract_spec.rb
@@ -35,6 +35,12 @@ RSpec.describe_current do
     it { expect(check).not_to be_success }
   end
 
+  context 'when topic is a false' do
+    before { config[:dead_letter_queue][:topic] = false }
+
+    it { expect(check).to be_success }
+  end
+
   context 'when max_retries is not an integer' do
     before { config[:dead_letter_queue][:max_retries] = 'invalid' }
 

--- a/spec/support/data_collector.rb
+++ b/spec/support/data_collector.rb
@@ -25,7 +25,7 @@ class DataCollector
       instance.topics
     end
 
-    # @return [ConcurrentHash] structure for aggregating data
+    # @return [Concurrent::Hash] structure for aggregating data
     def data
       instance.data
     end
@@ -79,12 +79,8 @@ class DataCollector
     @mutex = Mutex.new
     @topics = Concurrent::Array.new(100) { SecureRandom.uuid }
     @consumer_groups = @topics
-    @data = Concurrent::Hash.new do |hash, key|
-      @mutex.synchronize do
-        return hash[key] if hash.key?(key)
-
-        hash[key] = Concurrent::Array.new
-      end
+    @data = Concurrent::Map.new do |hash, key|
+      hash.compute_if_absent(key) { ::Concurrent::Array.new }
     end
   end
 


### PR DESCRIPTION
This PR:
- adds the ability not to dispatch message to DLQ with DLQ enabled. This can be used to just silently ignore messages and continue.
- Fixes remaining concurrency issues.

close https://github.com/karafka/karafka/issues/1164