### PR TITLE
add id to consumers and expand stdout listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 - [Improvement] Add instrumentation upon `#pause`.
 - [Improvement] Add instrumentation upon retries.
+- [Improvement] Assign `#id` to consumers similar to other entities for ease of debugging.
+- [Improvement] Add retries and pausing to the default `LoggerListener`.
 
 ## 2.0.23 (2022-12-07)
 - [Maintenance] Align with `waterdrop` and `karafka-core`

--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -4,6 +4,8 @@
 module Karafka
   # Base consumer from which all Karafka consumers should inherit
   class BaseConsumer
+    # @return [String] id of the current consumer
+    attr_reader :id
     # @return [Karafka::Routing::Topic] topic to which a given consumer is subscribed
     attr_accessor :topic
     # @return [Karafka::Messages::Messages] current messages batch
@@ -14,6 +16,11 @@ module Karafka
     attr_accessor :coordinator
     # @return [Waterdrop::Producer] producer instance
     attr_accessor :producer
+
+    # Creates new consumer and assigns it an id
+    def initialize
+      @id = SecureRandom.hex(6)
+    end
 
     # Can be used to run preparation code prior to the job being enqueued
     #

--- a/lib/karafka/instrumentation/logger_listener.rb
+++ b/lib/karafka/instrumentation/logger_listener.rb
@@ -63,7 +63,9 @@ module Karafka
         info "[#{job.id}] #{job_type} job for #{consumer} on #{topic} finished in #{time}ms"
       end
 
-      # Prints info about a pause occurrence. Irrelevant if user or system initiatied.
+      # Prints info about a pause occurrence. Irrelevant if user or system initiated.
+      #
+      # @param event [Karafka::Core::Monitoring::Event] event details including payload
       def on_consumer_consuming_pause(event)
         topic = event[:topic]
         partition = event[:partition]
@@ -71,7 +73,7 @@ module Karafka
         consumer = event[:caller]
         timeout = event[:timeout]
 
