### PR TITLE
FIX: Link for Dead Letter Queue in Readme is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Karafka is a Ruby and Rails multi-threaded efficient Kafka processing framework 
 - Supports parallel processing in [multiple threads](https://karafka.io/docs/Concurrency-and-multithreading) (also for a [single topic partition](https://karafka.io/docs/Pro-Virtual-Partitions) work)
 - [Automatically integrates](https://karafka.io/docs/Integrating-with-Ruby-on-Rails-and-other-frameworks#integrating-with-ruby-on-rails) with Ruby on Rails
 - Has [ActiveJob backend](https://karafka.io/docs/Active-Job) support (including [ordered jobs](https://karafka.io/docs/Pro-Enhanced-Active-Job#ordered-jobs))
-- Has a seamless [Dead Letter Queue](karafka.io/docs/Dead-Letter-Queue/) functionality built-in
+- Has a seamless [Dead Letter Queue](https://karafka.io/docs/Dead-Letter-Queue/) functionality built-in
 - Supports in-development [code reloading](https://karafka.io/docs/Auto-reload-of-code-changes-in-development)
 - Is powered by [librdkafka](https://github.com/edenhill/librdkafka) (the Apache Kafka C/C++ client library)
 - Has an out-of the box [StatsD/DataDog monitoring](https://karafka.io/docs/Monitoring-and-logging) with a dashboard template.


### PR DESCRIPTION
Readme link is pointing to [](https://github.com/karafka/karafka/blob/master/karafka.io/docs/Dead-Letter-Queue) instead of [](https://karafka.io/docs/Dead-Letter-Queue/)

**Before:**
<img width="1510" alt="Screenshot 2022-11-29 at 16 41 43" src="https://user-images.githubusercontent.com/5869653/204574795-a6aa9f05-64a0-4bbd-8a40-5ab935e8bc77.png">

**After:**
<img width="1512" alt="Screenshot 2022-11-29 at 16 43 09" src="https://user-images.githubusercontent.com/5869653/204575132-d2d485c1-e3ce-4184-9c95-60573f5742ff.png">
