### PR TITLE
Inactive topics support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 - [Improvement] Early terminate on `read_topic` when reaching the last offset available on the request time.
 - [Improvement] Introduce a `quiet` state that indicates that Karafka is not only moving to quiet mode but actually that it reached it and no work will happen anymore in any of the consumer groups.
 - [Improvement] Use Karafka defined routes topics when possible for `read_topic` admin API.
+- [Improvement] Allow for disabling given topics by setting `active` to false. It will exclude them from consumption but will allow to have their definitions for using admin APIs, etc.
 - [Fix] Fix proctitle listener state changes reporting on new states.
 - [Fix] Make sure all files descriptors are closed in the integration specs.
+- [Fix] Fix a case where empty subscription groups could leak into the execution flow.
 
 ## 2.0.24 (2022-12-19)
 - **[Feature]** Provide out of the box encryption support for Pro.

--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -44,6 +44,7 @@ en:
       dead_letter_queue.max_retries_format: needs to be equal or bigger than 0
       dead_letter_queue.topic_format: 'needs to be a string with a Kafka accepted format'
       dead_letter_queue.active_format: needs to be either true or false
+      active_format: needs to be either true or false
 
     consumer_group:
       missing: needs to be present

--- a/lib/karafka/app.rb
+++ b/lib/karafka/app.rb
@@ -29,6 +29,7 @@ module Karafka
           .delete_if { |_, sgs| sgs.empty? }
           .each { |_, sgs| sgs.each { |sg| sg.topics.delete_if { |top| !top.active? } } }
           .each { |_, sgs| sgs.delete_if { |sg| sg.topics.empty? } }
+          .select { |cg, _| !cg.subscription_groups.empty? }
           .to_h
       end
 

--- a/lib/karafka/app.rb
+++ b/lib/karafka/app.rb
@@ -29,7 +29,7 @@ module Karafka
           .delete_if { |_, sgs| sgs.empty? }
           .each { |_, sgs| sgs.each { |sg| sg.topics.delete_if { |top| !top.active? } } }
           .each { |_, sgs| sgs.delete_if { |sg| sg.topics.empty? } }
-          .select { |cg, _| !cg.subscription_groups.empty? }
+          .reject { |cg, _| cg.subscription_groups.empty? }
           .to_h
       end
 

--- a/lib/karafka/contracts/server_cli_options.rb
+++ b/lib/karafka/contracts/server_cli_options.rb
@@ -80,6 +80,7 @@ module Karafka
       # Makes sure we have anything to subscribe to when we start the server
       virtual do |_, errors|
         next unless errors.empty?
+
         next unless Karafka::App.subscription_groups.empty?
 
         [[%i[topics], :topics_missing]]

--- a/spec/integrations/routing/limited_scope/with_inactive_and_disabled_spec.rb
+++ b/spec/integrations/routing/limited_scope/with_inactive_and_disabled_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# When combination of cli disabled topics and routing disabled topics meet, we should error.
+
+setup_karafka
+
+draw_routes(create_topics: false) do
+  consumer_group 'a' do
+    subscription_group 'b' do
+      topic 'c' do
+        active false
+        consumer Class.new
+      end
+    end
+  end
+
+  consumer_group 'd' do
+    subscription_group 'e' do
+      topic 'f' do
+        consumer Class.new
+      end
+    end
+  end
+end
+
+Karafka::App.config.internal.routing.active.topics = %w[c]
+
+spotted = false
+
+begin
+  # This should fail with an exception
+  start_karafka_and_wait_until do
+    false
+  end
+rescue Karafka::Errors::InvalidConfigurationError
+  spotted = true
+end
+
+assert spotted

--- a/spec/integrations/routing/limited_scope/with_mix_but_inactive_without_consumer_spec.rb
+++ b/spec/integrations/routing/limited_scope/with_mix_but_inactive_without_consumer_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# When we have inactive topics, they should be ok without consumer defined
+
+setup_karafka
+
+draw_routes(create_topics: false) do
+  consumer_group 'a' do
+    subscription_group 'b' do
+      topic 'c' do
+        active false
+      end
+    end
+  end
+
+  consumer_group 'd' do
+    subscription_group 'e' do
+      topic 'f' do
+        consumer Class.new
+
+        # This is not needed but we nonetheless check such a case
+        active true
+      end
+    end
+  end
+end
+
+# This should not fail as one consumer group topic is active and with consumer
+start_karafka_and_wait_until do
+  true
+end

--- a/spec/integrations/routing/limited_scope/with_only_inactive_topics_spec.rb
+++ b/spec/integrations/routing/limited_scope/with_only_inactive_topics_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# When all our topics are disabled in routing, we should not allow Karafka to run
+
+setup_karafka
+
+draw_routes(create_topics: false) do
+  consumer_group 'a' do
+    subscription_group 'b' do
+      topic 'c' do
+        active false
+        consumer Class.new
+      end
+    end
+  end
+
+  consumer_group 'd' do
+    subscription_group 'e' do
+      topic 'f' do
+        active false
+        consumer Class.new
+      end
+    end
+  end
+end
+
+spotted = false
+
+begin
+  # This should fail with an exception
+  start_karafka_and_wait_until do
+    false
+  end
+rescue Karafka::Errors::InvalidConfigurationError
+  spotted = true
+end
+
+assert spotted

--- a/spec/lib/karafka/contracts/topic_spec.rb
+++ b/spec/lib/karafka/contracts/topic_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe_current do
     {
       id: 'id',
       name: 'name',
+      active: true,
       consumer: Class.new,
       deserializer: Class.new,
       kafka: { 'bootstrap.servers' => 'localhost:9092' },
@@ -84,6 +85,31 @@ RSpec.describe_current do
   context 'when we validate consumer' do
     context 'when it is not present' do
       before { config[:consumer] = nil }
+
+      it { expect(check).not_to be_success }
+    end
+
+    context 'when topic is not active' do
+      before do
+        config[:consumer] = nil
+        config[:active] = false
+      end
+
+      it 'expect not to require consumer' do
+        expect(check).to be_success
+      end
+    end
+  end
+
+  context 'when we validate active' do
+    context 'when it is nil' do
+      before { config[:active] = nil }
+
+      it { expect(check).not_to be_success }
+    end
+
+    context 'when it is not a boolean' do
+      before { config[:active] = 2 }
 
       it { expect(check).not_to be_success }
     end

--- a/spec/lib/karafka/routing/topic_spec.rb
+++ b/spec/lib/karafka/routing/topic_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe_current do
   describe '#to_h' do
     let(:expected_keys) do
       %i[
-        kafka deserializer max_messages max_wait_time initial_offset id name consumer
+        kafka deserializer max_messages max_wait_time initial_offset id name active consumer
         consumer_group_id subscription_group active_job dead_letter_queue manual_offset_management
       ]
     end


### PR DESCRIPTION
This PR introduces ability to set `active false` for topics.

This will make them inactive (won't be consumed under `karafka s`) but will allow to define deserializer and use it with the admin API if needed because their resolutions via routing will be present.
