### PR TITLE
Load early pro components into memory for visibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,5 +124,8 @@ jobs:
       - name: Run integration tests
         env:
           KARAFKA_PRO_LICENSE_TOKEN: ${{ secrets.KARAFKA_PRO_LICENSE_TOKEN }}
+          KARAFKA_PRO_USERNAME: ${{ secrets.KARAFKA_PRO_USERNAME }}
+          KARAFKA_PRO_PASSWORD: ${{ secrets.KARAFKA_PRO_PASSWORD }}
+          KARAFKA_PRO_VERSION: ${{ secrets.KARAFKA_PRO_VERSION }}
           GITHUB_COVERAGE: ${{matrix.coverage}}
         run: bin/integrations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka framework changelog
 
+## Unreleased
+- [Improvement] Load Pro components upon Karafka require so they can be altered prior to setup.
+
 ## 20.0.21 (2022-11-25)
 - [Improvement] Make revocation jobs for LRJ topics non-blocking to prevent blocking polling when someone uses non-revocation aware LRJ jobs and revocation happens.
 

--- a/bin/rspecs
+++ b/bin/rspecs
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
+set -e
+
 SPECS_TYPE=regular bundle exec rspec --tag ~type:pro
 SPECS_TYPE=pro bundle exec rspec --tag type:pro

--- a/lib/karafka.rb
+++ b/lib/karafka.rb
@@ -100,5 +100,14 @@ loader.eager_load
 # nor included here
 ::Karafka::Routing::Features::Base.load_all
 
+# We need to detect and require (not setup) Pro components during the gem load, because we need
+# to make pro components available in case anyone wants to use them as a base to their own
+# custom components. Otherwise inheritance would not work.
+Karafka::Licenser.detect do
+  require 'karafka/pro/loader'
+
+  Karafka::Pro::Loader.require_all
+end
+
 # Load railtie after everything else is ready so we know we can rely on it.
 require 'karafka/railtie'

--- a/lib/karafka/licenser.rb
+++ b/lib/karafka/licenser.rb
@@ -11,7 +11,8 @@ module Karafka
     class << self
       # Tries to load the license and yields if successful
       def detect
-        require('karafka-license')
+        # If required, do not require again
+        require('karafka-license') unless const_defined?('::Karafka::License')
 
         yield
 

--- a/lib/karafka/licenser.rb
+++ b/lib/karafka/licenser.rb
@@ -8,68 +8,70 @@ module Karafka
 
     private_constant :PUBLIC_KEY_LOCATION
 
-    # Tries to prepare license and verifies it
-    #
-    # @param license_config [Karafka::Core::Configurable::Node] config related to the licensing
-    def prepare_and_verify(license_config)
-      prepare(license_config)
-      verify(license_config)
-    end
+    class << self
+      # Tries to load the license and yields if successful
+      def detect
+        require('karafka-license')
 
-    private
+        yield
 
-    # @param license_config [Karafka::Core::Configurable::Node] config related to the licensing
-    def prepare(license_config)
-      # If there is token, no action needed
-      # We support a case where someone would put the token in instead of using one from the
-      # license. That's in case there are limitations to using external package sources, etc
-      return if license_config.token
-
-      begin
-        license_config.token || require('karafka-license')
+        true
       rescue LoadError
-        return
+        false
       end
 
-      license_config.token = Karafka::License.token
-    end
+      # Tries to prepare license and verifies it
+      #
+      # @param license_config [Karafka::Core::Configurable::Node] config related to the licensing
+      def prepare_and_verify(license_config)
+        # If license is not loaded, nothing to do
+        return unless const_defined?('::Karafka::License')
 
-    # Check license and setup license details (if needed)
-    # @param license_config [Karafka::Core::Configurable::Node] config related to the licensing
-    def verify(license_config)
-      # If no license, it will just run LGPL components without anything extra
-      return unless license_config.token
-
-      public_key = OpenSSL::PKey::RSA.new(File.read(PUBLIC_KEY_LOCATION))
-
-      # We gsub and strip in case someone copy-pasted it as a multi line string
-      formatted_token = license_config.token.strip.delete("\n").delete(' ')
-      decoded_token = Base64.decode64(formatted_token)
-
-      begin
-        data = public_key.public_decrypt(decoded_token)
-      rescue OpenSSL::OpenSSLError
-        data = nil
+        prepare(license_config)
+        verify(license_config)
       end
 
-      details = data ? JSON.parse(data) : raise_invalid_license_token(license_config)
+      private
 
-      license_config.entity = details.fetch('entity')
-    end
+      # @param license_config [Karafka::Core::Configurable::Node] config related to the licensing
+      def prepare(license_config)
+        license_config.token = Karafka::License.token
+      end
 
-    # Raises an error with info, that used token is invalid
-    # @param license_config [Karafka::Core::Configurable::Node]
-    def raise_invalid_license_token(license_config)
-      # We set it to false so `Karafka.pro?` method behaves as expected
-      license_config.token = false
+      # Check license and setup license details (if needed)
+      # @param license_config [Karafka::Core::Configurable::Node] config related to the licensing
+      def verify(license_config)
+        public_key = OpenSSL::PKey::RSA.new(File.read(PUBLIC_KEY_LOCATION))
 
-      raise(
-        Errors::InvalidLicenseTokenError,
-        <<~MSG.tr("\n", ' ')
-          License key you provided is invalid.
-          Please reach us at contact@karafka.io or visit https://karafka.io to obtain a valid one.
-        MSG
-      )
+        # We gsub and strip in case someone copy-pasted it as a multi line string
+        formatted_token = license_config.token.strip.delete("\n").delete(' ')
+        decoded_token = Base64.decode64(formatted_token)
+
+        begin
+          data = public_key.public_decrypt(decoded_token)
+        rescue OpenSSL::OpenSSLError
+          data = nil
+        end
+
+        details = data ? JSON.parse(data) : raise_invalid_license_token(license_config)
+
+        license_config.entity = details.fetch('entity')
+      end
+
+      # Raises an error with info, that used token is invalid
+      # @param license_config [Karafka::Core::Configurable::Node]
+      def raise_invalid_license_token(license_config)
+        # We set it to false so `Karafka.pro?` method behaves as expected
+        license_config.token = false
+
+        raise(
+          Errors::InvalidLicenseTokenError,
+          <<~MSG.tr("\n", ' ')
+            License key you provided is invalid.
+            Please reach us at contact@karafka.io or visit https://karafka.io to obtain a valid one.
+          MSG
+        )
+      end
     end
   end
 end

--- a/lib/karafka/pro/loader.rb
+++ b/lib/karafka/pro/loader.rb
@@ -45,8 +45,6 @@ module Karafka
         # @param config [Karafka::Core::Configurable::Node] app config that we can alter with pro
         #   components
         def setup(config)
-          require_all
-
           reconfigure(config)
 
           load_topic_features

--- a/spec/integrations/pro/consumption/from_earliest_spec.rb
+++ b/spec/integrations/pro/consumption/from_earliest_spec.rb
@@ -3,9 +3,7 @@
 # Karafka should be able to easily consume all the messages from earliest (default) exactly
 # the same way with pro as it does without
 
-setup_karafka do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/pro/consumption/strategies/aj_dlq_lrj_mom/with_non_recoverable_slow_jobs_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj_dlq_lrj_mom/with_non_recoverable_slow_jobs_error_spec.rb
@@ -19,7 +19,6 @@ Karafka.monitor.subscribe(Listener.new)
 
 setup_karafka(allow_errors: true) do |config|
   config.max_messages = 10
-  config.license.token = pro_license_token
   config.kafka[:'max.poll.interval.ms'] = 10_000
   config.kafka[:'session.timeout.ms'] = 10_000
 end

--- a/spec/integrations/pro/consumption/strategies/aj_dlq_lrj_mom/without_dispatch_to_dlq_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj_dlq_lrj_mom/without_dispatch_to_dlq_spec.rb
@@ -8,7 +8,6 @@ setup_active_job
 
 setup_karafka(allow_errors: true) do |config|
   config.max_messages = 10
-  config.license.token = pro_license_token
   config.kafka[:'max.poll.interval.ms'] = 10_000
   config.kafka[:'session.timeout.ms'] = 10_000
 end

