### PR TITLE
introduce quiet state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 - [Improvement] Early terminate on `read_topic` when reaching the last offset available on the request time.
+- [Improvement] Introduce a `quiet` state that indicates that Karafka is not only moving to quiet mode but actually that it reached it and no work will happen anymore in any of the consumer groups.
+- [Fix] Make sure all files descriptors are closed in the integration specs.
 
 ## 2.0.24 (2022-12-19)
 - **[Feature]** Provide out of the box encryption support for Pro.

--- a/bin/integrations
+++ b/bin/integrations
@@ -152,6 +152,13 @@ class Scenario
     end
   end
 
+  # Close all the files that are open, so they do not pile up
+  def close
+    @stdin.close
+    @stdout.close
+    @stderr.close
+  end
+
   private
 
   # Sets up a proper environment for a given spec to run and returns the run command
@@ -248,6 +255,7 @@ while finished_scenarios.size < scenarios.size
   active_scenarios.select(&:finished?).each do |exited|
     scenario = active_scenarios.delete(exited)
     scenario.report
+    scenario.close
     finished_scenarios << scenario
   end
 

--- a/lib/karafka/connection/consumer_group_coordinator.rb
+++ b/lib/karafka/connection/consumer_group_coordinator.rb
@@ -21,10 +21,16 @@ module Karafka
         @finished = Set.new
       end
 
+      # @return [Boolean] true if all the subscription groups from a given consumer group are
+      #   finished
+      def finished?
+        @finished.size == @group_size
+      end
+
       # @return [Boolean] can we start shutdown on a given listener
       # @note If true, will also obtain a lock so no-one else will be closing the same time we do
       def shutdown?
-        @finished.size == @group_size && @shutdown_lock.try_lock
+        finished? && @shutdown_lock.try_lock
       end
 
       # Unlocks the shutdown lock

--- a/lib/karafka/connection/listeners_batch.rb
+++ b/lib/karafka/connection/listeners_batch.rb
@@ -6,13 +6,19 @@ module Karafka
     class ListenersBatch
       include Enumerable
 
+      attr_reader :coordinators
+
       # @param jobs_queue [JobsQueue]
       # @return [ListenersBatch]
       def initialize(jobs_queue)
+        @coordinators = []
+
         @batch = App.subscription_groups.flat_map do |_consumer_group, subscription_groups|
           consumer_group_coordinator = Connection::ConsumerGroupCoordinator.new(
             subscription_groups.size
           )
+
+          @coordinators << consumer_group_coordinator
 
           subscription_groups.map do |subscription_group|
             Connection::Listener.new(

--- a/lib/karafka/instrumentation/logger_listener.rb
+++ b/lib/karafka/instrumentation/logger_listener.rb
@@ -136,6 +136,11 @@ module Karafka
         info 'Switching to quiet mode. New messages will not be processed.'
       end
 
+      # @param _event [Karafka::Core::Monitoring::Event] event details including payload
+      def on_app_quiet(_event)
+        info 'Reached quiet mode. No messages will be processed anymore.'
+      end
+
       # Logs info that we're going to stop the Karafka server.
       #
       # @param _event [Karafka::Core::Monitoring::Event] event details including payload

--- a/lib/karafka/instrumentation/notifications.rb
+++ b/lib/karafka/instrumentation/notifications.rb
@@ -20,6 +20,7 @@ module Karafka
         app.initialized
         app.running
         app.quieting
+        app.quiet
         app.stopping
         app.stopped
         app.terminated

--- a/lib/karafka/status.rb
+++ b/lib/karafka/status.rb
@@ -8,9 +8,15 @@ module Karafka
       initializing: :initialize!,
       initialized: :initialized!,
       running: :run!,
+      # will no longer pickup any work, but current work will be finished
       quieting: :quiet!,
+      # no work is happening but we keep process with the assignments running
+      quiet: :quieted!,
+      # shutdown started
       stopping: :stop!,
+      # all things are done and most of the things except critical are closed
       stopped: :stopped!,
+      # immediately after this process exists
       terminated: :terminate!
     }.freeze
 

