### PR TITLE
Stabilize group ids

### DIFF
--- a/lib/karafka/routing/builder.rb
+++ b/lib/karafka/routing/builder.rb
@@ -40,6 +40,9 @@ module Karafka
           consumer_group.topics.each do |topic|
             Contracts::Topic.new.validate!(topic.to_h)
           end
+
+          # Initialize subscription groups after all the routing is done
+          consumer_group.subscription_groups
         end
       end
 

--- a/lib/karafka/routing/consumer_group.rb
+++ b/lib/karafka/routing/consumer_group.rb
@@ -67,7 +67,12 @@ module Karafka
       # @return [Array<Routing::SubscriptionGroup>] all the subscription groups build based on
       #   the consumer group topics
       def subscription_groups
-        @subscription_groups ||= App.config.internal.routing.subscription_groups_builder.call(topics)
+        @subscription_groups ||= App
+                                 .config
+                                 .internal
+                                 .routing
+                                 .subscription_groups_builder
+                                 .call(topics)
       end
 
       # Hashed version of consumer group that can be used for validation purposes

--- a/lib/karafka/routing/consumer_group.rb
+++ b/lib/karafka/routing/consumer_group.rb
@@ -14,7 +14,7 @@ module Karafka
       # It allows us to store the "current" subscription group defined in the routing
       # This subscription group id is then injected into topics, so we can compute the subscription
       # groups
-      attr_accessor :current_subscription_group_name
+      attr_accessor :current_subscription_group_id
 
       # @param name [String, Symbol] raw name of this consumer group. Raw means, that it does not
       #   yet have an application client_id namespace, this will be added here by default.
@@ -24,6 +24,9 @@ module Karafka
         @name = name.to_s
         @id = Karafka::App.config.consumer_mapper.call(name)
         @topics = Topics.new([])
+        # Initialize the subscription group so there's always a value for it, since even if not
+        # defined directly, a subscription group will be created
+        @current_subscription_group_id = SecureRandom.uuid
       end
 
       # @return [Boolean] true if this consumer group should be active in our current process
@@ -41,7 +44,7 @@ module Karafka
         built_topic = @topics.last
         # We overwrite it conditionally in case it was not set by the user inline in the topic
         # block definition
-        built_topic.subscription_group ||= current_subscription_group_name
+        built_topic.subscription_group ||= current_subscription_group_id
         built_topic
       end
 
@@ -52,19 +55,19 @@ module Karafka
       def subscription_group=(name, &block)
         # We cast it here, so the routing supports symbol based but that's anyhow later on
         # validated as a string
-        self.current_subscription_group_name = name
+        @current_subscription_group_id = name
 
         Proxy.new(self, &block)
 
         # We need to reset the current subscription group after it is used, so it won't leak
         # outside to other topics that would be defined without a defined subscription group
-        self.current_subscription_group_name = nil
+        @current_subscription_group_id = SecureRandom.uuid
       end
 
       # @return [Array<Routing::SubscriptionGroup>] all the subscription groups build based on
       #   the consumer group topics
       def subscription_groups
-        App.config.internal.routing.subscription_groups_builder.call(topics)
+        @subscription_groups ||= App.config.internal.routing.subscription_groups_builder.call(topics)
       end
 
       # Hashed version of consumer group that can be used for validation purposes

--- a/lib/karafka/routing/subscription_group.rb
+++ b/lib/karafka/routing/subscription_group.rb
@@ -53,10 +53,7 @@ module Karafka
         # increments.
         group_instance_id = kafka.fetch(:'group.instance.id', false)
 
-        if group_instance_id
-          kafka[:'group.instance.id'] = "#{group_instance_id}_#{@position}"
-        end
-
+        kafka[:'group.instance.id'] = "#{group_instance_id}_#{@position}" if group_instance_id
         kafka[:'client.id'] ||= Karafka::App.config.client_id
         kafka[:'group.id'] ||= @topics.first.consumer_group.id
         kafka[:'auto.offset.reset'] ||= @topics.first.initial_offset

--- a/lib/karafka/routing/subscription_groups_builder.rb
+++ b/lib/karafka/routing/subscription_groups_builder.rb
@@ -24,6 +24,10 @@ module Karafka
 
       private_constant :DISTRIBUTION_KEYS
 