--- a/spec/integrations/pro/consumption/strategies/aj_dlq_mom/with_non_recoverable_job_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj_dlq_mom/with_non_recoverable_job_error_spec.rb
@@ -19,7 +19,6 @@ Karafka.monitor.subscribe(Listener.new)
 
 setup_karafka(allow_errors: true) do |config|
   config.max_messages = 10
-  config.license.token = pro_license_token
   config.kafka[:'max.poll.interval.ms'] = 10_000
   config.kafka[:'session.timeout.ms'] = 10_000
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/details_dispatch_transfer_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/details_dispatch_transfer_spec.rb
@@ -4,7 +4,6 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.max_messages = 1
-  config.license.token = pro_license_token
 end
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/pro/consumption/strategies/dlq/dispatch_instrumentation_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/dispatch_instrumentation_spec.rb
@@ -2,9 +2,7 @@
 
 # When DLQ delegation happens, Karafka should emit appropriate event.
 
-setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka(allow_errors: %w[consumer.consume.error])
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/pro/consumption/strategies/dlq/manual_dispatch_to_dlq_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/manual_dispatch_to_dlq_spec.rb
@@ -6,9 +6,7 @@
 # We can use this API to manually move stuff to DLQ without raising any errors upon detecting a
 # corrupted message.
 
-setup_karafka do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/pro/consumption/strategies/dlq/multi_partition_source_target_flow_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/multi_partition_source_target_flow_spec.rb
@@ -3,9 +3,7 @@
 # When handling failing messages from a many partitions and there are many errors, DLQ will provide
 # strong ordering warranties inside DLQ.
 
-setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka(allow_errors: %w[consumer.consume.error])
 
 create_topic(name: DT.topics[0], partitions: 10)
 create_topic(name: DT.topics[1], partitions: 10)

--- a/spec/integrations/pro/consumption/strategies/dlq/multi_partition_target_flow_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/multi_partition_target_flow_spec.rb
@@ -3,9 +3,7 @@
 # When handling failing messages from a single partition and there are many errors, enhanced DLQ
 # will provide strong ordering warranties inside DLQ.
 
-setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka(allow_errors: %w[consumer.consume.error])
 
 create_topic(name: DT.topics[1], partitions: 10)
 

--- a/spec/integrations/pro/consumption/strategies/dlq/original_offset_tracking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/original_offset_tracking_spec.rb
@@ -2,9 +2,7 @@
 
 # When we move messages to the DLQ, their offset should be preserved in headers
 
-setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka(allow_errors: %w[consumer.consume.error])
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/pro/consumption/strategies/dlq/with_error_handling_pipeline_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/with_error_handling_pipeline_spec.rb
@@ -2,9 +2,7 @@
 
 # We should be able to use DLQ in a pipeline where we handle each stage separately.
 
-setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka(allow_errors: %w[consumer.consume.error])
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/pro/consumption/strategies/dlq/with_non_recoverable_error_with_one_retry_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/with_non_recoverable_error_with_one_retry_spec.rb
@@ -3,9 +3,7 @@
 # When dead letter queue is used and we encounter non-recoverable message, we should skip it after
 # one retry and move the broken message to a separate topic
 
-setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka(allow_errors: %w[consumer.consume.error])
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/pro/consumption/strategies/dlq/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/with_non_recoverable_error_with_retries_spec.rb
@@ -3,9 +3,7 @@
 # When dead letter queue is used and we encounter non-recoverable message, we should skip it after
 # retries and move the broken message to a separate topic
 
-setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka(allow_errors: %w[consumer.consume.error])
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/pro/consumption/strategies/dlq/with_non_recoverable_error_without_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/with_non_recoverable_error_without_retries_spec.rb
@@ -3,9 +3,7 @@
 # When dead letter queue is used and we encounter non-recoverable message and we don't want to do
 # any retries, we should skip without retrying of processing.
 
-setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka(allow_errors: %w[consumer.consume.error])
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/pro/consumption/strategies/dlq/with_non_recoverable_first_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/with_non_recoverable_first_message_spec.rb
@@ -3,9 +3,7 @@
 # When dead letter queue is used and we first message out of all is broken, things should behave
 # like for any other broken message
 
-setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka(allow_errors: %w[consumer.consume.error])
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/pro/consumption/strategies/dlq/with_non_recoverable_last_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/with_non_recoverable_last_message_spec.rb
@@ -3,9 +3,7 @@
 # When dead letter queue is used and we last message out of all is broken, things should behave
 # like for any other broken message and we should pick up when more messages are present
 
-setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka(allow_errors: %w[consumer.consume.error])
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/pro/consumption/strategies/dlq/with_recoverable_error_on_retry_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/with_recoverable_error_on_retry_spec.rb
@@ -3,9 +3,7 @@
 # When dead letter queue is used and we encounter recoverable message, we should not skip and not
 # move it to the dead letter topic. Just retry.
 
-setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka(allow_errors: %w[consumer.consume.error])
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/pro/consumption/strategies/dlq/without_any_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/without_any_errors_spec.rb
@@ -2,9 +2,7 @@
 
 # When dead letter queue is used and we don't encounter any errors, all should be regular.
 
-setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka(allow_errors: %w[consumer.consume.error])
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/pro/consumption/strategies/dlq/without_dispatch_with_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/without_dispatch_with_retries_spec.rb
@@ -5,7 +5,6 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.max_messages = 1
-  config.license.token = pro_license_token
 end
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/pro/consumption/strategies/dlq/without_dispatch_without_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/without_dispatch_without_retries_spec.rb
@@ -5,7 +5,6 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.max_messages = 1
-  config.license.token = pro_license_token
 end
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/pro/consumption/strategies/dlq/without_intermediate_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/without_intermediate_marking_spec.rb
@@ -6,7 +6,6 @@
 # This should allow us to move one by one slowly and should mark on successful batches.
 
 setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
-  config.license.token = pro_license_token
   config.max_messages = 9
 end
 

--- a/spec/integrations/pro/consumption/strategies/dlq_lrj/fast_with_non_recoverable_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_lrj/fast_with_non_recoverable_errors_spec.rb
@@ -7,7 +7,6 @@ setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   # We set it here that way not too wait too long on stuff
   config.kafka[:'max.poll.interval.ms'] = 10_000
   config.kafka[:'session.timeout.ms'] = 10_000
-  config.license.token = pro_license_token
 end
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/pro/consumption/strategies/dlq_lrj/with_non_recoverable_slow_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_lrj/with_non_recoverable_slow_error_spec.rb
@@ -12,7 +12,6 @@ end
 Karafka.monitor.subscribe(Listener.new)
 
 setup_karafka(allow_errors: true) do |config|
-  config.license.token = pro_license_token
   config.kafka[:'max.poll.interval.ms'] = 10_000
   config.kafka[:'session.timeout.ms'] = 10_000
 end

--- a/spec/integrations/pro/consumption/strategies/dlq_lrj_mom/with_non_recoverable_slow_no_marking_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_lrj_mom/with_non_recoverable_slow_no_marking_error_spec.rb
@@ -14,7 +14,6 @@ Karafka.monitor.subscribe(Listener.new)
 
 setup_karafka(allow_errors: true) do |config|
   config.max_messages = 10
-  config.license.token = pro_license_token
   config.kafka[:'max.poll.interval.ms'] = 10_000
   config.kafka[:'session.timeout.ms'] = 10_000
 end

--- a/spec/integrations/pro/consumption/strategies/dlq_mom/multi_partition_source_target_flow_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_mom/multi_partition_source_target_flow_spec.rb
@@ -2,9 +2,7 @@
 
 # Same as pure DLQ version until rebalance
 
-setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka(allow_errors: %w[consumer.consume.error])
 
 create_topic(name: DT.topics[0], partitions: 10)
 create_topic(name: DT.topics[1], partitions: 10)

--- a/spec/integrations/pro/consumption/strategies/dlq_mom/multi_partition_target_flow_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_mom/multi_partition_target_flow_spec.rb
@@ -3,9 +3,7 @@
 # Same as pure DLQ version until rebalance
 # Needs to go to same partition
 
-setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka(allow_errors: %w[consumer.consume.error])
 
 create_topic(name: DT.topics[1], partitions: 10)
 

--- a/spec/integrations/pro/consumption/strategies/dlq_mom/with_error_handling_pipeline_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_mom/with_error_handling_pipeline_spec.rb
@@ -2,9 +2,7 @@
 
 # Same as pure DLQ version until rebalance
 
-setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka(allow_errors: %w[consumer.consume.error])
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/pro/consumption/strategies/dlq_mom/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_mom/with_non_recoverable_error_with_retries_spec.rb
@@ -2,9 +2,7 @@
 
 # Same as pure DLQ version until rebalance
 
-setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka(allow_errors: %w[consumer.consume.error])
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/pro/consumption/strategies/dlq_mom/with_non_recoverable_error_without_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_mom/with_non_recoverable_error_without_retries_spec.rb
@@ -2,9 +2,7 @@
 
 # Same as pure DLQ version until rebalance
 
-setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka(allow_errors: %w[consumer.consume.error])
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/pro/consumption/strategies/dlq_mom/with_non_recoverable_first_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_mom/with_non_recoverable_first_message_spec.rb
@@ -2,9 +2,7 @@
 
 # Same as pure DLQ version until rebalance
 
-setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka(allow_errors: %w[consumer.consume.error])
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/pro/consumption/strategies/dlq_mom/with_non_recoverable_last_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_mom/with_non_recoverable_last_message_spec.rb
@@ -2,9 +2,7 @@
 
 # Same as pure DLQ version until rebalance
 
-setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka(allow_errors: %w[consumer.consume.error])
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/pro/consumption/strategies/dlq_mom/with_recoverable_error_on_retry_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_mom/with_recoverable_error_on_retry_spec.rb
@@ -2,9 +2,7 @@
 
 # Same as pure DLQ version until rebalance
 
-setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka(allow_errors: %w[consumer.consume.error])
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/pro/consumption/strategies/dlq_mom/without_any_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_mom/without_any_errors_spec.rb
@@ -2,9 +2,7 @@
 
 # Same as pure DLQ version until rebalance
 
-setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka(allow_errors: %w[consumer.consume.error])
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/pro/consumption/strategies/dlq_mom/without_intermediate_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_mom/without_intermediate_marking_spec.rb
@@ -5,7 +5,6 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.max_messages = 6
-  config.license.token = pro_license_token
 end
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/pro/consumption/strategies/lrj/attempts_tracking_with_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/attempts_tracking_with_errors_spec.rb
@@ -4,7 +4,6 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.max_messages = 20
-  config.license.token = pro_license_token
 end
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/pro/consumption/strategies/lrj/attempts_tracking_with_non_recoverable_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/attempts_tracking_with_non_recoverable_errors_spec.rb
@@ -4,7 +4,6 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.max_messages = 20
-  config.license.token = pro_license_token
 end
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/pro/consumption/strategies/lrj/attempts_tracking_without_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/attempts_tracking_without_errors_spec.rb
@@ -4,7 +4,6 @@
 
 setup_karafka do |config|
   config.max_messages = 20
-  config.license.token = pro_license_token
 end
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/pro/consumption/strategies/lrj/fast_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/fast_spec.rb
@@ -7,7 +7,6 @@ setup_karafka do |config|
   # We set it here that way not too wait too long on stuff
   config.kafka[:'max.poll.interval.ms'] = 10_000
   config.kafka[:'session.timeout.ms'] = 10_000
-  config.license.token = pro_license_token
 end
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/pro/consumption/strategies/lrj/multiple_batches_processing_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/multiple_batches_processing_spec.rb
@@ -6,7 +6,6 @@ setup_karafka do |config|
   config.max_messages = 10
   config.kafka[:'max.poll.interval.ms'] = 10_000
   config.kafka[:'session.timeout.ms'] = 10_000
-  config.license.token = pro_license_token
 end
 
 # We want to sleep few times but not all the time not to exceed max execution time of specs

--- a/spec/integrations/pro/consumption/strategies/lrj/no_revocation_on_low_concurrency_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/no_revocation_on_low_concurrency_spec.rb
@@ -10,7 +10,6 @@ setup_karafka do |config|
   # We set it here that way not too wait too long on stuff
   config.kafka[:'max.poll.interval.ms'] = 10_000
   config.kafka[:'session.timeout.ms'] = 10_000
-  config.license.token = pro_license_token
   config.concurrency = 1
 end
 

--- a/spec/integrations/pro/consumption/strategies/lrj/parallel_non_lrj_with_lrj_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/parallel_non_lrj_with_lrj_spec.rb
@@ -6,7 +6,6 @@
 setup_karafka do |config|
   config.max_messages = 1
   config.concurrency = 5
-  config.license.token = pro_license_token
   config.kafka[:'max.poll.interval.ms'] = 10_000
   config.kafka[:'session.timeout.ms'] = 10_000
 end

--- a/spec/integrations/pro/consumption/strategies/lrj/processing_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/processing_spec.rb
@@ -8,7 +8,6 @@ setup_karafka do |config|
   # We set it here that way not too wait too long on stuff
   config.kafka[:'max.poll.interval.ms'] = 10_000
   config.kafka[:'session.timeout.ms'] = 10_000
-  config.license.token = pro_license_token
 end
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/pro/consumption/strategies/lrj/saturated_before_revocation_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/saturated_before_revocation_spec.rb
@@ -8,7 +8,6 @@ setup_karafka(allow_errors: %w[connection.client.poll.error]) do |config|
   config.max_messages = 1
   config.kafka[:'max.poll.interval.ms'] = 10_000
   config.kafka[:'session.timeout.ms'] = 10_000
-  config.license.token = pro_license_token
 end
 
 events = []

--- a/spec/integrations/pro/consumption/strategies/lrj/shutdown_order_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/shutdown_order_spec.rb
@@ -8,7 +8,6 @@ setup_karafka do |config|
   # We set it here that way not too wait too long on stuff
   config.kafka[:'max.poll.interval.ms'] = 10_000
   config.kafka[:'session.timeout.ms'] = 10_000
-  config.license.token = pro_license_token
 end
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/pro/consumption/strategies/lrj/starved_revocation_on_rebalance_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/starved_revocation_on_rebalance_spec.rb
@@ -5,7 +5,6 @@
 
 setup_karafka do |config|
   config.max_messages = 5
-  config.license.token = pro_license_token
   config.concurrency = 2
 end
 

--- a/spec/integrations/pro/consumption/strategies/lrj/with_auto_offset_management_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/with_auto_offset_management_spec.rb
@@ -5,7 +5,6 @@
 
 setup_karafka do |config|
   config.max_messages = 5
-  config.license.token = pro_license_token
 end
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/pro/consumption/strategies/lrj/with_continuous_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/with_continuous_error_spec.rb
@@ -12,9 +12,7 @@ end
 
 Karafka.monitor.subscribe(Listener.new)
 
-setup_karafka(allow_errors: true) do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka(allow_errors: true)
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/pro/consumption/strategies/lrj/with_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/with_error_spec.rb
@@ -11,9 +11,7 @@ end
 
 Karafka.monitor.subscribe(Listener.new)
 
-setup_karafka(allow_errors: true) do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka(allow_errors: true)
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/pro/consumption/strategies/lrj/with_manual_offset_management_endless_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/with_manual_offset_management_endless_spec.rb
@@ -8,7 +8,6 @@ setup_karafka do |config|
   # We set it here that way not too wait too long on stuff
   config.kafka[:'max.poll.interval.ms'] = 10_000
   config.kafka[:'session.timeout.ms'] = 10_000
-  config.license.token = pro_license_token
 end
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/pro/consumption/strategies/lrj/with_never_ending_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/with_never_ending_error_spec.rb
@@ -5,7 +5,6 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.max_messages = 20
-  config.license.token = pro_license_token
 end
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/pro/consumption/strategies/vp/consistent_distribution_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/consistent_distribution_spec.rb
@@ -5,7 +5,6 @@
 # stay the same (consistent).
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 2
   config.max_messages = 100
   config.initial_offset = 'earliest'

