### PR TITLE
Introduce terminated state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - [Improvement] Add instrumentation upon retries.
 - [Improvement] Assign `#id` to consumers similar to other entities for ease of debugging.
 - [Improvement] Add retries and pausing to the default `LoggerListener`.
+- [Improvement] Introduce a new final `terminated` state that will kick in prior to exit but after all the instrumentation and other things are done.
+- [Improvement] Ensure that state transitions are thread-safe and ensure state transitions can occur in one direction.
+- [Fix] Shutdown producer after all the consumer components are down and the status is stopped. This will ensure, that any instrumentation related Kafka messaging can still operate.
 
 ## 2.0.23 (2022-12-07)
 - [Maintenance] Align with `waterdrop` and `karafka-core`

--- a/lib/karafka/instrumentation/notifications.rb
+++ b/lib/karafka/instrumentation/notifications.rb
@@ -22,6 +22,7 @@ module Karafka
         app.quieting
         app.stopping
         app.stopped
+        app.terminated
 
         consumer.consumed
         consumer.consuming.pause

--- a/lib/karafka/server.rb
+++ b/lib/karafka/server.rb
@@ -47,7 +47,7 @@ module Karafka
         # in a separate thread (or trap context) to indicate everything is closed
         # Since `#start` is blocking, we were get here only after the runner is done. This will
         # not add any performance degradation because of that.
-        Thread.pass until Karafka::App.stopped?
+        Thread.pass until Karafka::App.terminated?
       # Try its best to shutdown underlying components before re-raising
       # rubocop:disable Lint/RescueException
       rescue Exception => e
@@ -75,6 +75,7 @@ module Karafka
         # Initialize the stopping process only if Karafka was running
         return if Karafka::App.stopping?
         return if Karafka::App.stopped?
+        return if Karafka::App.terminated?
 
         Karafka::App.stop!
 
@@ -84,13 +85,7 @@ module Karafka
         # their work and if so, we can just return and normal shutdown process will take place
         # We divide it by 1000 because we use time in ms.
         ((timeout / 1_000) * SUPERVISION_CHECK_FACTOR).to_i.times do
-          if listeners.count(&:alive?).zero? &&
-             workers.count(&:alive?).zero?
-
-            Karafka::App.producer.close
-
-            return
-          end
+          return if listeners.count(&:alive?).zero? && workers.count(&:alive?).zero?
 
           sleep SUPERVISION_SLEEP
         end
@@ -122,18 +117,23 @@ module Karafka
       ensure
         # We need to check if it wasn't an early exit to make sure that only on stop invocation
         # can change the status after everything is closed
-        Karafka::App.stopped! if timeout
+        return unless timeout
+
+        Karafka::App.stopped!
+
+        # We close producer as the last thing as it can be used in the notification pipeline
+        # to dispatch state changes, etc
+        Karafka::App.producer.close
+
+        Karafka::App.terminate!
       end
 
       # Quiets the Karafka server.
       # Karafka will stop processing but won't quiet to consumer group, so no rebalance will be
       # triggered until final shutdown.
       def quiet
-        # If we are already quieting or in the stop procedures, we should not do it again.
-        return if Karafka::App.quieting?
-        return if Karafka::App.stopping?
-        return if Karafka::App.stopped?
-
+        # We don't have to safe-guard it with check states as the state transitions work only
+        # in one direction
         Karafka::App.quiet!
       end
 

--- a/lib/karafka/server.rb
+++ b/lib/karafka/server.rb
@@ -117,15 +117,15 @@ module Karafka
       ensure
         # We need to check if it wasn't an early exit to make sure that only on stop invocation
         # can change the status after everything is closed
-        return unless timeout
+        if timeout
+          Karafka::App.stopped!
 
-        Karafka::App.stopped!
+          # We close producer as the last thing as it can be used in the notification pipeline
+          # to dispatch state changes, etc
+          Karafka::App.producer.close
 