+      def initialize
+        @position = -1
+      end
+
       # @param topics [Karafka::Routing::Topics] all the topics based on which we want to build
       #   subscription groups
       # @return [Array<SubscriptionGroup>] all subscription groups we need in separate threads
@@ -34,7 +38,7 @@ module Karafka
           .values
           .map { |value| value.map(&:last) }
           .map { |topics_array| Routing::Topics.new(topics_array) }
-          .map { |grouped_topics| SubscriptionGroup.new(grouped_topics) }
+          .map { |grouped_topics| SubscriptionGroup.new(@position += 1, grouped_topics) }
       end
 
       private

--- a/spec/integrations/routing/routing_with_subscription_groups_arg_based_spec.rb
+++ b/spec/integrations/routing/routing_with_subscription_groups_arg_based_spec.rb
@@ -30,5 +30,5 @@ assert_equal 'topic1', Karafka::App.consumer_groups.first.topics.first.name
 assert_equal 'topic2', Karafka::App.consumer_groups.first.topics[1].name
 assert_equal 'topic3', Karafka::App.consumer_groups.first.topics[2].name
 assert_equal 'group1', subscription_groups.first.topics.first.subscription_group
-assert_equal nil, subscription_groups[1].topics.first.subscription_group
+assert !subscription_groups[1].topics.first.subscription_group.nil?
 assert_equal 'group2', subscription_groups[2].topics.first.subscription_group

--- a/spec/integrations/routing/routing_with_subscription_groups_block_based_spec.rb
+++ b/spec/integrations/routing/routing_with_subscription_groups_block_based_spec.rb
@@ -32,5 +32,5 @@ assert_equal 'topic1', Karafka::App.consumer_groups.first.topics.first.name
 assert_equal 'topic2', Karafka::App.consumer_groups.first.topics[1].name
 assert_equal 'topic3', Karafka::App.consumer_groups.first.topics[2].name
 assert_equal 'group1', subscription_groups.first.topics.first.subscription_group
-assert_equal nil, subscription_groups[1].topics.first.subscription_group
+assert !subscription_groups[1].topics.first.subscription_group.nil?
 assert_equal 'group2', subscription_groups[2].topics.first.subscription_group

--- a/spec/integrations/routing/routing_with_subscription_groups_chaotic_order_spec.rb
+++ b/spec/integrations/routing/routing_with_subscription_groups_chaotic_order_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Karafka should support chaotic order group definitions and should correctly assign the
+# subscription groups
+
+setup_karafka
+
+draw_routes(create_topics: false) do
+  topic 'topic0' do
+    consumer Class.new
+  end
+
+  subscription_group 'group1' do
+    topic 'topic1' do
+      consumer Class.new
+    end
+  end
+
+  consumer_group 'test' do
+    topic 'topic1' do
+      consumer Class.new
+    end
+  end
+
+  topic 'topic2' do
+    consumer Class.new
+  end
+end
+
+subscription_groups = Karafka::App.subscription_groups
+
+assert_equal 3, subscription_groups.values.first.count
+assert_equal 1, subscription_groups.values.last.count

--- a/spec/integrations/routing/stable_with_subscription_groups.rb
+++ b/spec/integrations/routing/stable_with_subscription_groups.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Building subscription groups multiple times should not change their static group membership ids
+# as long as topics structure is unchanged.
+
+UUID = 'TEST'
+
+setup_karafka do |config|
+  config.kafka[:'group.instance.id'] = UUID
+end
+
+draw_routes do
+  subscription_group do
+    topic 'topic1' do
+      consumer Class.new
+    end
+  end
+
+  topic 'topic2' do
+    consumer Class.new
+  end
+
+  consumer_group :test do
+    topic 'topic2' do
+      consumer Class.new
+    end
+  end
+end
+
+g00 = Karafka::App.subscription_groups.values[0][0].kafka[:'group.instance.id']
+g01 = Karafka::App.subscription_groups.values[0][1].kafka[:'group.instance.id']
+g10 = Karafka::App.subscription_groups.values[1][0].kafka[:'group.instance.id']
+
+assert [g00, g01, g10].uniq.count == 3
+assert_equal g00, "#{UUID}_0"
+assert_equal g01, "#{UUID}_1"
+assert_equal g10, "#{UUID}_2"