--- a/spec/integrations/pro/consumption/strategies/vp/custom_partitioning_engine_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/custom_partitioning_engine_spec.rb
@@ -50,7 +50,9 @@ end
 draw_routes do
   topic SPECIAL_TOPIC do
     consumer Consumer
-    # Irrelevant because we use custom partitioner
+
+    # Can be set up without any arguments as the virtualization is delegated to the
+    # CustomPartitioner
     virtual_partitions
   end
 

--- a/spec/integrations/pro/consumption/strategies/vp/custom_partitioning_engine_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/custom_partitioning_engine_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+SPECIAL_TOPIC = DT.topics[0]
+
+setup_karafka
+
+class CustomPartitioner < Karafka::Pro::Processing::Partitioner
+  def call(topic_name, messages, &block)
+    if topic_name == SPECIAL_TOPIC
+      balanced_strategy(messages, &block)
+    else
+      super
+    end
+  end
+
+  private
+
+  def balanced_strategy(messages)
+    messages.each_slice(20).with_index do |slice, index|
+      yield(index, slice)
+    end
+  end
+end
+
+setup_karafka do |config|
+  config.concurrency = 2
+  config.max_messages = 500
+  config.max_wait_time = 5_000
+  config.initial_offset = 'earliest'
+  config.internal.processing.partitioner_class = CustomPartitioner
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[topic.name] << messages.count
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    # Irrelevant because we use custom partitioner
+    virtual_partitions
+  end
+
+  topic DT.topics[1] do
+    consumer Consumer
+  end
+end
+
+10.times do
+  produce_many(DT.topics[0], DT.uuids(1_000))
+end
+
+produce_many(DT.topics[1], DT.uuids(1_000))
+
+start_karafka_and_wait_until do
+  DT[DT.topics[0]].sum >= 5_000 &&
+    DT[DT.topics[1]].sum >= 100
+end
+
+p DT

--- a/spec/integrations/pro/consumption/strategies/vp/custom_partitioning_engine_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/custom_partitioning_engine_spec.rb
@@ -77,4 +77,4 @@ def median(array)
 end
 
 assert_equal 20, median(DT[SPECIAL_TOPIC])
-assert (400..500).include?(median(DT[REGULAR_TOPIC]))
+assert (400..500).cover?(median(DT[REGULAR_TOPIC]))

--- a/spec/integrations/pro/consumption/strategies/vp/different_coordinator_different_partitions_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/different_coordinator_different_partitions_spec.rb
@@ -3,7 +3,6 @@
 # Karafka should not use the same coordinator for jobs from different partitions
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 10
   config.max_messages = 5
   config.initial_offset = 'latest'

--- a/spec/integrations/pro/consumption/strategies/vp/distributing_work_randomly_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/distributing_work_randomly_spec.rb
@@ -5,7 +5,6 @@
 # mix within a batch.
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 5
   config.max_messages = 20
   config.initial_offset = 'latest'

--- a/spec/integrations/pro/consumption/strategies/vp/distributing_work_using_message_keys_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/distributing_work_using_message_keys_spec.rb
@@ -11,7 +11,6 @@
 # virtual consumers. Virtual consumer instance is **not** warrantied.
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 10
   config.max_messages = 5
   config.initial_offset = 'latest'

--- a/spec/integrations/pro/consumption/strategies/vp/from_earliest_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/from_earliest_spec.rb
@@ -5,7 +5,6 @@
 # of all the messages
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 10
 end
 

--- a/spec/integrations/pro/consumption/strategies/vp/many_batches_same_key_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/many_batches_same_key_spec.rb
@@ -4,7 +4,6 @@
 # should always use one thread despite having more available
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 10
 end
 

--- a/spec/integrations/pro/consumption/strategies/vp/many_batches_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/many_batches_spec.rb
@@ -5,7 +5,6 @@
 # not change
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 10
 end
 

--- a/spec/integrations/pro/consumption/strategies/vp/many_distributed_batches_end_order_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/many_distributed_batches_end_order_spec.rb
@@ -4,7 +4,6 @@
 # the single partition batches should be preserved.
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 10
 end
 

--- a/spec/integrations/pro/consumption/strategies/vp/shared_coordinator_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/shared_coordinator_spec.rb
@@ -3,7 +3,6 @@
 # Karafka should use the same coordinator for all the jobs in a group
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 10
   config.max_messages = 5
 end

--- a/spec/integrations/pro/consumption/strategies/vp/with_error_on_another_batch_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/with_error_on_another_batch_spec.rb
@@ -12,7 +12,6 @@ end
 Karafka.monitor.subscribe(Listener.new)
 
 setup_karafka(allow_errors: true) do |config|
-  config.license.token = pro_license_token
   config.concurrency = 10
 end
 

--- a/spec/integrations/pro/consumption/strategies/vp/with_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/with_error_spec.rb
@@ -13,7 +13,6 @@ end
 Karafka.monitor.subscribe(Listener.new)
 
 setup_karafka(allow_errors: true) do |config|
-  config.license.token = pro_license_token
   config.concurrency = 10
 end
 

--- a/spec/integrations/pro/consumption/strategies/vp/with_headers_usage_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/with_headers_usage_spec.rb
@@ -3,7 +3,6 @@
 # Ruby had some header related bugs in 3.0.2. This PR checks that all works as expected
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 10
 end
 

--- a/spec/integrations/pro/consumption/strategies/vp/with_limited_concurrency_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/with_limited_concurrency_spec.rb
@@ -5,7 +5,6 @@
 # always available for other work.
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 3
   config.max_messages = 1_000
   config.max_wait_time = 1_000

--- a/spec/integrations/pro/consumption/strategies/vp/with_more_vps_than_workers_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/with_more_vps_than_workers_spec.rb
@@ -5,7 +5,6 @@
 # any of the resource details
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 5
   config.max_messages = 500
   config.max_wait_time = 2_000

--- a/spec/integrations/pro/consumption/strategies/vp/with_parallel_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/with_parallel_errors_spec.rb
@@ -12,7 +12,6 @@ end
 Karafka.monitor.subscribe(Listener.new)
 
 setup_karafka(allow_errors: true) do |config|
-  config.license.token = pro_license_token
   config.concurrency = 10
 end
 

--- a/spec/integrations/pro/consumption/vp_with_lrj_from_earliest_spec.rb
+++ b/spec/integrations/pro/consumption/vp_with_lrj_from_earliest_spec.rb
@@ -8,7 +8,6 @@ setup_karafka do |config|
   # We set it here that way not too wait too long on stuff
   config.kafka[:'max.poll.interval.ms'] = 10_000
   config.kafka[:'session.timeout.ms'] = 10_000
-  config.license.token = pro_license_token
   config.concurrency = 5
 end
 

--- a/spec/integrations/pro/consumption/with_never_ending_error_spec.rb
+++ b/spec/integrations/pro/consumption/with_never_ending_error_spec.rb
@@ -4,7 +4,6 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
   config.max_messages = 20
-  config.license.token = pro_license_token
 end
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/pro/consumption/with_pro_scheduler_from_earliest_spec.rb
+++ b/spec/integrations/pro/consumption/with_pro_scheduler_from_earliest_spec.rb
@@ -4,7 +4,6 @@
 # Here we just aim to ensure, that we schedule all the jobs and that things operate as expected
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 10
 end
 

--- a/spec/integrations/pro/licensing/configure_with_invalid_token_spec.rb
+++ b/spec/integrations/pro/licensing/configure_with_invalid_token_spec.rb
@@ -4,10 +4,10 @@
 
 failed_as_expected = false
 
+ENV['KARAFKA_PRO_LICENSE_TOKEN'] = rand.to_s
+
 begin
-  setup_karafka do |config|
-    config.license.token = rand.to_s
-  end
+  setup_karafka
 rescue Karafka::Errors::InvalidLicenseTokenError
   failed_as_expected = true
 end
@@ -15,20 +15,4 @@ end
 assert failed_as_expected
 assert_equal false, Karafka.pro?
 