-        info <<~MSG.gsub!("\n", ' ').strip
+        info <<~MSG.tr!("\n", ' ').strip
           [#{consumer.id}] Pausing partition #{partition} of topic #{topic}
           on offset #{offset} for #{timeout} ms.
         MSG
@@ -87,9 +89,9 @@ module Karafka
         consumer = event[:caller]
         timeout = event[:timeout]
 
-        info <<~MSG.gsub!("\n", ' ').strip
+        info <<~MSG.tr!("\n", ' ').strip
           [#{consumer.id}] Retrying of #{consumer.class} after #{timeout} ms
-          on topic #{topic} from offset #{offset}
+          on partition #{partition} of topic #{topic} from offset #{offset}
         MSG
       end
 

--- a/lib/karafka/instrumentation/logger_listener.rb
+++ b/lib/karafka/instrumentation/logger_listener.rb
@@ -63,6 +63,36 @@ module Karafka
         info "[#{job.id}] #{job_type} job for #{consumer} on #{topic} finished in #{time}ms"
       end
 
+      # Prints info about a pause occurrence. Irrelevant if user or system initiatied.
+      def on_consumer_consuming_pause(event)
+        topic = event[:topic]
+        partition = event[:partition]
+        offset = event[:offset]
+        consumer = event[:caller]
+        timeout = event[:timeout]
+
+        info <<~MSG.gsub!("\n", ' ').strip
+          [#{consumer.id}] Pausing partition #{partition} of topic #{topic}
+          on offset #{offset} for #{timeout} ms.
+        MSG
+      end
+
+      # Prints info about retry of processing after an error
+      #
+      # @param event [Karafka::Core::Monitoring::Event] event details including payload
+      def on_consumer_consuming_retry(event)
+        topic = event[:topic]
+        partition = event[:partition]
+        offset = event[:offset]
+        consumer = event[:caller]
+        timeout = event[:timeout]
+
+        info <<~MSG.gsub!("\n", ' ').strip
+          [#{consumer.id}] Retrying of #{consumer.class} after #{timeout} ms
+          on topic #{topic} from offset #{offset}
+        MSG
+      end
+
       # Logs info about system signals that Karafka received and prints backtrace for threads in
       # case of ttin
       #

--- a/lib/karafka/instrumentation/logger_listener.rb
+++ b/lib/karafka/instrumentation/logger_listener.rb
@@ -73,7 +73,7 @@ module Karafka
         consumer = event[:caller]
         timeout = event[:timeout]
 
-        info <<~MSG.tr!("\n", ' ').strip
+        info <<~MSG.tr("\n", ' ').strip!
           [#{consumer.id}] Pausing partition #{partition} of topic #{topic}
           on offset #{offset} for #{timeout} ms.
         MSG
@@ -89,7 +89,7 @@ module Karafka
         consumer = event[:caller]
         timeout = event[:timeout]
 
-        info <<~MSG.tr!("\n", ' ').strip
+        info <<~MSG.tr("\n", ' ').strip!
           [#{consumer.id}] Retrying of #{consumer.class} after #{timeout} ms
           on partition #{partition} of topic #{topic} from offset #{offset}
         MSG

--- a/spec/lib/karafka/instrumentation/logger_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/logger_listener_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe_current do
 
     let(:consumer) { Class.new(Karafka::BaseConsumer).new }
     let(:message) do
-      <<~MSG.tr!("\n", ' ').strip
+      <<~MSG.tr("\n", ' ').strip
         [#{consumer.id}] Retrying of #{consumer.class} after 100 ms on partition 0
         of topic Topic from offset 12
       MSG

--- a/spec/lib/karafka/instrumentation/logger_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/logger_listener_spec.rb
@@ -73,6 +73,44 @@ RSpec.describe_current do
     it { expect(Karafka.logger).to have_received(:info) }
   end
 
+  describe '#on_consumer_consuming_pause' do
+    subject(:trigger) { listener.on_consumer_consuming_pause(event) }
+
+    let(:message) { "[#{consumer.id}] Pausing partition 0 of topic Topic on offset 12 for 100 ms." }
+    let(:consumer) { Class.new(Karafka::BaseConsumer).new }
+    let(:payload) do
+      {
+        caller: consumer,
+        topic: 'Topic',
+        partition: 0,
+        offset: 12,
+        timeout: 100
+      }
+    end
+
+    it { expect(Karafka.logger).to have_received(:info).with(message) }
+  end
+
+  describe '#on_consumer_consuming_retry' do
+    subject(:trigger) { listener.on_consumer_consuming_retry(event) }
+
+    let(:consumer) { Class.new(Karafka::BaseConsumer).new }
+    let(:message) do
+      "[#{consumer.id}] Retrying of #{consumer.class} after 100 ms on topic Topic from offset 12"
+    end
+    let(:payload) do
+      {
+        caller: consumer,
+        topic: 'Topic',
+        partition: 0,
+        offset: 12,
+        timeout: 100
+      }
+    end
+
+    it { expect(Karafka.logger).to have_received(:info).with(message) }
+  end
+
   describe '#on_process_notice_signal' do
     subject(:trigger) { listener.on_process_notice_signal(event) }
 

--- a/spec/lib/karafka/instrumentation/logger_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/logger_listener_spec.rb
@@ -76,8 +76,10 @@ RSpec.describe_current do
   describe '#on_consumer_consuming_pause' do
     subject(:trigger) { listener.on_consumer_consuming_pause(event) }
 
-    let(:message) { "[#{consumer.id}] Pausing partition 0 of topic Topic on offset 12 for 100 ms." }
     let(:consumer) { Class.new(Karafka::BaseConsumer).new }
+    let(:message) do
+      "[#{consumer.id}] Pausing partition 0 of topic Topic on offset 12 for 100 ms."
+    end
     let(:payload) do
       {
         caller: consumer,
@@ -96,7 +98,10 @@ RSpec.describe_current do
 
     let(:consumer) { Class.new(Karafka::BaseConsumer).new }
     let(:message) do
-      "[#{consumer.id}] Retrying of #{consumer.class} after 100 ms on topic Topic from offset 12"
+      <<~MSG.tr!("\n", ' ').strip
+        [#{consumer.id}] Retrying of #{consumer.class} after 100 ms on partition 0
+        of topic Topic from offset 12
+      MSG
     end
     let(:payload) do
       {


### PR DESCRIPTION
This PR:
- connects previously added instrumentation into stdout listener
- adds the `#id` to consumers similar to other places