--- a/spec/lib/karafka/routing/builder_spec.rb
+++ b/spec/lib/karafka/routing/builder_spec.rb
@@ -42,10 +42,10 @@ RSpec.describe_current do
       it { expect(topic1.id).to eq "#{Karafka::App.config.client_id}_app_topic_name1" }
       it { expect(topic2.id).to eq "#{Karafka::App.config.client_id}_app_topic_name2" }
       it { expect(builder.size).to eq 1 }
-      it { expect(topic1.subscription_group).to eq nil }
+      it { expect(topic1.subscription_group).not_to eq(nil) }
       it { expect(topic1.name).to eq 'topic_name1' }
       it { expect(topic2.name).to eq 'topic_name2' }
-      it { expect(topic2.subscription_group).to eq nil }
+      it { expect(topic2.subscription_group).not_to eq(nil) }
       it { expect(builder.first.id).to eq "#{Karafka::App.config.client_id}_app" }
     end
 
@@ -141,7 +141,7 @@ RSpec.describe_current do
       before { draw }
 
       it { expect(topic1.subscription_group).to eq 'test1' }
-      it { expect(topic2.subscription_group).to eq nil }
+      it { expect(topic2.subscription_group).not_to eq(nil) }
     end
 
     context 'when we use 0.6 simple topic style single topic groups' do
@@ -176,9 +176,9 @@ RSpec.describe_current do
       end
 
       it { expect(topic1.id).to eq "#{Karafka::App.config.client_id}_group_name1_topic_name1" }
-      it { expect(topic1.subscription_group).to eq nil }
+      it { expect(topic1.subscription_group).not_to eq(nil) }
       it { expect(topic2.id).to eq "#{Karafka::App.config.client_id}_group_name2_topic_name2" }
-      it { expect(topic2.subscription_group).to eq nil }
+      it { expect(topic2.subscription_group).not_to eq(nil) }
       it { expect(builder.size).to eq 2 }
     end
 

--- a/spec/lib/karafka/routing/subscription_group_spec.rb
+++ b/spec/lib/karafka/routing/subscription_group_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe_current do
-  subject(:group) { described_class.new([topic]) }
+  subject(:group) { described_class.new(0, [topic]) }
 
   let(:topic) { build(:routing_topic, kafka: { 'bootstrap.servers': 'kafka://kafka:9092' }) }
 
   describe '#id' do
-    it { expect(group.id).not_to eq(nil) }
+    it { expect(group.id).to eq(topic.subscription_group) }
   end
 
   describe '#max_messages' do

--- a/spec/lib/karafka/routing/subscription_groups_builder_spec.rb
+++ b/spec/lib/karafka/routing/subscription_groups_builder_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe_current do
     it { expect(groups.size).to eq(1) }
   end
 
-  context 'when there are more topics with the same setings' do
-    let(:consumer_group_topics) { Array.new(3) { build(:routing_topic) } }
+  context 'when there are more topics with the same settings' do
+    let(:consumer_group_topics) { Array.new(3) { build(:routing_topic, subscription_group: '1') } }
 
     it { expect(groups.size).to eq(1) }
   end

--- a/spec/support/factories/routing/subscription_group.rb
+++ b/spec/support/factories/routing/subscription_group.rb
@@ -2,12 +2,13 @@
 
 FactoryBot.define do
   factory :routing_subscription_group, class: 'Karafka::Routing::SubscriptionGroup' do
+    sequence(:position)
     topics { Karafka::Routing::Topics.new([build(:routing_topic)]) }
 
     skip_create
 
     initialize_with do
-      new(topics)
+      new(position, topics)
     end
   end
 end

--- a/spec/support/factories/routing/topic.rb
+++ b/spec/support/factories/routing/topic.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     kafka { {} }
     max_messages { 1000 }
     max_wait_time { 10_000 }
+    subscription_group { SecureRandom.uuid }
 
     skip_create
 
@@ -16,6 +17,7 @@ FactoryBot.define do
 
       instance.tap do |topic|
         topic.consumer = consumer
+        topic.subscription_group = subscription_group
       end
     end
   end


### PR DESCRIPTION
This PR makes the groups ids stable, that is consecutive usage of subscription groups should not increment the counter.