### PR TITLE
emit stats every 5 seconds by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [Improvement] Allow for easier state usage by introducing explicit `#to_s` for reporting.
 - [Improvement] Change auto-generated id from `SecureRandom#uuid` to `SecureRandom#hex(6)`
 - [Fix] Shutdown producer after all the consumer components are down and the status is stopped. This will ensure, that any instrumentation related Kafka messaging can still operate.
+- [Improvement] Emit statistic every 5 seconds by default.
 
 ## 2.0.23 (2022-12-07)
 - [Maintenance] Align with `waterdrop` and `karafka-core`
@@ -437,7 +438,7 @@ There are several things in the plan already for 2.1 and beyond, including a web
 - Small integration specs refactoring + specs for pausing scenarios
 
 ## 2.0.0-alpha6 (2022-04-17)
-- Fix a bug, where upon missing boot file and Rails, railtie would fail with a generic exception (#818) 
+- Fix a bug, where upon missing boot file and Rails, railtie would fail with a generic exception (#818)
 - Fix an issue with parallel pristine specs colliding with each other during `bundle install` (#820)
 - Replace `consumer.consume` with `consumer.consumed` event to match the behaviour
 - Make sure, that offset committing happens before the `consumer.consumed` event is propagated

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -16,7 +16,8 @@ module Karafka
 
       # Defaults for kafka settings, that will be overwritten only if not present already
       KAFKA_DEFAULTS = {
-        'client.id': 'karafka'
+        'client.id': 'karafka',
+        'statistics.interval.ms': 5_000
       }.freeze
 
       # Contains settings that should not be used in production but make life easier in dev

--- a/spec/lib/karafka/setup/config_spec.rb
+++ b/spec/lib/karafka/setup/config_spec.rb
@@ -46,4 +46,20 @@ RSpec.describe_current do
       end
     end
   end
+
+  describe "kafka config defaults" do
+    subject(:defaults) { Karafka::App.config.kafka }
+
+    let(:expected_defaults) do
+      {
+        "allow.auto.create.topics": "true",
+        "bootstrap.servers": "127.0.0.1:9092",
+        "client.id": "karafka",
+        "statistics.interval.ms": 5000,
+        "topic.metadata.refresh.interval.ms": 5000
+      }
+    end
+
+    it { is_expected.to eq(expected_defaults) }
+  end
 end


### PR DESCRIPTION
As discussed on Slack, that would be a more convenient default