### PR TITLE
prevent lrj saturation on revocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka framework changelog
 
+## Unreleased
+- [Improvement] Make revocation jobs for LRJ topics non-blocking to prevent blocking polling when someone uses non-revocation aware LRJ jobs and revocation happens.
+
 ## 2.0.20 (2022-11-24)
 - [Improvement] Support `group.instance.id` assignment (static group membership) for a case where a single consumer group has multiple subscription groups (#1173).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Karafka framework changelog
 
-## Unreleased
+## 2.0.20 (2022-11-24)
 - [Improvement] Support `group.instance.id` assignment (static group membership) for a case where a single consumer group has multiple subscription groups (#1173).
 
 ## 2.0.19 (2022-11-20)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka (2.0.19)
+    karafka (2.0.20)
       karafka-core (>= 2.0.4, < 3.0.0)
       rdkafka (>= 0.12)
       thor (>= 0.20)

--- a/lib/karafka/pro/processing/jobs/revoked_non_blocking.rb
+++ b/lib/karafka/pro/processing/jobs/revoked_non_blocking.rb
@@ -17,17 +17,15 @@ module Karafka
     module Processing
       # Pro jobs
       module Jobs
-        # The main job type in a non-blocking variant.
-        # This variant works "like" the regular consumption but does not block the queue.
+        # The revoked job type in a non-blocking variant.
+        # This variant works "like" the regular revoked but does not block the queue.
         #
         # It can be useful when having long lasting jobs that would exceed `max.poll.interval`
-        # if would block.
-        #
-        # @note It needs to be working with a proper consumer that will handle the partition
-        #   management. This layer of the framework knows nothing about Kafka messages consumption.
-        class ConsumeNonBlocking < ::Karafka::Processing::Jobs::Consume
+        # in scenarios where there are more jobs than threads, without this being async we
+        # would potentially stop polling
+        class RevokedNonBlocking < ::Karafka::Processing::Jobs::Revoked
           # Makes this job non-blocking from the start
-          # @param args [Array] any arguments accepted by `::Karafka::Processing::Jobs::Consume`
+          # @param args [Array] any arguments accepted by `::Karafka::Processing::Jobs::Revoked`
           def initialize(*args)
             super
             @non_blocking = true

--- a/lib/karafka/pro/processing/jobs_builder.rb
+++ b/lib/karafka/pro/processing/jobs_builder.rb
@@ -28,6 +28,18 @@ module Karafka
             super
           end
         end
+
+        # @param executor [Karafka::Processing::Executor]
+        # @return [Karafka::Processing::Jobs::Revoked] revocation job for non LRJ
+        # @return [Karafka::Processing::Jobs::RevokedNonBlocking] revocation job that is
+        #   non-blocking, so when revocation job is scheduled for LRJ it also will not block
+        def revoked(executor)
+          if executor.topic.long_running_job?
+            Jobs::RevokedNonBlocking.new(executor)
+          else
+            super
+          end
+        end
       end
     end
   end

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '2.0.19'
+  VERSION = '2.0.20'
 end

--- a/spec/integrations/pro/consumption/strategies/lrj/saturated_before_revocation_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/saturated_before_revocation_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# When we have a LRJ job and revocation happens, non revocation aware LRJ may cause time poll
-# interval exceeding because revocation jobs are blocking.
+# When we have a LRJ job and revocation happens, non revocation aware LRJ should not cause a
+# timeout because the revocation job is also non-blocking.
 
 setup_karafka(allow_errors: %w[connection.client.poll.error]) do |config|
   config.concurrency = 2
@@ -59,4 +59,4 @@ start_karafka_and_wait_until do
   true
 end
 
-assert events.first[:error].message.include?('Maximum application poll interval'), events
+assert events.empty?, events

--- a/spec/lib/karafka/pro/processing/jobs/revoked_non_blocking_spec.rb
+++ b/spec/lib/karafka/pro/processing/jobs/revoked_non_blocking_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:job) { described_class.new(executor) }
+
+  let(:executor) { build(:processing_executor) }
+
+  it { expect(job.non_blocking?).to eq(true) }
+  it { expect(described_class).to be < ::Karafka::Processing::Jobs::Revoked }
+end

--- a/spec/lib/karafka/pro/processing/jobs_builder_spec.rb
+++ b/spec/lib/karafka/pro/processing/jobs_builder_spec.rb
@@ -25,9 +25,20 @@ RSpec.describe_current do
   end
 
   describe '#revoked' do
-    it do
-      job = builder.revoked(executor)
-      expect(job).to be_a(Karafka::Processing::Jobs::Revoked)
+    context 'when it is a lrj topic' do
+      before { executor.topic.long_running_job true }
+
+      it 'expect to use the non blocking pro revocation job' do
+        job = builder.revoked(executor)
+        expect(job).to be_a(Karafka::Pro::Processing::Jobs::RevokedNonBlocking)
+      end
+    end
+
+    context 'when it is not a lrj topic' do
+      it do
+        job = builder.revoked(executor)
+        expect(job).to be_a(Karafka::Processing::Jobs::Revoked)
+      end
     end
   end
 


### PR DESCRIPTION
close https://github.com/karafka/karafka/issues/1177

blocked by https://github.com/karafka/karafka/pull/1178

will have to update the https://github.com/karafka/karafka/pull/1178 spec once merged and rebased.