-# Pro components should not be visible
-assert_equal false, const_visible?('Karafka::Pro::Processing::StrategySelector')
-assert_equal false, const_visible?('Karafka::Pro::Processing::Partitioner')
-assert_equal false, const_visible?('Karafka::Pro::Processing::Coordinator')
-assert_equal false, const_visible?('Karafka::Pro::Processing::JobsBuilder')
-assert_equal false, const_visible?('Karafka::Pro::Routing::Features::LongRunningJob::Topic')
-assert_equal false, const_visible?('Karafka::Pro::Routing::Features::LongRunningJob::Contract')
-assert_equal false, const_visible?('Karafka::Pro::Routing::Features::LongRunningJob::Config')
-assert_equal false, const_visible?('Karafka::Pro::Routing::Features::VirtualPartitions::Topic')
-assert_equal false, const_visible?('Karafka::Pro::Routing::Features::VirtualPartitions::Contract')
-assert_equal false, const_visible?('Karafka::Pro::Routing::Features::VirtualPartitions::Config')
-assert_equal false, const_visible?('Karafka::Pro::Processing::Jobs::ConsumeNonBlocking')
-assert_equal false, const_visible?('Karafka::Pro::ActiveJob::Consumer')
-assert_equal false, const_visible?('Karafka::Pro::ActiveJob::Dispatcher')
-assert_equal false, const_visible?('Karafka::Pro::ActiveJob::JobOptionsContract')
-assert_equal false, const_visible?('Karafka::Pro::PerformanceTracker')
-assert_equal false, const_visible?('Karafka::Pro::Processing::Scheduler')
+# No need to check visibility of anything because we raise exception

--- a/spec/integrations/pro/licensing/configure_with_valid_token_spec.rb
+++ b/spec/integrations/pro/licensing/configure_with_valid_token_spec.rb
@@ -6,7 +6,6 @@ LOGS = StringIO.new
 
 setup_karafka do |config|
   config.logger = Logger.new(LOGS)
-  config.license.token = pro_license_token
 end
 
 LOGS.rewind

--- a/spec/integrations/pro/licensing/load_poro/Gemfile
+++ b/spec/integrations/pro/licensing/load_poro/Gemfile
@@ -2,4 +2,12 @@
 
 source 'https://rubygems.org'
 
+KARAFKA_PRO_USERNAME = ENV.fetch('KARAFKA_PRO_USERNAME')
+KARAFKA_PRO_PASSWORD = ENV.fetch('KARAFKA_PRO_PASSWORD')
+KARAFKA_PRO_VERSION = ENV.fetch('KARAFKA_PRO_VERSION')
+
+source "https://#{KARAFKA_PRO_USERNAME}:#{KARAFKA_PRO_PASSWORD}@gems.karafka.io" do
+  gem 'karafka-license', KARAFKA_PRO_VERSION
+end
+
 gem 'karafka', path: ENV.fetch('KARAFKA_GEM_DIR'), require: true

--- a/spec/integrations/pro/licensing/load_poro/configure_spec.rb
+++ b/spec/integrations/pro/licensing/load_poro/configure_spec.rb
@@ -5,13 +5,12 @@
 require 'karafka'
 
 class KarafkaApp < Karafka::App
-  setup do |config|
-    config.license.token = ENV.fetch('KARAFKA_PRO_LICENSE_TOKEN')
-  end
+  setup
 
   routes.draw do
     topic :visits do
       consumer Class.new(Karafka::BaseConsumer)
+      long_running_job
     end
   end
 end

--- a/spec/integrations/pro/licensing/load_poro/early_components_visibility_spec.rb
+++ b/spec/integrations/pro/licensing/load_poro/early_components_visibility_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Karafka in a PORO project should load components after the require even prior to the setup, so
+# we can use those when needed
+
+require 'karafka'
+
+class Partitioner < Karafka::Pro::Processing::Partitioner
+end

--- a/spec/integrations/pro/offset_management/with_manual_offset_and_error_spec.rb
+++ b/spec/integrations/pro/offset_management/with_manual_offset_and_error_spec.rb
@@ -5,7 +5,6 @@
 
 setup_karafka(allow_errors: true) do |config|
   config.max_messages = 2
-  config.license.token = pro_license_token
 end
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/pro/performance_tracking_spec.rb
+++ b/spec/integrations/pro/performance_tracking_spec.rb
@@ -4,7 +4,6 @@
 # This metrics tracker is then used internally for optimization purposes
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 5
   config.max_messages = 2
 end

--- a/spec/integrations/pro/rails/active_job/dispatching_async_job_spec.rb
+++ b/spec/integrations/pro/rails/active_job/dispatching_async_job_spec.rb
@@ -2,9 +2,7 @@
 
 # Karafka should be able to dispatch jobs using async pro adapter
 
-setup_karafka do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka
 
 setup_active_job
 

--- a/spec/integrations/pro/rails/active_job/dispatching_sync_job_spec.rb
+++ b/spec/integrations/pro/rails/active_job/dispatching_sync_job_spec.rb
@@ -2,9 +2,7 @@
 
 # Karafka should be able to dispatch jobs using sync pro adapter
 
-setup_karafka do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka
 
 setup_active_job
 

--- a/spec/integrations/pro/rails/active_job/invalid_configuration_attempt_spec.rb
+++ b/spec/integrations/pro/rails/active_job/invalid_configuration_attempt_spec.rb
@@ -3,9 +3,7 @@
 # When there is a misconfiguration of karafka options on ActiveJob job class, it should raise an
 # error
 
-setup_karafka do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka
 
 setup_active_job
 

--- a/spec/integrations/pro/rails/active_job/long_running_job_processing_spec.rb
+++ b/spec/integrations/pro/rails/active_job/long_running_job_processing_spec.rb
@@ -7,7 +7,6 @@ setup_karafka do |config|
   # We set it here that way not too wait too long on stuff
   config.kafka[:'max.poll.interval.ms'] = 10_000
   config.kafka[:'session.timeout.ms'] = 10_000
-  config.license.token = pro_license_token
 end
 
 setup_active_job

--- a/spec/integrations/pro/rails/active_job/long_running_jobs/fast_spec.rb
+++ b/spec/integrations/pro/rails/active_job/long_running_jobs/fast_spec.rb
@@ -2,9 +2,7 @@
 
 # Fast jobs should also not have any problems (though not recommended) when running as lrj
 
-setup_karafka do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka
 
 setup_active_job
 

--- a/spec/integrations/pro/rails/active_job/long_running_jobs/with_error_spec.rb
+++ b/spec/integrations/pro/rails/active_job/long_running_jobs/with_error_spec.rb
@@ -2,9 +2,7 @@
 
 # When we have an lrj job and it fails, it should use regular Karafka retry policies
 
-setup_karafka(allow_errors: true) do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka(allow_errors: true)
 
 setup_active_job
 

--- a/spec/integrations/pro/rails/active_job/long_running_jobs/with_revocation_spec.rb
+++ b/spec/integrations/pro/rails/active_job/long_running_jobs/with_revocation_spec.rb
@@ -7,7 +7,6 @@
 # of them and detect this.
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.max_wait_time = 2_500
   config.concurrency = 10
   config.shutdown_timeout = 60_000

--- a/spec/integrations/pro/rails/active_job/long_running_jobs/with_shutdown_pickup_spec.rb
+++ b/spec/integrations/pro/rails/active_job/long_running_jobs/with_shutdown_pickup_spec.rb
@@ -8,7 +8,6 @@
 setup_karafka do |config|
   # This will ensure we get more jobs in one go
   config.max_wait_time = 5_000
-  config.license.token = pro_license_token
 end
 
 setup_active_job

--- a/spec/integrations/pro/rails/active_job/ordered_jobs_with_key_spec.rb
+++ b/spec/integrations/pro/rails/active_job/ordered_jobs_with_key_spec.rb
@@ -5,7 +5,6 @@
 # proper results when using `:key`.
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.initial_offset = 'latest'
 end
 

--- a/spec/integrations/pro/rails/active_job/ordered_jobs_with_partition_key_spec.rb
+++ b/spec/integrations/pro/rails/active_job/ordered_jobs_with_partition_key_spec.rb
@@ -5,7 +5,6 @@
 # proper results when using `:partition_key`.
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.initial_offset = 'latest'
 end
 

--- a/spec/integrations/pro/rails/active_job/processing_few_on_shutdown_lrj_spec.rb
+++ b/spec/integrations/pro/rails/active_job/processing_few_on_shutdown_lrj_spec.rb
@@ -8,7 +8,6 @@
 setup_karafka do |config|
   # This will ensure we get more jobs in one go
   config.max_wait_time = 5_000
