### PR TITLE
use shorter ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 - [Improvement] Introduce a new final `terminated` state that will kick in prior to exit but after all the instrumentation and other things are done.
 - [Improvement] Ensure that state transitions are thread-safe and ensure state transitions can occur in one direction.
 - [Improvement] Optimize status methods proxying to `Karafka::App`.
-- [Improvement] Allow for easier state usage by introducing explicit `#to_s` for reporting. 
+- [Improvement] Allow for easier state usage by introducing explicit `#to_s` for reporting.
+- [Improvement] Change auto-generated id from `SecureRandom#uuid` to `SecureRandom#hex(6)`
 - [Fix] Shutdown producer after all the consumer components are down and the status is stopped. This will ensure, that any instrumentation related Kafka messaging can still operate.
 
 ## 2.0.23 (2022-12-07)

--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ Karafka.producer.produce_sync(topic: 'example', payload: { 'ping' => 'pong' }.to
 ```bash
 bundle exec karafka server
 
-[7616dc24-505a-417f-b87b-6bf8fc2d98c5] Polled 1 message in 1000ms
-[dcf3a8d8-0bd9-433a-8f63-b70a0cdb0732] Consume job for ExampleConsumer on example started
+[86d47f0b92f7] Polled 1 message in 1000ms
+[3732873c8a74] Consume job for ExampleConsumer on example started
 {"ping"=>"pong"}
-[dcf3a8d8-0bd9-433a-8f63-b70a0cdb0732] Consume job for ExampleConsumer on example finished in 0ms
+[3732873c8a74] Consume job for ExampleConsumer on example finished in 0ms
 ```
 
 ## Want to Upgrade? LGPL is not for you? Want to help?

--- a/lib/karafka/connection/listener.rb
+++ b/lib/karafka/connection/listener.rb
@@ -21,7 +21,7 @@ module Karafka
       def initialize(consumer_group_coordinator, subscription_group, jobs_queue)
         proc_config = ::Karafka::App.config.internal.processing
 
-        @id = SecureRandom.uuid
+        @id = SecureRandom.hex(6)
         @consumer_group_coordinator = consumer_group_coordinator
         @subscription_group = subscription_group
         @jobs_queue = jobs_queue

--- a/lib/karafka/processing/executor.rb
+++ b/lib/karafka/processing/executor.rb
@@ -31,7 +31,7 @@ module Karafka
       # @param client [Karafka::Connection::Client] kafka client
       # @param topic [Karafka::Routing::Topic] topic for which this executor will run
       def initialize(group_id, client, topic)
-        @id = SecureRandom.uuid
+        @id = SecureRandom.hex(6)
         @group_id = group_id
         @client = client
         @topic = topic

--- a/lib/karafka/processing/worker.rb
+++ b/lib/karafka/processing/worker.rb
@@ -25,7 +25,7 @@ module Karafka
       # @param jobs_queue [JobsQueue]
       # @return [Worker]
       def initialize(jobs_queue)
-        @id = SecureRandom.uuid
+        @id = SecureRandom.hex(6)
         @jobs_queue = jobs_queue
       end
 

--- a/lib/karafka/routing/builder.rb
+++ b/lib/karafka/routing/builder.rb
@@ -80,7 +80,7 @@ module Karafka
       # @param subscription_group_name [String, Symbol] subscription group id. When not provided,
       #   a random uuid will be used
       # @param block [Proc] further topics definitions
-      def subscription_group(subscription_group_name = SecureRandom.uuid, &block)
+      def subscription_group(subscription_group_name = SecureRandom.hex(6), &block)
         consumer_group('app') do
           target.public_send(:subscription_group=, subscription_group_name.to_s, &block)
         end

--- a/lib/karafka/routing/consumer_group.rb
+++ b/lib/karafka/routing/consumer_group.rb
@@ -26,7 +26,7 @@ module Karafka
         @topics = Topics.new([])
         # Initialize the subscription group so there's always a value for it, since even if not
         # defined directly, a subscription group will be created
-        @current_subscription_group_id = SecureRandom.uuid
+        @current_subscription_group_id = SecureRandom.hex(6)
       end
 
       # @return [Boolean] true if this consumer group should be active in our current process
@@ -55,7 +55,7 @@ module Karafka
       # topic definition
       # @param name [String, Symbol] name of the current subscription group
       # @param block [Proc] block that may include topics definitions
-      def subscription_group=(name = SecureRandom.uuid, &block)
+      def subscription_group=(name = SecureRandom.hex(6), &block)
         # We cast it here, so the routing supports symbol based but that's anyhow later on
         # validated as a string
         @current_subscription_group_id = name
@@ -64,7 +64,7 @@ module Karafka
 
         # We need to reset the current subscription group after it is used, so it won't leak
         # outside to other topics that would be defined without a defined subscription group
-        @current_subscription_group_id = SecureRandom.uuid
+        @current_subscription_group_id = SecureRandom.hex(6)
       end
 
       # @return [Array<Routing::SubscriptionGroup>] all the subscription groups build based on

--- a/spec/benchmarks_helper.rb
+++ b/spec/benchmarks_helper.rb
@@ -12,7 +12,7 @@ $stdout.sync = true
 def setup_karafka
   Karafka::App.setup do |config|
     # Use some decent defaults
-    caller_id = [caller_locations(1..1).first.path.split('/').last, SecureRandom.uuid].join('-')
+    caller_id = [caller_locations(1..1).first.path.split('/').last, SecureRandom.hex(6)].join('-')
 
     config.kafka = { 'bootstrap.servers': '127.0.0.1:9092' }
     config.client_id = caller_id

--- a/spec/integrations/consumption/one_consumer_group_two_topics_spec.rb
+++ b/spec/integrations/consumption/one_consumer_group_two_topics_spec.rb
@@ -6,8 +6,8 @@ setup_karafka
 
 topic1 = DT.topics[0]
 topic2 = DT.topics[1]
-topic1_data = Array.new(10) { { SecureRandom.uuid => rand.to_s } }
-topic2_data = Array.new(10) { { SecureRandom.uuid => rand.to_s } }
+topic1_data = Array.new(10) { { SecureRandom.hex(6) => rand.to_s } }
+topic2_data = Array.new(10) { { SecureRandom.hex(6) => rand.to_s } }
 
 class Consumer1 < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/consumption/strategies/default/constant_error_should_not_clog_others_spec.rb
+++ b/spec/integrations/consumption/strategies/default/constant_error_should_not_clog_others_spec.rb
@@ -15,7 +15,7 @@ create_topic(partitions: 3)
 # 300 messages to consume tops from all 3 partitions
 # There can be more if we run this in development several times
 300.times do |i|
-  result = produce(DT.topic, SecureRandom.uuid, partition: i % 3)
+  result = produce(DT.topic, SecureRandom.hex(6), partition: i % 3)
   DT[:last_offsets][result.partition] = result.offset
 end
 

--- a/spec/integrations/consumption/strategies/default/of_many_partitions_with_error_spec.rb
+++ b/spec/integrations/consumption/strategies/default/of_many_partitions_with_error_spec.rb
@@ -46,7 +46,7 @@ Thread.new { Karafka::Server.run }
 # Give it some time to boot and connect before dispatching messages
 sleep(5)
 
-10.times { |i| produce(DT.topic, SecureRandom.uuid, partition: i) }
+10.times { |i| produce(DT.topic, SecureRandom.hex(6), partition: i) }
 
 wait_until do
   DT.data.values.flatten.size >= 11

--- a/spec/integrations/consumption/strategies/default/of_many_partitions_with_many_workers_spec.rb
+++ b/spec/integrations/consumption/strategies/default/of_many_partitions_with_many_workers_spec.rb
@@ -42,7 +42,7 @@ sleep(5)
 
 # We send only one message to each topic partition, so when messages are consumed, it forces them
 # to be in separate worker threads
-10.times { |i| produce(DT.topic, SecureRandom.uuid, partition: i) }
+10.times { |i| produce(DT.topic, SecureRandom.hex(6), partition: i) }
 
 wait_until do
   DT.data.values.flatten.size >= 10

--- a/spec/integrations/consumption/strategies/dlq/with_non_recoverable_last_message_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/with_non_recoverable_last_message_spec.rb
@@ -49,7 +49,7 @@ start_karafka_and_wait_until do
   # Send one more when we reached all
   if DT[:offsets].uniq.count == 99 && DT[:extra].empty?
     DT[:extra] << true
-    produce(DT.topic, SecureRandom.uuid)
+    produce(DT.topic, SecureRandom.hex(6))
   end
 
   DT[:offsets].uniq.count >= 100 &&

--- a/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_last_message_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_last_message_spec.rb
@@ -50,7 +50,7 @@ start_karafka_and_wait_until do
   # Send one more when we reached all
   if DT[:offsets].uniq.count == 99 && DT[:extra].empty?
     DT[:extra] << true
-    produce(DT.topic, SecureRandom.uuid)
+    produce(DT.topic, SecureRandom.hex(6))
   end
 
   DT[:offsets].uniq.count >= 100 &&

--- a/spec/integrations/consumption/two_consumer_groups_one_active_spec.rb
+++ b/spec/integrations/consumption/two_consumer_groups_one_active_spec.rb
@@ -31,7 +31,7 @@ end
 # Listen only on one consumer group
 Karafka::App.config.internal.routing.active.consumer_groups = [DT.consumer_groups.first]
 
-jsons = Array.new(10) { { SecureRandom.uuid => rand.to_s } }
+jsons = Array.new(10) { { SecureRandom.hex(6) => rand.to_s } }
 
 # We send same messages to both topics, but except only one to run and consume
 jsons.each do |data|

--- a/spec/integrations/consumption/two_consumer_groups_same_topic_spec.rb
+++ b/spec/integrations/consumption/two_consumer_groups_same_topic_spec.rb
@@ -27,7 +27,7 @@ draw_routes do
   end
 end
 
-jsons = Array.new(100) { { SecureRandom.uuid => rand.to_s } }
+jsons = Array.new(100) { { SecureRandom.hex(6) => rand.to_s } }
 jsons.each { |data| produce(DT.topic, data.to_json) }
 
 start_karafka_and_wait_until do

--- a/spec/integrations/consumption/with_mixed_performance_in_subscription_group_spec.rb
+++ b/spec/integrations/consumption/with_mixed_performance_in_subscription_group_spec.rb
@@ -32,7 +32,7 @@ end
 
 draw_routes do
   DT.topics.first(10).each_slice(2) do |topics|
-    slice_uuid = SecureRandom.uuid
+    slice_uuid = SecureRandom.hex(6)
 
     subscription_group slice_uuid do
       topics.each do |topic_name|

--- a/spec/integrations/consumption/with_mixed_subscription_groups_spec.rb
+++ b/spec/integrations/consumption/with_mixed_subscription_groups_spec.rb
@@ -15,7 +15,7 @@ end
 
 draw_routes do
   DT.topics.first(10).each_slice(2) do |topics|
-    slice_uuid = SecureRandom.uuid
+    slice_uuid = SecureRandom.hex(6)
 
     subscription_group slice_uuid do
       topics.each do |topic_name|

--- a/spec/integrations/consumption/with_static_group_of_many_subscriptions_spec.rb
+++ b/spec/integrations/consumption/with_static_group_of_many_subscriptions_spec.rb
@@ -4,7 +4,7 @@
 # This requires us to inject extra postfix to group id per client and should happen automatically.
 
 setup_karafka do |config|
-  config.kafka[:'group.instance.id'] = SecureRandom.uuid
+  config.kafka[:'group.instance.id'] = SecureRandom.hex(6)
 end
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/deserialization/default_deserializer_usage_spec.rb
+++ b/spec/integrations/deserialization/default_deserializer_usage_spec.rb
@@ -4,7 +4,7 @@
 
 setup_karafka
 
-jsons = Array.new(100) { { SecureRandom.uuid => rand.to_s } }
+jsons = Array.new(100) { { SecureRandom.hex(6) => rand.to_s } }
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/embedding/puma_poro/config/puma.rb
+++ b/spec/integrations/embedding/puma_poro/config/puma.rb
@@ -3,7 +3,7 @@
 require 'karafka'
 require 'securerandom'
 
-TOPIC = SecureRandom.uuid
+TOPIC = SecureRandom.hex(6)
 PID = Process.pid
 
 workers 1
@@ -26,7 +26,7 @@ end
 on_worker_boot do
   ::Karafka::App.setup do |config|
     config.kafka = { 'bootstrap.servers': '127.0.0.1:9092' }
-    config.client_id = SecureRandom.uuid
+    config.client_id = SecureRandom.hex(6)
   end
 
   ::Karafka.producer.produce_sync(topic: TOPIC, payload: 'bye bye')

--- a/spec/integrations/pausing/with_manual_pause_and_other_partitions_working_spec.rb
+++ b/spec/integrations/pausing/with_manual_pause_and_other_partitions_working_spec.rb
@@ -50,7 +50,7 @@ Thread.new do
 
   100.times do
     2.times do |partition|
-      produce(DT.topics[1], SecureRandom.uuid, partition: partition)
+      produce(DT.topics[1], SecureRandom.hex(6), partition: partition)
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/with_non_recoverable_last_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/with_non_recoverable_last_message_spec.rb
@@ -49,7 +49,7 @@ start_karafka_and_wait_until do
   # Send one more when we reached all
   if DT[:offsets].uniq.count == 99 && DT[:extra].empty?
     DT[:extra] << true
-    produce(DT.topic, SecureRandom.uuid)
+    produce(DT.topic, SecureRandom.hex(6))
   end
 
   DT[:offsets].uniq.count >= 100 &&

--- a/spec/integrations/pro/consumption/strategies/dlq_mom/with_non_recoverable_last_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_mom/with_non_recoverable_last_message_spec.rb
@@ -50,7 +50,7 @@ start_karafka_and_wait_until do
   # Send one more when we reached all
   if DT[:offsets].uniq.count == 99 && DT[:extra].empty?
     DT[:extra] << true
-    produce(DT.topic, SecureRandom.uuid)
+    produce(DT.topic, SecureRandom.hex(6))
   end
 
   DT[:offsets].uniq.count >= 100 &&

--- a/spec/integrations/pro/rebalancing/with_static_membership_reconnect_spec.rb
+++ b/spec/integrations/pro/rebalancing/with_static_membership_reconnect_spec.rb
@@ -8,7 +8,7 @@ require 'securerandom'
 
 setup_karafka do |config|
   config.initial_offset = 'latest'
-  config.kafka[:'group.instance.id'] = SecureRandom.uuid
+  config.kafka[:'group.instance.id'] = SecureRandom.hex(6)
 end
 
 create_topic(partitions: 2)
@@ -60,7 +60,7 @@ sleep(2)
 # one partition assigned, so we don't have to worry about figuring out which partition it got
 other = Thread.new do
   consumer = setup_rdkafka_consumer(
-    'group.instance.id': SecureRandom.uuid,
+    'group.instance.id': SecureRandom.hex(6),
     'auto.offset.reset': 'latest'
   )
 

--- a/spec/integrations/rebalancing/with_static_membership_reconnect_spec.rb
+++ b/spec/integrations/rebalancing/with_static_membership_reconnect_spec.rb
@@ -8,7 +8,7 @@ require 'securerandom'
 
 setup_karafka do |config|
   config.initial_offset = 'latest'
-  config.kafka[:'group.instance.id'] = SecureRandom.uuid
+  config.kafka[:'group.instance.id'] = SecureRandom.hex(6)
 end
 
 create_topic(partitions: 2)
@@ -60,7 +60,7 @@ sleep(2)
 # one partition assigned, so we don't have to worry about figuring out which partition it got
 other = Thread.new do
   consumer = setup_rdkafka_consumer(
-    'group.instance.id': SecureRandom.uuid,
+    'group.instance.id': SecureRandom.hex(6),
     'auto.offset.reset': 'latest'
   )
 

--- a/spec/integrations/rebalancing/without_using_revoked_partition_data_spec.rb
+++ b/spec/integrations/rebalancing/without_using_revoked_partition_data_spec.rb
@@ -12,7 +12,7 @@
 
 require 'securerandom'
 
-RUN = SecureRandom.uuid.split('-').first
+RUN = SecureRandom.hex(6).split('-').first
 
 setup_karafka do |config|
   config.max_wait_time = 20_000

--- a/spec/integrations/shutdown/on_shutdown_when_messages_received_spec.rb
+++ b/spec/integrations/shutdown/on_shutdown_when_messages_received_spec.rb
@@ -11,7 +11,7 @@ topic3 = DT.topics[2]
 class Consumer < Karafka::BaseConsumer
   def initialize
     super
-    @id = SecureRandom.uuid
+    @id = SecureRandom.hex(6)
   end
 
   def consume

--- a/spec/integrations_helper.rb
+++ b/spec/integrations_helper.rb
@@ -36,7 +36,7 @@ def setup_karafka(
 
   Karafka::App.setup do |config|
     # Use some decent defaults
-    caller_id = [caller_locations(1..1).first.path.split('/').last, SecureRandom.uuid].join('-')
+    caller_id = [caller_locations(1..1).first.path.split('/').last, SecureRandom.hex(6)].join('-')
 
     config.kafka = {
       'bootstrap.servers': '127.0.0.1:9092',

--- a/spec/lib/karafka/connection/client_spec.rb
+++ b/spec/lib/karafka/connection/client_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe_current do
   let(:subscription_group) { build(:routing_subscription_group) }
 
   describe '#name' do
-    let(:client_id) { SecureRandom.uuid }
+    let(:client_id) { SecureRandom.hex(6) }
     let(:start_nr) { client.name.split('-').last.to_i }
 
     before { Karafka::App.config.client_id = client_id }

--- a/spec/lib/karafka/contracts/topic_spec.rb
+++ b/spec/lib/karafka/contracts/topic_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe_current do
       max_messages: 10,
       max_wait_time: 10_000,
       initial_offset: 'earliest',
-      subscription_group: SecureRandom.uuid
+      subscription_group: SecureRandom.hex(6)
     }
   end
 

--- a/spec/lib/karafka/instrumentation/callbacks/error_spec.rb
+++ b/spec/lib/karafka/instrumentation/callbacks/error_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe_current do
     )
   end
 
-  let(:subscription_group_id) { SecureRandom.uuid }
-  let(:consumer_group_id) { SecureRandom.uuid }
-  let(:client_name) { SecureRandom.uuid }
+  let(:subscription_group_id) { SecureRandom.hex(6) }
+  let(:consumer_group_id) { SecureRandom.hex(6) }
+  let(:client_name) { SecureRandom.hex(6) }
   let(:monitor) { ::Karafka::Instrumentation::Monitor.new }
   let(:error) { ::Rdkafka::RdkafkaError.new(1, []) }
 

--- a/spec/lib/karafka/instrumentation/callbacks/statistics_spec.rb
+++ b/spec/lib/karafka/instrumentation/callbacks/statistics_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe_current do
     described_class.new(subscription_group_id, consumer_group_id, client_name, monitor)
   end
 
-  let(:subscription_group_id) { SecureRandom.uuid }
-  let(:consumer_group_id) { SecureRandom.uuid }
-  let(:client_name) { SecureRandom.uuid }
+  let(:subscription_group_id) { SecureRandom.hex(6) }
+  let(:consumer_group_id) { SecureRandom.hex(6) }
+  let(:client_name) { SecureRandom.hex(6) }
   let(:monitor) { ::Karafka::Instrumentation::Monitor.new }
 
   describe '#call' do

--- a/spec/lib/karafka/pro/performance_tracker_spec.rb
+++ b/spec/lib/karafka/pro/performance_tracker_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe_current do
     let(:event) { Karafka::Core::Monitoring::Event.new(rand.to_s, payload) }
 
     context 'when given topic does not exist' do
-      let(:topic) { SecureRandom.uuid }
+      let(:topic) { SecureRandom.hex(6) }
       let(:partition) { 0 }
 
       it { expect(p95).to eq(0) }

--- a/spec/lib/karafka/pro/processing/partitioner_spec.rb
+++ b/spec/lib/karafka/pro/processing/partitioner_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe_current do
       yielded
     end
 
-    before { topic.virtual_partitions(partitioner: ->(_) { SecureRandom.uuid }) }
+    before { topic.virtual_partitions(partitioner: ->(_) { SecureRandom.hex(6) }) }
 
     it 'expect to use all the threads' do
       expect(yielded.map(&:first).sort).to eq((0..4).to_a)

--- a/spec/lib/karafka/processing/executors_buffer_spec.rb
+++ b/spec/lib/karafka/processing/executors_buffer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe_current do
   subject(:buffer) { described_class.new(client, subscription_group) }
 
   let(:client) { instance_double(Karafka::Connection::Client) }
-  let(:group_id) { SecureRandom.uuid }
+  let(:group_id) { SecureRandom.hex(6) }
   let(:topic_name) { 'topic_name1' }
   let(:partition_id) { 0 }
   let(:parallel_key) { 0 }

--- a/spec/lib/karafka/processing/jobs_queue_spec.rb
+++ b/spec/lib/karafka/processing/jobs_queue_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe_current do
     end
 
     context 'when there are no jobs of a given group' do
-      let(:group_id) { SecureRandom.uuid }
+      let(:group_id) { SecureRandom.hex(6) }
 
       it 'expect not to wait' do
         queue.wait(group_id)

--- a/spec/support/data_collector.rb
+++ b/spec/support/data_collector.rb
@@ -63,7 +63,7 @@ class DataCollector
     # @param amount [Integer] number of uuids we want to get
     # @return [Array<String>] array with uuids
     def uuids(amount)
-      Array.new(amount) { SecureRandom.hex(6) }
+      Array.new(amount) { SecureRandom.uuid }
     end
 
     # Removes all the data from the collector

--- a/spec/support/data_collector.rb
+++ b/spec/support/data_collector.rb
@@ -63,7 +63,7 @@ class DataCollector
     # @param amount [Integer] number of uuids we want to get
     # @return [Array<String>] array with uuids
     def uuids(amount)
-      Array.new(amount) { SecureRandom.uuid }
+      Array.new(amount) { SecureRandom.hex(6) }
     end
 
     # Removes all the data from the collector
@@ -88,7 +88,7 @@ class DataCollector
   # Creates a collector
   def initialize
     @mutex = Mutex.new
-    @topics = Concurrent::Array.new(100) { SecureRandom.uuid }
+    @topics = Concurrent::Array.new(100) { SecureRandom.hex(6) }
     @consumer_groups = @topics
     # We need to use a concurrent hash and not a map because we want to print this data upon
     # failures and debugging

--- a/spec/support/factories/processing/executor.rb
+++ b/spec/support/factories/processing/executor.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :processing_executor, class: 'Karafka::Processing::Executor' do
     skip_create
 
-    group_id { SecureRandom.uuid }
+    group_id { SecureRandom.hex(6) }
     client { nil }
     topic { build(:routing_topic) }
 

--- a/spec/support/factories/routing/topic.rb
+++ b/spec/support/factories/routing/topic.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     kafka { {} }
     max_messages { 1000 }
     max_wait_time { 10_000 }
-    subscription_group { SecureRandom.uuid }
+    subscription_group { SecureRandom.hex(6) }
 
     skip_create
 


### PR DESCRIPTION
This PR aligns the id format with waterdrop and makes it shorter

aligns with waterdrop: https://github.com/karafka/waterdrop/pull/280

note: We don't have to use `hex(12)` for really unique ids (like Sidekiq) because we do not assign ids per each job and rest of the objects like threads, consumers, executors are long living.