--- a/spec/integrations/shutdown/on_quiet_with_work_finalization_spec.rb
+++ b/spec/integrations/shutdown/on_quiet_with_work_finalization_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# When Karafka is being moved to quiet mode, it is requested to first reach quieting and then stop
+# on the quiet state.
+
+setup_karafka do |config|
+  config.concurrency = 1
+end
+
+Karafka::App.monitor.subscribe('app.quieting') do
+  DT[:states] << Karafka::App.config.internal.status.to_s
+end
+
+Karafka::App.monitor.subscribe('app.quiet') do
+  DT[:states] << Karafka::App.config.internal.status.to_s
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[:in] << true
+    sleep(2)
+  end
+end
+
+draw_routes(Consumer)
+
+produce(DT.topic, '1')
+
+Thread.new do
+  sleep(0.1) while DT[:in].empty?
+  Process.kill('TSTP', ::Process.pid)
+end
+
+start_karafka_and_wait_until do
+  DT[:states].count >= 2
+end
+
+assert_equal DT[:states], %w[quieting quiet]

--- a/spec/lib/karafka/connection/consumer_group_coordinator_spec.rb
+++ b/spec/lib/karafka/connection/consumer_group_coordinator_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe_current do
     before { coordinator.finish_work(1) }
 
     it { expect(coordinator.shutdown?).to eq(false) }
+    it { expect(coordinator.finished?).to eq(false) }
   end
 
   context 'when we finish enough work and can get the lock' do
@@ -17,5 +18,6 @@ RSpec.describe_current do
     after { coordinator.unlock }
 
     it { expect(coordinator.shutdown?).to eq(true) }
+    it { expect(coordinator.finished?).to eq(true) }
   end
 end

--- a/spec/lib/karafka/instrumentation/logger_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/logger_listener_spec.rb
@@ -151,6 +151,17 @@ RSpec.describe_current do
     end
   end
 
+  describe '#on_app_quiet' do
+    subject(:trigger) { listener.on_app_quiet(event) }
+
+    let(:payload) { {} }
+    let(:message) { 'Reached quiet mode. No messages will be processed anymore.' }
+
+    it 'expect logger to log server quiet' do
+      expect(Karafka.logger).to have_received(:info).with(message).at_least(:once)
+    end
+  end
+
   describe '#on_app_stopping' do
     subject(:trigger) { listener.on_app_stopping(event) }
 

--- a/spec/lib/karafka/server_spec.rb
+++ b/spec/lib/karafka/server_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe_current do
     allow(Karafka::App).to receive(:run!)
     allow(Karafka::App).to receive(:stopped?).and_return(true)
     allow(Karafka::App).to receive(:terminated?).and_return(true)
-    allow(Karafka::App).to receive(:subscription_groups).and_return({ 1 => []})
+    allow(Karafka::App).to receive(:subscription_groups).and_return({ 1 => [] })
     # Do not close the real producer as we use it in specs
     allow(Karafka::App.producer).to receive(:close)
     allow(Karafka::Runner).to receive(:new).and_return(runner)
@@ -120,7 +120,6 @@ RSpec.describe_current do
     after do
       Karafka::App.config.internal.status.run!
       server_class.stop
-      #described_class.listeners.clear
       described_class.workers = []
       # After shutdown we need to reinitialize the app for other specs
       Karafka::App.initialize!
@@ -139,10 +138,7 @@ RSpec.describe_current do
       end
 
       context 'when there are no active threads (all shutdown ok)' do
-        before do
-          server_class.stop
-#          described_class.listeners.clear
-        end
+        before { server_class.stop }
 
         it 'expect stop without exit or sleep' do
           expect(Karafka::App).to have_received(:stop!)
@@ -165,7 +161,6 @@ RSpec.describe_current do
         before do
           described_class.listeners = [active_thread]
           server_class.stop
-          #described_class.listeners.clear
         end
 
         it 'expect stop and exit with sleep' do
@@ -190,7 +185,6 @@ RSpec.describe_current do
           allow(process).to receive(:supervised?).and_return(false)
           described_class.listeners = [active_thread]
           server_class.stop
-          #described_class.listeners.clear
         end
 
         it 'expect stop and exit with sleep' do
@@ -214,7 +208,7 @@ RSpec.describe_current do
         before do
           described_class.workers = [active_thread]
           server_class.stop
-          #described_class.workers.clear
+          described_class.workers.clear
         end
 
         it 'expect stop and exit with sleep' do