-  config.license.token = pro_license_token
 end
 
 setup_active_job

--- a/spec/integrations/pro/rails/active_job/processing_few_on_shutdown_spec.rb
+++ b/spec/integrations/pro/rails/active_job/processing_few_on_shutdown_spec.rb
@@ -7,7 +7,6 @@
 setup_karafka do |config|
   # This will ensure we get more jobs in one go
   config.max_wait_time = 5_000
-  config.license.token = pro_license_token
 end
 
 setup_active_job

--- a/spec/integrations/pro/rails/active_job/virtual_partitions/from_earliest_spec.rb
+++ b/spec/integrations/pro/rails/active_job/virtual_partitions/from_earliest_spec.rb
@@ -4,7 +4,6 @@
 # unless we use headers data to balance work.
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 5
   config.max_messages = 50
 end

--- a/spec/integrations/pro/rails/active_job/virtual_partitions/with_error_on_next_job_spec.rb
+++ b/spec/integrations/pro/rails/active_job/virtual_partitions/with_error_on_next_job_spec.rb
@@ -4,7 +4,6 @@
 # for parallel jobs. In general it should not mark intermediate jobs as consumed.
 
 setup_karafka(allow_errors: true) do |config|
-  config.license.token = pro_license_token
   config.concurrency = 1
   config.max_messages = 60
   config.max_wait_time = 2_000

--- a/spec/integrations/pro/rails/active_job/virtual_partitions/with_error_spec.rb
+++ b/spec/integrations/pro/rails/active_job/virtual_partitions/with_error_spec.rb
@@ -4,7 +4,6 @@
 # jobs
 
 setup_karafka(allow_errors: true) do |config|
-  config.license.token = pro_license_token
   config.concurrency = 5
 end
 

--- a/spec/integrations/pro/rails/active_job/virtual_partitions/with_partitioning_using_key_spec.rb
+++ b/spec/integrations/pro/rails/active_job/virtual_partitions/with_partitioning_using_key_spec.rb
@@ -4,7 +4,6 @@
 # concurrent Active Job work execution.
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 10
 end
 

--- a/spec/integrations/pro/rails/active_job/virtual_partitions/with_revocation_continuity_spec.rb
+++ b/spec/integrations/pro/rails/active_job/virtual_partitions/with_revocation_continuity_spec.rb
@@ -5,7 +5,6 @@
 # finished.
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 2
   config.max_messages = 2
 end

--- a/spec/integrations/pro/rails/active_job/virtual_partitions/with_revocation_spec.rb
+++ b/spec/integrations/pro/rails/active_job/virtual_partitions/with_revocation_spec.rb
@@ -9,7 +9,6 @@
 # early enough
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.max_wait_time = 2_500
   config.max_messages = 20
   config.concurrency = 4

--- a/spec/integrations/pro/rails/rails5_pristine/railtie_setup_spec.rb
+++ b/spec/integrations/pro/rails/rails5_pristine/railtie_setup_spec.rb
@@ -18,9 +18,7 @@ ENV['KARAFKA_BOOT_FILE'] = dummy_boot_file
 
 ExampleApp.initialize!
 
-setup_karafka do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/pro/rails/rails6_pristine/railtie_setup_spec.rb
+++ b/spec/integrations/pro/rails/rails6_pristine/railtie_setup_spec.rb
@@ -16,9 +16,7 @@ ENV['KARAFKA_BOOT_FILE'] = dummy_boot_file
 
 ExampleApp.initialize!
 
-setup_karafka do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/pro/rails/rails7_pristine/railtie_setup_spec.rb
+++ b/spec/integrations/pro/rails/rails7_pristine/railtie_setup_spec.rb
@@ -16,9 +16,7 @@ ENV['KARAFKA_BOOT_FILE'] = dummy_boot_file
 
 ExampleApp.initialize!
 
-setup_karafka do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/pro/rebalancing/coordinator_replacement_after_rebalance_spec.rb
+++ b/spec/integrations/pro/rebalancing/coordinator_replacement_after_rebalance_spec.rb
@@ -5,7 +5,6 @@
 
 setup_karafka do |config|
   config.concurrency = 4
-  config.license.token = pro_license_token
 end
 
 create_topic(partitions: 2)

--- a/spec/integrations/pro/rebalancing/long_running_jobs/constant_rebalance_continuity_spec.rb
+++ b/spec/integrations/pro/rebalancing/long_running_jobs/constant_rebalance_continuity_spec.rb
@@ -8,7 +8,6 @@
 
 setup_karafka do |config|
   config.concurrency = 1
-  config.license.token = pro_license_token
 end
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/pro/rebalancing/long_running_jobs/continuity_after_error_and_rebalance_spec.rb
+++ b/spec/integrations/pro/rebalancing/long_running_jobs/continuity_after_error_and_rebalance_spec.rb
@@ -6,7 +6,6 @@
 
 setup_karafka(allow_errors: true) do |config|
   config.max_messages = 1
-  config.license.token = pro_license_token
 end
 
 create_topic(partitions: 2)

--- a/spec/integrations/pro/rebalancing/long_running_jobs/coordinator_replacement_after_rebalance_spec.rb
+++ b/spec/integrations/pro/rebalancing/long_running_jobs/coordinator_replacement_after_rebalance_spec.rb
@@ -5,7 +5,6 @@
 
 setup_karafka do |config|
   config.concurrency = 4
-  config.license.token = pro_license_token
 end
 
 create_topic(partitions: 2)

--- a/spec/integrations/pro/rebalancing/long_running_jobs/rebalance_consumer_recreation_spec.rb
+++ b/spec/integrations/pro/rebalancing/long_running_jobs/rebalance_consumer_recreation_spec.rb
@@ -4,7 +4,6 @@
 # consumer instance. We should use one before and one after we got the partition back.
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 4
   config.initial_offset = 'latest'
 end

--- a/spec/integrations/pro/rebalancing/long_running_jobs/rebalance_continuity_spec.rb
+++ b/spec/integrations/pro/rebalancing/long_running_jobs/rebalance_continuity_spec.rb
@@ -9,7 +9,6 @@ setup_karafka do |config|
   # We set it here that way not too wait too long on stuff
   config.kafka[:'max.poll.interval.ms'] = 10_000
   config.kafka[:'session.timeout.ms'] = 10_000
-  config.license.token = pro_license_token
 end
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/pro/rebalancing/long_running_jobs/rebalance_continuity_without_marking_spec.rb
+++ b/spec/integrations/pro/rebalancing/long_running_jobs/rebalance_continuity_without_marking_spec.rb
@@ -9,7 +9,6 @@ setup_karafka do |config|
   # We set it here that way not too wait too long on stuff
   config.kafka[:'max.poll.interval.ms'] = 10_000
   config.kafka[:'session.timeout.ms'] = 10_000
-  config.license.token = pro_license_token
 end
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/pro/rebalancing/long_running_jobs/revoke_continuity_spec.rb
+++ b/spec/integrations/pro/rebalancing/long_running_jobs/revoke_continuity_spec.rb
@@ -4,7 +4,6 @@
 # offset committed without any problems
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   # We need 4: two partitions processing and non-blocking revokes
   config.concurrency = 4
   config.shutdown_timeout = 60_000

--- a/spec/integrations/pro/rebalancing/long_running_jobs/revoke_mark_as_consumed_enough_threads_spec.rb
+++ b/spec/integrations/pro/rebalancing/long_running_jobs/revoke_mark_as_consumed_enough_threads_spec.rb
@@ -9,7 +9,6 @@
 # finishing the processing. Otherwise when enqueued, will run after (for this we have another spec)
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   # We need 4: two partitions processing and non-blocking revokes
   config.concurrency = 4
   config.shutdown_timeout = 60_000

--- a/spec/integrations/pro/rebalancing/long_running_jobs/revoke_mark_as_consumed_not_enough_threads_spec.rb
+++ b/spec/integrations/pro/rebalancing/long_running_jobs/revoke_mark_as_consumed_not_enough_threads_spec.rb
@@ -6,7 +6,6 @@
 # state could not be set on a consumer in the revocation job becuase it is pending in the queue.
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 2
   config.shutdown_timeout = 60_000
 end

