### PR TITLE
illustrate lrj saturation

### DIFF
--- a/spec/integrations/pro/consumption/strategies/lrj/saturated_before_revocation_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/saturated_before_revocation_spec.rb
@@ -27,7 +27,7 @@ class Consumer < Karafka::BaseConsumer
 
     sleep(1) while DT[:done].empty?
 
-    sleep(10)
+    sleep(15)
   end
 end
 

--- a/spec/integrations/pro/consumption/strategies/lrj/saturated_before_revocation_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/saturated_before_revocation_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# When we have a LRJ job and revocation happens, non revocation aware LRJ may cause time poll
+# interval exceeding because revocation jobs are blocking.
+
+setup_karafka(allow_errors: %w[connection.client.poll.error]) do |config|
+  config.concurrency = 2
+  config.max_messages = 1
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+  config.license.token = pro_license_token
+end
+
+events = []
+
+Karafka::App.monitor.subscribe('error.occurred') do |event|
+  next unless event[:type] == 'connection.client.poll.error'
+
+  events << event
+end
+
+create_topic(partitions: 2)
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[:any] << object_id
+
+    sleep(1) while DT[:done].empty?
+
+    sleep(10)
+  end
+end
+
+draw_routes do
+  consumer_group DT.consumer_group do
+    topic DT.topic do
+      consumer Consumer
+      long_running_job true
+      manual_offset_management true
+    end
+  end
+end
+
+produce(DT.topic, '1', partition: 0)
+produce(DT.topic, '1', partition: 1)
+
+start_karafka_and_wait_until do
+  sleep(0.1) while DT[:any].uniq.size < 2
+
+  consumer = setup_rdkafka_consumer
+  consumer.subscribe(DT.topics[0])
+  consumer.each { break }
+  consumer.close
+
+  DT[:done] << true
+
+  sleep(15)
+
+  true
+end
+
+assert events.first[:error].message.include?('Maximum application poll interval'), events


### PR DESCRIPTION
This spec illustrates a case where full job queue can get extra work due to revocation and LRJ revocation jobs are blocking.

this may be changed with this: https://github.com/karafka/karafka/issues/1177 though for now its good to cover this case.