-        # We close producer as the last thing as it can be used in the notification pipeline
-        # to dispatch state changes, etc
-        Karafka::App.producer.close
-
-        Karafka::App.terminate!
+          Karafka::App.terminate!
+        end
       end
 
       # Quiets the Karafka server.

--- a/lib/karafka/status.rb
+++ b/lib/karafka/status.rb
@@ -14,11 +14,10 @@ module Karafka
       terminated: :terminate!
     }.freeze
 
-    private_constant :STATES
-
+    # Mutex to ensure that state transitions are thread-safe
     MUTEX = Mutex.new
 
-    private_constant :MUTEX
+    private_constant :STATES, :MUTEX
 
     # By default we are in the initializing state
     def initialize

--- a/lib/karafka/status.rb
+++ b/lib/karafka/status.rb
@@ -10,14 +10,25 @@ module Karafka
       running: :run!,
       quieting: :quiet!,
       stopping: :stop!,
-      stopped: :stopped!
+      stopped: :stopped!,
+      terminated: :terminate!
     }.freeze
 
     private_constant :STATES
 
+    MUTEX = Mutex.new
+
+    private_constant :MUTEX
+
     # By default we are in the initializing state
     def initialize
       initialize!
+    end
+
+    # Resets the status state
+    # This is used mostly in the integration suite
+    def reset!
+      @status = :initializing
     end
 
     STATES.each do |state, transition|
@@ -26,16 +37,19 @@ module Karafka
       end
 
       define_method transition do
-        # Do nothing if the state change would change nothing (same state)
-        return if @status == state
+        MUTEX.synchronize do
+          # Do not allow reverse state transitions (we always go one way) or transition to the same
+          # state as currently
+          return if @status && STATES.keys.index(state) <= STATES.keys.index(@status)
 
-        @status = state
+          @status = state
 
-        # Skip on creation (initializing)
-        # We skip as during this state we do not have yet a monitor
-        return if initializing?
+          # Skip on creation (initializing)
+          # We skip as during this state we do not have yet a monitor
+          return if initializing?
 
-        Karafka.monitor.instrument("app.#{state}")
+          Karafka.monitor.instrument("app.#{state}")
+        end
       end
     end
   end

--- a/spec/integrations/consumption/removing_a_topic_should_still_consume_rest_spec.rb
+++ b/spec/integrations/consumption/removing_a_topic_should_still_consume_rest_spec.rb
@@ -39,7 +39,7 @@ elements2 = DT.uuids(10)
 produce_many(DT.topics.first, elements1)
 produce_many(DT.topics.last, elements2)
 
-start_karafka_and_wait_until do
+start_karafka_and_wait_until(reset_status: true) do
   DT[0].size >= 10 &&
     DT[1].size >= 10
 end
@@ -69,7 +69,7 @@ elements2.each do |data|
   producer.produce_sync(topic: DT.topics.last, payload: data)
 end
 
-start_karafka_and_wait_until do
+start_karafka_and_wait_until(reset_status: true) do
   DT[1].size >= 20
 end
 

--- a/spec/integrations/pro/rebalancing/with_static_membership_reconnect_spec.rb
+++ b/spec/integrations/pro/rebalancing/with_static_membership_reconnect_spec.rb
@@ -78,7 +78,7 @@ end
 # Give it some time to start before starting Karafka main process
 sleep 5
 
-start_karafka_and_wait_until do
+start_karafka_and_wait_until(reset_status: true) do
   DT[:process2].size >= 20
 end
 
@@ -87,7 +87,7 @@ sleep 5
 
 # After stopping start once again
 
-start_karafka_and_wait_until do
+start_karafka_and_wait_until(reset_status: true) do
   DT[:process2].size >= 100
 end
 

--- a/spec/integrations/rebalancing/with_static_membership_reconnect_spec.rb
+++ b/spec/integrations/rebalancing/with_static_membership_reconnect_spec.rb
@@ -78,7 +78,7 @@ end
 # Give it some time to start before starting Karafka main process
 sleep 5
 
