### PR TITLE
include topic discovery in read_topic admin api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 - [Improvement] Early terminate on `read_topic` when reaching the last offset available on the request time.
 - [Improvement] Introduce a `quiet` state that indicates that Karafka is not only moving to quiet mode but actually that it reached it and no work will happen anymore in any of the consumer groups.
+- [Improvement] Use Karafka defined routes topics when possible for `read_topic` admin API.
 - [Fix] Fix proctitle listener state changes reporting on new states.
 - [Fix] Make sure all files descriptors are closed in the integration specs.
 

--- a/lib/karafka/admin.rb
+++ b/lib/karafka/admin.rb
@@ -68,7 +68,10 @@ module Karafka
         messages.map do |message|
           Messages::Builders::Message.call(
             message,
-            Topic.new(name, Karafka::App.config.deserializer),
+            # Use topic from routes if we can match it or create a dummy one
+            # Dummy one is used in case we cannot match the topic with routes. This can happen
+            # when admin API is used to read topics that are not part of the routing
+            Routing::Router.find_by(name: name) || Topic.new(name, App.config.deserializer),
             Time.now
           )
         end

--- a/lib/karafka/routing/router.rb
+++ b/lib/karafka/routing/router.rb
@@ -14,16 +14,26 @@ module Karafka
       # @raise [Karafka::Topic::NonMatchingTopicError] raised if topic name does not match
       #   any route defined by user using routes.draw
       def find(topic_id)
+        find_by(id: topic_id) || raise(Errors::NonMatchingRouteError, topic_id)
+      end
+
+      # Finds first reference of a given topic based on provided lookup attribute
+      # @param lookup [Hash<Symbol, String>] hash with attribute - value key pairs
+      # @return [Karafka::Routing::Topic, nil] proper route details or nil if not found
+      def find_by(lookup)
         App.consumer_groups.each do |consumer_group|
           consumer_group.topics.each do |topic|
-            return topic if topic.id == topic_id
+            return topic if lookup.all? do |attribute, value|
+              topic.public_send(attribute) == value
+            end
           end
         end
 
-        raise(Errors::NonMatchingRouteError, topic_id)
+        nil
       end
 
       module_function :find
+      module_function :find_by
     end
   end
 end

--- a/spec/lib/karafka/routing/router_spec.rb
+++ b/spec/lib/karafka/routing/router_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe_current do
     end
   end
 
-  describe 'find' do
+  describe '.find' do
     context 'when we look for non existing topic' do
       let(:topic_id) { rand.to_s }
       let(:expected_error) { Karafka::Errors::NonMatchingRouteError }
@@ -26,6 +26,22 @@ RSpec.describe_current do
       let(:topic_id) { topic.id }
 
       it { expect(router.find(topic_id)).to eq topic }
+    end
+  end
+
+  describe '.find_by' do
+    context 'when we look for non existing topic by name' do
+      let(:name) { rand.to_s }
+      let(:expected_error) { Karafka::Errors::NonMatchingRouteError }
+
+      it { expect(router.find_by(name: name)).to eq(nil) }
+    end
+
+    context 'when we look for existing topic' do
+      let(:topic) { Karafka::App.config.internal.routing.builder.last.topics.last }
+      let(:name) { topic.name }
+
+      it { expect(router.find_by(name: name)).to eq topic }
     end
   end
 end


### PR DESCRIPTION
This PR enhances the admin API by injecting the topic notion if possible to the `read_topic` admin API.