### PR TITLE
Move consumption to strategies

### DIFF
--- a/lib/karafka/pro/processing/strategies/default.rb
+++ b/lib/karafka/pro/processing/strategies/default.rb
@@ -22,6 +22,7 @@ module Karafka
         # Nothing. Just standard, automatic flow
         module Default
           include Base
+          include ::Karafka::Processing::Strategies::Default
 
           # Apply strategy for a non-feature based flow
           FEATURES = %i[].freeze

--- a/lib/karafka/processing/strategies/base.rb
+++ b/lib/karafka/processing/strategies/base.rb
@@ -22,6 +22,11 @@ module Karafka
           raise NotImplementedError, 'Implement in a subclass'
         end
 
+        # What should happen in the processing
+        def handle_consume
+          raise NotImplementedError, 'Implement in a subclass'
+        end
+
         # Post-consumption handling
         def handle_after_consume
           raise NotImplementedError, 'Implement in a subclass'


### PR DESCRIPTION
This PR moves the consume handler to strategies so we can customize this for LRJ and others when needed.