--- a/spec/integrations/pro/rebalancing/long_running_jobs/revoke_mark_as_consumed_sync_enough_threads_spec.rb
+++ b/spec/integrations/pro/rebalancing/long_running_jobs/revoke_mark_as_consumed_sync_enough_threads_spec.rb
@@ -9,7 +9,6 @@
 # finishing the processing. Otherwise when enqueued, will run after (for this we have another spec)
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   # We need 4: two partitions processing and non-blocking revokes
   config.concurrency = 4
   config.shutdown_timeout = 60_000

--- a/spec/integrations/pro/rebalancing/long_running_jobs/revoke_mark_as_consumed_sync_not_enough_threads_spec.rb
+++ b/spec/integrations/pro/rebalancing/long_running_jobs/revoke_mark_as_consumed_sync_not_enough_threads_spec.rb
@@ -6,7 +6,6 @@
 # state could not be set on a consumer in the revocation job becuase it is pending in the queue.
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 2
   config.shutdown_timeout = 60_000
 end

--- a/spec/integrations/pro/rebalancing/long_running_jobs/revoked_detection_spec.rb
+++ b/spec/integrations/pro/rebalancing/long_running_jobs/revoked_detection_spec.rb
@@ -9,7 +9,6 @@ setup_karafka do |config|
   # We set it here that way not too wait too long on stuff
   config.kafka[:'max.poll.interval.ms'] = 10_000
   config.kafka[:'session.timeout.ms'] = 10_000
-  config.license.token = pro_license_token
   config.concurrency = 10
   config.shutdown_timeout = 120_000
   config.initial_offset = 'latest'

--- a/spec/integrations/pro/rebalancing/on_partition_data_revoked_spec.rb
+++ b/spec/integrations/pro/rebalancing/on_partition_data_revoked_spec.rb
@@ -4,9 +4,7 @@
 # Initially we should own all the partitions and then after they are taken away, we should get
 # back to two (as the last one will be owned by the second consumer).
 
-setup_karafka do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka
 
 create_topic(partitions: 3)
 

--- a/spec/integrations/pro/rebalancing/revoke_continuity_spec.rb
+++ b/spec/integrations/pro/rebalancing/revoke_continuity_spec.rb
@@ -4,7 +4,6 @@
 # last offset committed without any problems
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 4
 end
 

--- a/spec/integrations/pro/rebalancing/virtual_partitions/coordinator_replacement_after_rebalance_spec.rb
+++ b/spec/integrations/pro/rebalancing/virtual_partitions/coordinator_replacement_after_rebalance_spec.rb
@@ -5,7 +5,6 @@
 
 setup_karafka do |config|
   config.concurrency = 4
-  config.license.token = pro_license_token
 end
 
 create_topic(partitions: 2)

--- a/spec/integrations/pro/rebalancing/virtual_partitions/rebalance_continuity_spec.rb
+++ b/spec/integrations/pro/rebalancing/virtual_partitions/rebalance_continuity_spec.rb
@@ -7,7 +7,6 @@
 setup_karafka do |config|
   config.max_messages = 5
   config.concurrency = 5
-  config.license.token = pro_license_token
 end
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/pro/rebalancing/with_static_membership_reconnect_spec.rb
+++ b/spec/integrations/pro/rebalancing/with_static_membership_reconnect_spec.rb
@@ -7,7 +7,6 @@
 require 'securerandom'
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.initial_offset = 'latest'
   config.kafka[:'group.instance.id'] = SecureRandom.uuid
 end

--- a/spec/integrations/pro/routing/dlq_with_vp_spec.rb
+++ b/spec/integrations/pro/routing/dlq_with_vp_spec.rb
@@ -3,7 +3,6 @@
 # Karafka should not allow for using VP with DLQ
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 10
 end
 

--- a/spec/integrations/pro/routing/non_pro_without_long_running_job_spec.rb
+++ b/spec/integrations/pro/routing/non_pro_without_long_running_job_spec.rb
@@ -2,7 +2,7 @@
 
 # When running non-pro, LRJ should not be available
 
-setup_karafka
+setup_karafka(pro: false)
 
 not_found = false
 

--- a/spec/integrations/pro/routing/non_pro_without_virtual_partitioner_spec.rb
+++ b/spec/integrations/pro/routing/non_pro_without_virtual_partitioner_spec.rb
@@ -2,7 +2,7 @@
 
 # When running non-pro, VP should not be available
 
-setup_karafka
+setup_karafka(pro: false)
 
 not_found = false
 

--- a/spec/integrations/pro/routing/pro_with_long_running_job_spec.rb
+++ b/spec/integrations/pro/routing/pro_with_long_running_job_spec.rb
@@ -3,9 +3,7 @@
 # I should be able to define a topic consumption with long-running job indication
 # It should not impact other jobs and the default should not be lrj
 
-setup_karafka do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka
 
 draw_routes do
   consumer_group DT.consumer_group do

--- a/spec/integrations/pro/routing/pro_with_virtual_partitioner_spec.rb
+++ b/spec/integrations/pro/routing/pro_with_virtual_partitioner_spec.rb
@@ -3,9 +3,7 @@
 # I should be able to define a topic consumption with virtual partitioner.
 # It should not impact other jobs and the default should not have it.
 
-setup_karafka do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka
 
 draw_routes do
   consumer_group DT.consumer_group do

--- a/spec/integrations/pro/routing/valid_with_features_usage_spec.rb
+++ b/spec/integrations/pro/routing/valid_with_features_usage_spec.rb
@@ -2,9 +2,7 @@
 
 # Karafka should auto-load all the routing features
 
-setup_karafka do |config|
-  config.license.token = pro_license_token
-end
+setup_karafka
 
 draw_routes do
   subscription_group do

--- a/spec/integrations/pro/routing/virtual_partitions_with_manual_offset_management_spec.rb
+++ b/spec/integrations/pro/routing/virtual_partitions_with_manual_offset_management_spec.rb
@@ -3,7 +3,6 @@
 # Karafka should not allow for using VP with MOM
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 10
 end
 

--- a/spec/integrations/pro/shutdown/long_running_jobs/revocation_awareness_on_shutdown_spec.rb
+++ b/spec/integrations/pro/shutdown/long_running_jobs/revocation_awareness_on_shutdown_spec.rb
@@ -5,7 +5,6 @@
 # to make decisions also based on the revocation status.
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 20
 end
 

--- a/spec/integrations/pro/shutdown/long_running_jobs/stopping_awareness_spec.rb
+++ b/spec/integrations/pro/shutdown/long_running_jobs/stopping_awareness_spec.rb
@@ -7,7 +7,6 @@
 # be turned on.
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 5
 end
 

--- a/spec/integrations/pro/shutdown/virtual_partitions/shutdown_on_all_consumers_spec.rb
+++ b/spec/integrations/pro/shutdown/virtual_partitions/shutdown_on_all_consumers_spec.rb
@@ -3,7 +3,6 @@
 # Karafka should run the shutdown on all the consumers that processed virtual partitions.
 
 setup_karafka do |config|
-  config.license.token = pro_license_token
   config.concurrency = 5
 end
 

--- a/spec/integrations/setup/load_poro/Gemfile
+++ b/spec/integrations/setup/load_poro/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'karafka', path: ENV.fetch('KARAFKA_GEM_DIR'), require: true

--- a/spec/integrations/setup/load_poro/configure_spec.rb
+++ b/spec/integrations/setup/load_poro/configure_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Karafka in a PORO project should load without any problems when regular (not pro)
+
+require 'karafka'
+
+class KarafkaApp < Karafka::App
+  setup
+
+  routes.draw do
+    topic :visits do
+      consumer Class.new(Karafka::BaseConsumer)
+    end
+  end
+end

--- a/spec/integrations_helper.rb
+++ b/spec/integrations_helper.rb
@@ -28,7 +28,8 @@ DT = DataCollector
 #   or a given types (array with types)
 def setup_karafka(
   allow_errors: false,
-  pro: caller_locations.first.path.include?('integrations/pro/')
+  # automatically load pro for all the pro specs unless stated otherwise
+  pro: caller_locations(1..1).first.path.include?('integrations/pro/')
 )
   # If the spec  is in pro, run in pro mode
   become_pro! if pro