--- a/spec/lib/karafka/server_spec.rb
+++ b/spec/lib/karafka/server_spec.rb
@@ -10,12 +10,15 @@ RSpec.describe_current do
     allow(Karafka::App).to receive(:run!)
     allow(Karafka::App).to receive(:stopped?).and_return(true)
     allow(Karafka::App).to receive(:terminated?).and_return(true)
-    allow(Karafka::App).to receive(:subscription_groups).and_return({ 1 => 1 })
+    allow(Karafka::App).to receive(:subscription_groups).and_return({ 1 => []})
     # Do not close the real producer as we use it in specs
     allow(Karafka::App.producer).to receive(:close)
     allow(Karafka::Runner).to receive(:new).and_return(runner)
     allow(runner).to receive(:call)
-    described_class.listeners = []
+
+    jobs_queue = Karafka::Processing::JobsQueue.new
+
+    described_class.listeners = ::Karafka::Connection::ListenersBatch.new(jobs_queue)
     described_class.workers = []
   end
 
@@ -117,7 +120,7 @@ RSpec.describe_current do
     after do
       Karafka::App.config.internal.status.run!
       server_class.stop
-      described_class.listeners.clear
+      #described_class.listeners.clear
       described_class.workers = []
       # After shutdown we need to reinitialize the app for other specs
       Karafka::App.initialize!
@@ -138,7 +141,7 @@ RSpec.describe_current do
       context 'when there are no active threads (all shutdown ok)' do
         before do
           server_class.stop
-          described_class.listeners.clear
+#          described_class.listeners.clear
         end
 
         it 'expect stop without exit or sleep' do
@@ -162,7 +165,7 @@ RSpec.describe_current do
         before do
           described_class.listeners = [active_thread]
           server_class.stop
-          described_class.listeners.clear
+          #described_class.listeners.clear
         end
 
         it 'expect stop and exit with sleep' do
@@ -187,7 +190,7 @@ RSpec.describe_current do
           allow(process).to receive(:supervised?).and_return(false)
           described_class.listeners = [active_thread]
           server_class.stop
-          described_class.listeners.clear
+          #described_class.listeners.clear
         end
 
         it 'expect stop and exit with sleep' do
@@ -211,7 +214,7 @@ RSpec.describe_current do
         before do
           described_class.workers = [active_thread]
           server_class.stop
-          described_class.workers.clear
+          #described_class.workers.clear
         end
 
         it 'expect stop and exit with sleep' do

--- a/spec/lib/karafka/status_spec.rb
+++ b/spec/lib/karafka/status_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe_current do
     it { expect(status_manager.stopped?).to eq false }
     it { expect(status_manager.initializing?).to eq true }
     it { expect(status_manager.to_s).to eq 'initializing' }
+    it { expect(status_manager.quieting?).to eq false }
+    it { expect(status_manager.quiet?).to eq false }
     it { expect(status_manager.terminated?).to eq false }
   end
 
@@ -29,6 +31,8 @@ RSpec.describe_current do
       it { expect(status_manager.to_s).to eq 'running' }
       it { expect(status_manager.running?).to eq true }
       it { expect(status_manager.terminated?).to eq false }
+      it { expect(status_manager.quieting?).to eq false }
+      it { expect(status_manager.quiet?).to eq false }
     end
   end
 
@@ -43,6 +47,8 @@ RSpec.describe_current do
       it { expect(status_manager.stopping?).to eq false }
       it { expect(status_manager.stopped?).to eq false }
       it { expect(status_manager.terminated?).to eq false }
+      it { expect(status_manager.quieting?).to eq false }
+      it { expect(status_manager.quiet?).to eq false }
     end
   end
 
@@ -56,6 +62,8 @@ RSpec.describe_current do
       it { expect(status_manager.stopping?).to eq false }
       it { expect(status_manager.stopped?).to eq false }
       it { expect(status_manager.terminated?).to eq false }
+      it { expect(status_manager.quieting?).to eq false }
+      it { expect(status_manager.quiet?).to eq false }
     end
 
     context 'when status is set to stopping' do
@@ -68,6 +76,8 @@ RSpec.describe_current do
       it { expect(status_manager.stopping?).to eq true }
       it { expect(status_manager.stopped?).to eq false }
       it { expect(status_manager.terminated?).to eq false }
