### PR TITLE
Do not reload when consumer persistence on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@
 - [Improvement] Optimize status methods proxying to `Karafka::App`.
 - [Improvement] Allow for easier state usage by introducing explicit `#to_s` for reporting.
 - [Improvement] Change auto-generated id from `SecureRandom#uuid` to `SecureRandom#hex(6)`
-- [Fix] Shutdown producer after all the consumer components are down and the status is stopped. This will ensure, that any instrumentation related Kafka messaging can still operate.
 - [Improvement] Emit statistic every 5 seconds by default.
+- [Fix] Do not trigger code reloading when `consumer_persistence` is enabled.
+- [Fix] Shutdown producer after all the consumer components are down and the status is stopped. This will ensure, that any instrumentation related Kafka messaging can still operate.
 
 ### Upgrade notes
 

--- a/lib/karafka/railtie.rb
+++ b/lib/karafka/railtie.rb
@@ -79,6 +79,9 @@ if rails
         ::Karafka::App.monitor.subscribe('connection.listener.fetch_loop') do
           # Reload code each time there is a change in the code
           next unless Rails.application.reloaders.any?(&:updated?)
+          # If consumer persistence is enabled, no reason to reload because we will still keep
+          # old consumer instances in memory.
+          next if Karafka::App.config.consumer_persistence
 
           Rails.application.reloader.reload!
         end

--- a/lib/karafka/templates/karafka.rb.erb
+++ b/lib/karafka/templates/karafka.rb.erb
@@ -5,8 +5,7 @@
 # If by any chance you've wanted a setup for Rails app, either run the `karafka:install`
 # command again or refer to the install templates available in the source codes
 
-ENV['RACK_ENV'] ||= 'development'
-ENV['KARAFKA_ENV'] ||= ENV['RACK_ENV']
+ENV['KARAFKA_ENV'] ||= 'development'
 Bundler.require(:default, ENV['KARAFKA_ENV'])
 
 # Zeitwerk custom loader for loading the app components before the whole


### PR DESCRIPTION
This PR fixes a case where code reload would run with persisted consumers. Alongside of that it actually also fully disables the reload when persistence is on (no point)

close https://github.com/karafka/karafka/issues/1084