--- a/spec/integrations_helper.rb
+++ b/spec/integrations_helper.rb
@@ -24,7 +24,15 @@ $stdout.sync = true
 DT = DataCollector
 
 # Test setup for the framework
-def setup_karafka(allow_errors: false)
+# @param allow_errors [true, false, Array<String>] Should we allow any errors (true), none (false)
+#   or a given types (array with types)
+def setup_karafka(
+  allow_errors: false,
+  pro: caller_locations.first.path.include?('integrations/pro/')
+)
+  # If the spec  is in pro, run in pro mode
+  become_pro! if pro
+
   Karafka::App.setup do |config|
     # Use some decent defaults
     caller_id = [caller_locations(1..1).first.path.split('/').last, SecureRandom.uuid].join('-')
@@ -85,6 +93,20 @@ def setup_karafka(allow_errors: false)
 
     exit! 8
   end
+end
+
+# Switches specs into a Pro mode
+def become_pro!
+  mod = Module.new do
+    def self.token
+      ENV.fetch('KARAFKA_PRO_LICENSE_TOKEN')
+    end
+  end
+
+  Karafka.const_set('License', mod)
+  require 'karafka/pro/loader'
+
+  Karafka::Pro::Loader.require_all
 end
 
 # Configures ActiveJob stuff in a similar way as the Railtie does for full Rails setup
@@ -252,11 +274,6 @@ end
 #   collector data will be printed
 def assert(received, message = DT)
   assert_equal(true, received, message)
-end
-
-# @return [String] valid pro license token that we use in the integration tests
-def pro_license_token
-  ENV.fetch('KARAFKA_PRO_LICENSE_TOKEN')
 end
 
 # Checks that what we've received and what we do not expect is not equal

--- a/spec/lib/karafka/connection/consumer_group_coordinator_spec.rb
+++ b/spec/lib/karafka/connection/consumer_group_coordinator_spec.rb
@@ -1,7 +1,21 @@
 # frozen_string_literal: true
 
 RSpec.describe_current do
-  subject(:status) { described_class.new(2) }
+  subject(:coordinator) { described_class.new(2) }
 
-  pending
+  it { expect(coordinator.shutdown?).to eq(false) }
+
+  context 'when we finish some of the work' do
+    before { coordinator.finish_work(1) }
+
+    it { expect(coordinator.shutdown?).to eq(false) }
+  end
+
+  context 'when we finish enough work and can get the lock' do
+    before { 2.times { |i| coordinator.finish_work(i) } }
+
+    after { coordinator.unlock }
+
+    it { expect(coordinator.shutdown?).to eq(true) }
+  end
 end

--- a/spec/lib/karafka/embedded_spec.rb
+++ b/spec/lib/karafka/embedded_spec.rb
@@ -22,4 +22,13 @@ RSpec.describe_current do
       expect(Karafka::Server).to have_received(:stop)
     end
   end
+
+  describe '#quiet' do
+    before { allow(Karafka::Server).to receive(:quiet) }
+
+    it 'expect to invoke server quiet' do
+      embedded.quiet
+      expect(Karafka::Server).to have_received(:quiet)
+    end
+  end
 end

--- a/spec/lib/karafka/licenser_spec.rb
+++ b/spec/lib/karafka/licenser_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe_current do
-  subject(:prepare_and_verify) { described_class.new.prepare_and_verify(license_config) }
+  subject(:prepare_and_verify) { described_class.prepare_and_verify(license_config) }
 
   let(:license_config) { Karafka::App.config.license.deep_dup.tap(&:configure) }
 
@@ -10,11 +10,5 @@ RSpec.describe_current do
 
     it { expect { prepare_and_verify }.not_to raise_error }
     it { expect { prepare_and_verify }.not_to change(license_config, :entity) }
-  end
-
-  context 'when token is invalid' do
-    before { license_config.token = rand.to_s }
-
-    it { expect { prepare_and_verify }.to raise_error(Karafka::Errors::InvalidLicenseTokenError) }
   end
 end

--- a/spec/lib/karafka/routing/subscription_group_spec.rb
+++ b/spec/lib/karafka/routing/subscription_group_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe_current do
   let(:topic) { build(:routing_topic, kafka: { 'bootstrap.servers': 'kafka://kafka:9092' }) }
 
   describe '#id' do
-    it { expect(group.id).to eq(topic.subscription_group) }
+    it { expect(group.id).to eq("#{topic.subscription_group}_0") }
   end
 
   describe '#max_messages' do

--- a/spec/lib/karafka/server_spec.rb
+++ b/spec/lib/karafka/server_spec.rb
@@ -240,6 +240,7 @@ RSpec.describe_current do
       let(:new_status) { :run! }
 
       before do
+        allow(Karafka::App).to receive(:quieting?).and_return(false)
         allow(Karafka::App).to receive(:stopped?).and_return(false)
         allow(Karafka::App).to receive(:stopping?).and_return(false)
       end

--- a/spec/lib/karafka/server_spec.rb
+++ b/spec/lib/karafka/server_spec.rb
@@ -205,4 +205,60 @@ RSpec.describe_current do
       end
     end
   end
+
+  describe '#quiet' do
+    before do
+      Karafka::App.public_send(new_status)
+      allow(Karafka::App).to receive(:quiet!)
+    end
+
+    context 'when already in quiet mode' do
+      let(:new_status) { :quiet! }
+
+      before { allow(Karafka::App).to receive(:stopped?).and_return(false) }
+
+      it do
+        described_class.quiet
+
+        expect(Karafka::App).not_to have_received(:quiet!)
+      end
+    end
+
+    context 'when stopping' do
+      let(:new_status) { :stop! }
+
+      before { allow(Karafka::App).to receive(:stopped?).and_return(false) }
+
+      it do
+        described_class.quiet
+
+        expect(Karafka::App).not_to have_received(:quiet!)
+      end
+    end
+
+    context 'when running' do
+      let(:new_status) { :run! }
+
+      before do
+        allow(Karafka::App).to receive(:stopped?).and_return(false)
+        allow(Karafka::App).to receive(:stopping?).and_return(false)
+      end
+
+      it do
+        described_class.quiet
+
+        expect(Karafka::App).to have_received(:quiet!)
+      end
+    end
+
+    context 'when stopped' do
+      let(:new_status) { :stopped! }
+
+      it do
+        described_class.quiet
+
+        expect(Karafka::App).not_to have_received(:quiet!)
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,8 @@ SimpleCov.start do
   merge_timeout 3600
 end
 
-SimpleCov.minimum_coverage(94)
+# Require total coverage after running both regular and pro
+SimpleCov.minimum_coverage(94) if ENV.fetch('SPECS_TYPE', 'pro')
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"]
   .sort

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
   require lib
 end
 
+# Are we running regular specs or pro specs
 SPECS_TYPE = ENV.fetch('SPECS_TYPE', 'default')
 
 # Don't include unnecessary stuff into rcov

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,8 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
   require lib
 end
 
+SPECS_TYPE = ENV.fetch('SPECS_TYPE', 'default')
+
 # Don't include unnecessary stuff into rcov
 SimpleCov.start do
   add_filter '/vendor/'
@@ -28,12 +30,12 @@ SimpleCov.start do
   add_filter '/processing/strategies'
 
   # enable_coverage :branch
-  command_name ENV.fetch('SPECS_TYPE', 'default')
+  command_name SPECS_TYPE
   merge_timeout 3600
 end
 
 # Require total coverage after running both regular and pro
-SimpleCov.minimum_coverage(94) if ENV.fetch('SPECS_TYPE', 'pro')
+SimpleCov.minimum_coverage(94) if SPECS_TYPE == 'pro'
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"]
   .sort


### PR DESCRIPTION
This PR detects the license gem and loads the pro components so they can be used as base for custom components.
It also fixes a case where custom pro components would be replaces by default pro components upon config.

It also reorganizes how we load pro in specs and adds specs to check actual integration with the license gem.

close https://github.com/karafka/karafka/issues/1189
close https://github.com/karafka/karafka/issues/1188