-start_karafka_and_wait_until do
+start_karafka_and_wait_until(reset_status: true) do
   DT[:process2].size >= 20
 end
 
@@ -87,7 +87,7 @@ sleep 5
 
 # After stopping start once again
 
-start_karafka_and_wait_until do
+start_karafka_and_wait_until(reset_status: true) do
   DT[:process2].size >= 100
 end
 

--- a/spec/integrations/rebalancing/without_using_revoked_partition_data_spec.rb
+++ b/spec/integrations/rebalancing/without_using_revoked_partition_data_spec.rb
@@ -70,7 +70,7 @@ other = Thread.new do
     DT[:process2] << message
 
     # We wait for the main Karafka process to stop, so data is not skewed by second rebalance
-    sleep(0.1) until Karafka::App.stopped?
+    sleep(0.1) until Karafka::App.terminated?
 
     break
   end

--- a/spec/integrations_helper.rb
+++ b/spec/integrations_helper.rb
@@ -223,10 +223,17 @@ def wait_until
 end
 
 # Starts Karafka and waits until the block evaluates to true. Then it stops Karafka.
-def start_karafka_and_wait_until(&block)
+# @param reset_status [Boolean] should we reset the server status to initializing after the
+#   shutdown. This allows us to run server multiple times in the same process, making some
+#   integration specs much easier to run
+def start_karafka_and_wait_until(reset_status: false, &block)
   Thread.new { wait_until(&block) }
 
   Karafka::Server.run
+
+  return unless reset_status
+
+  Karafka::App.config.internal.status.reset!
 end
 
 # Sends data to Kafka in a sync way

--- a/spec/lib/karafka/server_spec.rb
+++ b/spec/lib/karafka/server_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe_current do
   before do
     allow(Karafka::App).to receive(:run!)
     allow(Karafka::App).to receive(:stopped?).and_return(true)
+    allow(Karafka::App).to receive(:terminated?).and_return(true)
     allow(Karafka::App).to receive(:subscription_groups).and_return({ 1 => 1 })
     # Do not close the real producer as we use it in specs
     allow(Karafka::App.producer).to receive(:close)
@@ -128,6 +129,7 @@ RSpec.describe_current do
 
       before do
         allow(Karafka::App).to receive(:stopped?).and_return(false)
+        allow(Karafka::App).to receive(:terminated?).and_return(false)
         allow(Karafka::App).to receive(:stop!)
         allow(described_class).to receive(:sleep)
         allow(Kernel).to receive(:exit!)
@@ -229,18 +231,6 @@ RSpec.describe_current do
 
     after { Karafka::App.initialized! }
 
-    context 'when already in quiet mode' do
-      let(:new_status) { :quiet! }
-
-      before { allow(Karafka::App).to receive(:stopped?).and_return(false) }
-
-      it do
-        described_class.quiet
-
-        expect(Karafka::App).not_to have_received(:quiet!)
-      end
-    end
-
     context 'when stopping' do
       let(:new_status) { :stop! }
 
@@ -249,7 +239,7 @@ RSpec.describe_current do
       it do
         described_class.quiet
 
-        expect(Karafka::App).not_to have_received(:quiet!)
+        expect(Karafka::App).to have_received(:quiet!)
       end
     end
 
@@ -275,7 +265,7 @@ RSpec.describe_current do
       it do
         described_class.quiet
 
-        expect(Karafka::App).not_to have_received(:quiet!)
+        expect(Karafka::App).to have_received(:quiet!)
       end
     end
   end

--- a/spec/lib/karafka/status_spec.rb
+++ b/spec/lib/karafka/status_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe_current do
   subject(:status_manager) { described_class.new }
 
-  let(:status) { rand }
+  let(:status) { :initializing }
 
   before { status_manager.instance_variable_set(:'@status', status) }
 
@@ -12,7 +12,8 @@ RSpec.describe_current do
     it { expect(status_manager.running?).to eq false }
     it { expect(status_manager.stopping?).to eq false }
     it { expect(status_manager.stopped?).to eq false }