+      it { expect(status_manager.quieting?).to eq false }
+      it { expect(status_manager.quiet?).to eq false }
     end
   end
 
@@ -84,6 +94,8 @@ RSpec.describe_current do
       it { expect(status_manager.stopping?).to eq true }
       it { expect(status_manager.stopped?).to eq false }
       it { expect(status_manager.terminated?).to eq false }
+      it { expect(status_manager.quieting?).to eq false }
+      it { expect(status_manager.quiet?).to eq false }
     end
   end
 
@@ -102,6 +114,8 @@ RSpec.describe_current do
       it { expect(status_manager.to_s).to eq 'stopped' }
       it { expect(status_manager.stopped?).to eq true }
       it { expect(status_manager.terminated?).to eq false }
+      it { expect(status_manager.quieting?).to eq false }
+      it { expect(status_manager.quiet?).to eq false }
     end
   end
 
@@ -110,6 +124,8 @@ RSpec.describe_current do
       it { expect(status_manager.to_s).to eq 'initializing' }
       it { expect(status_manager.initializing?).to eq true }
       it { expect(status_manager.terminated?).to eq false }
+      it { expect(status_manager.quieting?).to eq false }
+      it { expect(status_manager.quiet?).to eq false }
     end
 
     context 'when status is set to initializing' do
@@ -119,6 +135,8 @@ RSpec.describe_current do
       it { expect(status_manager.initializing?).to eq true }
       it { expect(status_manager.initialized?).to eq false }
       it { expect(status_manager.terminated?).to eq false }
+      it { expect(status_manager.quieting?).to eq false }
+      it { expect(status_manager.quiet?).to eq false }
     end
   end
 
@@ -133,6 +151,8 @@ RSpec.describe_current do
       it { expect(status_manager.initializing?).to eq true }
       it { expect(status_manager.stopping?).to eq false }
       it { expect(status_manager.terminated?).to eq false }
+      it { expect(status_manager.quieting?).to eq false }
+      it { expect(status_manager.quiet?).to eq false }
     end
   end
 
@@ -148,6 +168,8 @@ RSpec.describe_current do
       it { expect(status_manager.initializing?).to eq false }
       it { expect(status_manager.stopping?).to eq false }
       it { expect(status_manager.terminated?).to eq false }
+      it { expect(status_manager.quieting?).to eq false }
+      it { expect(status_manager.quiet?).to eq false }
     end
   end
 
@@ -164,6 +186,44 @@ RSpec.describe_current do
       it { expect(status_manager.initializing?).to eq true }
       it { expect(status_manager.stopping?).to eq false }
       it { expect(status_manager.terminated?).to eq false }
+      it { expect(status_manager.quieting?).to eq false }
+      it { expect(status_manager.quiet?).to eq false }
+    end
+  end
+
+  describe '#quiet!' do
+    context 'when we quiet!' do
+      before do
+        status_manager.reset!
+        status_manager.quiet!
+      end
+
+      it { expect(status_manager.initialized?).to eq false }
+      it { expect(status_manager.running?).to eq false }
+      it { expect(status_manager.to_s).to eq 'quieting' }
+      it { expect(status_manager.initializing?).to eq false }
+      it { expect(status_manager.stopping?).to eq false }
+      it { expect(status_manager.terminated?).to eq false }
+      it { expect(status_manager.quieting?).to eq true }
+      it { expect(status_manager.quiet?).to eq false }
+    end
+  end
+
+  describe '#quieted!' do
+    context 'when we quieted!' do
+      before do
+        status_manager.reset!
+        status_manager.quieted!
+      end
+
+      it { expect(status_manager.initialized?).to eq false }
+      it { expect(status_manager.running?).to eq false }
+      it { expect(status_manager.to_s).to eq 'quiet' }
+      it { expect(status_manager.initializing?).to eq false }
+      it { expect(status_manager.stopping?).to eq false }
+      it { expect(status_manager.terminated?).to eq false }
+      it { expect(status_manager.quieting?).to eq false }
+      it { expect(status_manager.quiet?).to eq true }
     end
   end
 end


### PR DESCRIPTION
This PR introduces a new state of `quiet`. This state is the outcome of the quieting process and is reached when no more work is done in any consumer groups. This is the moment when we know we can safely shutdown.