-    it { expect(status_manager.initializing?).to eq false }
+    it { expect(status_manager.initializing?).to eq true }
+    it { expect(status_manager.terminated?).to eq false }
   end
 
   describe 'running?' do
@@ -25,6 +26,7 @@ RSpec.describe_current do
 
       it { expect(status_manager.initialized?).to eq false }
       it { expect(status_manager.running?).to eq true }
+      it { expect(status_manager.terminated?).to eq false }
     end
   end
 
@@ -37,6 +39,7 @@ RSpec.describe_current do
       it { expect(status_manager.initialized?).to eq false }
       it { expect(status_manager.stopping?).to eq false }
       it { expect(status_manager.stopped?).to eq false }
+      it { expect(status_manager.terminated?).to eq false }
     end
   end
 
@@ -49,6 +52,7 @@ RSpec.describe_current do
       it { expect(status_manager.initialized?).to eq false }
       it { expect(status_manager.stopping?).to eq false }
       it { expect(status_manager.stopped?).to eq false }
+      it { expect(status_manager.terminated?).to eq false }
     end
 
     context 'when status is set to stopping' do
@@ -59,6 +63,7 @@ RSpec.describe_current do
       it { expect(status_manager.initialized?).to eq false }
       it { expect(status_manager.stopping?).to eq true }
       it { expect(status_manager.stopped?).to eq false }
+      it { expect(status_manager.terminated?).to eq false }
     end
   end
 
@@ -74,6 +79,7 @@ RSpec.describe_current do
       it { expect(status_manager.initialized?).to eq false }
       it { expect(status_manager.stopping?).to eq true }
       it { expect(status_manager.stopped?).to eq false }
+      it { expect(status_manager.terminated?).to eq false }
     end
   end
 
@@ -90,12 +96,14 @@ RSpec.describe_current do
       it { expect(status_manager.initialized?).to eq false }
       it { expect(status_manager.stopping?).to eq false }
       it { expect(status_manager.stopped?).to eq true }
+      it { expect(status_manager.terminated?).to eq false }
     end
   end
 
   describe 'initializing?' do
     context 'when status is not set to initializing' do
-      it { expect(status_manager.initializing?).to eq false }
+      it { expect(status_manager.initializing?).to eq true }
+      it { expect(status_manager.terminated?).to eq false }
     end
 
     context 'when status is set to initializing' do
@@ -103,6 +111,7 @@ RSpec.describe_current do
 
       it { expect(status_manager.initializing?).to eq true }
       it { expect(status_manager.initialized?).to eq false }
+      it { expect(status_manager.terminated?).to eq false }
     end
   end
 
@@ -115,6 +124,7 @@ RSpec.describe_current do
       it { expect(status_manager.running?).to eq false }
       it { expect(status_manager.initializing?).to eq true }
       it { expect(status_manager.stopping?).to eq false }
+      it { expect(status_manager.terminated?).to eq false }
     end
   end
 
@@ -128,6 +138,22 @@ RSpec.describe_current do
       it { expect(status_manager.running?).to eq false }
       it { expect(status_manager.initializing?).to eq false }
       it { expect(status_manager.stopping?).to eq false }
+      it { expect(status_manager.terminated?).to eq false }
+    end
+  end
+
+  describe '#reset!' do
+    context 'when we reset!' do
+      before do
+        status_manager.initialized!
+        status_manager.reset!
+      end
+
+      it { expect(status_manager.initialized?).to eq false }
+      it { expect(status_manager.running?).to eq false }
+      it { expect(status_manager.initializing?).to eq true }
+      it { expect(status_manager.stopping?).to eq false }
+      it { expect(status_manager.terminated?).to eq false }
     end
   end
 end


### PR DESCRIPTION
This PR introduces `terminated` state to differentiate between the stopped (no consumption, no connections via listeners, etc) and the last step, which is termination (exit).

The distinction is needed because we need to be able to instrument on stopped in the web UI and via listeners. `terminated` will run right after exit.