### PR TITLE
better pause-resume instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [Fix] Fix proctitle listener state changes reporting on new states.
 - [Fix] Make sure all files descriptors are closed in the integration specs.
 - [Fix] Fix a case where empty subscription groups could leak into the execution flow.
+- [Fix] Fix `LoggerListener` reporting so it does not end with `.`.
 
 ## 2.0.24 (2022-12-19)
 - **[Feature]** Provide out of the box encryption support for Pro.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - [Improvement] Early terminate on `read_topic` when reaching the last offset available on the request time.
 - [Improvement] Introduce a `quiet` state that indicates that Karafka is not only moving to quiet mode but actually that it reached it and no work will happen anymore in any of the consumer groups.
 - [Improvement] Use Karafka defined routes topics when possible for `read_topic` admin API.
+- [Improvement] Introduce `client.pause` and `client.resume` instrumentation hooks for tracking client topic partition pausing and resuming. This is alongside of `consumer.consuming.pause` that can be used to track both manual and automatic pausing with more granular consumer related details. The `client.*` should be used for low level tracking.
+- [Improvement] Replace `LoggerListener` pause notification with one based on `client.pause` instead of `consumer.consuming.pause`.
+- [Improvement] Expand `LoggerListener` with `client.resume` notification.
 - [Fix] Fix proctitle listener state changes reporting on new states.
 - [Fix] Make sure all files descriptors are closed in the integration specs.
 - [Fix] Fix a case where empty subscription groups could leak into the execution flow.

--- a/lib/karafka/instrumentation/logger_listener.rb
+++ b/lib/karafka/instrumentation/logger_listener.rb
@@ -63,19 +63,30 @@ module Karafka
         info "[#{job.id}] #{job_type} job for #{consumer} on #{topic} finished in #{time}ms"
       end
 
-      # Prints info about a pause occurrence. Irrelevant if user or system initiated.
+      # Prints info about a consumer pause occurrence. Irrelevant if user or system initiated.
       #
       # @param event [Karafka::Core::Monitoring::Event] event details including payload
-      def on_consumer_consuming_pause(event)
+      def on_client_pause(event)
         topic = event[:topic]
         partition = event[:partition]
         offset = event[:offset]
-        consumer = event[:caller]
-        timeout = event[:timeout]
+        client = event[:caller]
 
         info <<~MSG.tr("\n", ' ').strip!
-          [#{consumer.id}] Pausing partition #{partition} of topic #{topic}
-          on offset #{offset} for #{timeout} ms.
+          [#{client.id}] Pausing partition #{partition} of topic #{topic} on offset #{offset}.
+        MSG
+      end
+
+      # Prints information about resuming of processing of a given topic partition
+      #
+      # @param event [Karafka::Core::Monitoring::Event] event details including payload
+      def on_client_resume(event)
+        topic = event[:topic]
+        partition = event[:partition]
+        client = event[:caller]
+
+        info <<~MSG.tr("\n", ' ').strip!
+          [#{client.id}] Resuming partition #{partition} of topic #{topic}.
         MSG
       end
 

--- a/lib/karafka/instrumentation/logger_listener.rb
+++ b/lib/karafka/instrumentation/logger_listener.rb
@@ -73,7 +73,7 @@ module Karafka
         client = event[:caller]
 
         info <<~MSG.tr("\n", ' ').strip!
-          [#{client.id}] Pausing partition #{partition} of topic #{topic} on offset #{offset}.
+          [#{client.id}] Pausing partition #{partition} of topic #{topic} on offset #{offset}
         MSG
       end
 
@@ -86,7 +86,7 @@ module Karafka
         client = event[:caller]
 
         info <<~MSG.tr("\n", ' ').strip!
-          [#{client.id}] Resuming partition #{partition} of topic #{topic}.
+          [#{client.id}] Resuming partition #{partition} of topic #{topic}
         MSG
       end
 
@@ -139,17 +139,17 @@ module Karafka
 
         return if Karafka.pro?
 
-        info 'See LICENSE and the LGPL-3.0 for licensing details.'
+        info 'See LICENSE and the LGPL-3.0 for licensing details'
       end
 
       # @param _event [Karafka::Core::Monitoring::Event] event details including payload
       def on_app_quieting(_event)
-        info 'Switching to quiet mode. New messages will not be processed.'
+        info 'Switching to quiet mode. New messages will not be processed'
       end
 
       # @param _event [Karafka::Core::Monitoring::Event] event details including payload
       def on_app_quiet(_event)
-        info 'Reached quiet mode. No messages will be processed anymore.'
+        info 'Reached quiet mode. No messages will be processed anymore'
       end
 
       # Logs info that we're going to stop the Karafka server.

--- a/lib/karafka/instrumentation/notifications.rb
+++ b/lib/karafka/instrumentation/notifications.rb
@@ -25,25 +25,28 @@ module Karafka
         app.stopped
         app.terminated
 
-        consumer.consumed
-        consumer.consuming.pause
-        consumer.consuming.retry
-        consumer.revoked
-        consumer.shutdown
-
-        process.notice_signal
+        client.pause
+        client.resume
 
         connection.listener.before_fetch_loop
         connection.listener.fetch_loop
         connection.listener.fetch_loop.received
 
+        consumer.consuming.pause
+        consumer.consumed
+        consumer.consuming.retry
+        consumer.revoked
+        consumer.shutdown
+
         dead_letter_queue.dispatched
+
+        process.notice_signal
+
+        statistics.emitted
 
         worker.process
         worker.processed
         worker.completed
-
-        statistics.emitted
 
         error.occurred
       ].freeze

--- a/lib/karafka/routing/subscription_group.rb
+++ b/lib/karafka/routing/subscription_group.rb
@@ -8,7 +8,7 @@ module Karafka
     # @note One subscription group will always belong to one consumer group, but one consumer
     #   group can have multiple subscription groups.
     class SubscriptionGroup
-      attr_reader :id, :name, :topics, :kafka
+      attr_reader :id, :name, :topics, :kafka, :consumer_group
 
       # @param position [Integer] position of this subscription group in all the subscriptions
       #   groups array. We need to have this value for sake of static group memberships, where
@@ -17,6 +17,7 @@ module Karafka
       # @return [SubscriptionGroup] built subscription group
       def initialize(position, topics)
         @name = topics.first.subscription_group
+        @consumer_group = topics.first.consumer_group
         @id = "#{@name}_#{position}"
         @position = position
         @topics = topics

--- a/spec/integrations/instrumentation/pausing_and_retry_client_callbacks_spec.rb
+++ b/spec/integrations/instrumentation/pausing_and_retry_client_callbacks_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# We should be able to get client level instrumentation on pausing and resuming
+
+setup_karafka do |config|
+  config.pause_timeout = 50
+  config.pause_max_timeout = 50
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    pause(messages.first.offset, 100)
+  end
+end
+
+draw_routes(Consumer)
+
+pause_events = []
+resume_events = []
+
+Karafka::App.monitor.subscribe('client.pause') do |event|
+  pause_events << event
+end
+
+Karafka::App.monitor.subscribe('client.resume') do |event|
+  resume_events << event
+end
+
+produce_many(DT.topic, DT.uuids(2))
+
+start_karafka_and_wait_until do
+  pause_events.size >= 1 && resume_events.size >= 1
+end
+
+pause_event = pause_events.last
+resume_event = resume_events.last
+
+assert_equal DT.topic, pause_event[:topic]
+assert_equal 0, pause_event[:partition]
+assert_equal 0, pause_event[:offset]
+
+assert_equal DT.topic, resume_event[:topic]
+assert_equal 0, resume_event[:partition]

--- a/spec/integrations/routing/limited_scope/with_mix_but_inactive_without_consumer_spec.rb
+++ b/spec/integrations/routing/limited_scope/with_mix_but_inactive_without_consumer_spec.rb
@@ -4,7 +4,7 @@
 
 setup_karafka
 
-draw_routes(create_topics: false) do
+draw_routes do
   consumer_group 'a' do
     subscription_group 'b' do
       topic 'c' do

--- a/spec/integrations/setup/attributes_distribution_spec.rb
+++ b/spec/integrations/setup/attributes_distribution_spec.rb
@@ -40,5 +40,7 @@ end
 $stdout = proper_stdout
 $stderr = proper_stderr
 
-assert_equal false, strio.string.include?('Configuration property heartbeat.interval.ms')
-assert_equal false, strio.string.include?('Configuration property max.poll.interval.ms')
+content = strio.string
+
+assert_equal false, content.include?('Configuration property heartbeat.interval.ms'), content
+assert_equal false, content.include?('Configuration property max.poll.interval.ms'), content

--- a/spec/integrations_helper.rb
+++ b/spec/integrations_helper.rb
@@ -184,6 +184,8 @@ def create_routes_topics
 
   Karafka::App.routes.map(&:topics).flatten.each do |topics|
     topics.each do |topic|
+      next unless topic.active?
+
       topics_names << topic.name
 
       next unless topic.dead_letter_queue?

--- a/spec/lib/karafka/instrumentation/logger_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/logger_listener_spec.rb
@@ -73,20 +73,37 @@ RSpec.describe_current do
     it { expect(Karafka.logger).to have_received(:info) }
   end
 
-  describe '#on_consumer_consuming_pause' do
-    subject(:trigger) { listener.on_consumer_consuming_pause(event) }
+  describe '#on_client_pause' do
+    subject(:trigger) { listener.on_client_pause(event) }
 
-    let(:consumer) { Class.new(Karafka::BaseConsumer).new }
+    let(:client) { instance_double(Karafka::Connection::Client, id: SecureRandom.hex(6)) }
     let(:message) do
-      "[#{consumer.id}] Pausing partition 0 of topic Topic on offset 12 for 100 ms."
+      "[#{client.id}] Pausing partition 0 of topic Topic on offset 12."
     end
     let(:payload) do
       {
-        caller: consumer,
+        caller: client,
         topic: 'Topic',
         partition: 0,
-        offset: 12,
-        timeout: 100
+        offset: 12
+      }
+    end
+
+    it { expect(Karafka.logger).to have_received(:info).with(message) }
+  end
+
+  describe '#on_client_resume' do
+    subject(:trigger) { listener.on_client_resume(event) }
+
+    let(:client) { instance_double(Karafka::Connection::Client, id: SecureRandom.hex(6)) }
+    let(:message) do
+      "[#{client.id}] Resuming partition 0 of topic Topic."
+    end
+    let(:payload) do
+      {
+        caller: client,
+        topic: 'Topic',
+        partition: 0
       }
     end
 

--- a/spec/lib/karafka/instrumentation/logger_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/logger_listener_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe_current do
 
     let(:client) { instance_double(Karafka::Connection::Client, id: SecureRandom.hex(6)) }
     let(:message) do
-      "[#{client.id}] Pausing partition 0 of topic Topic on offset 12."
+      "[#{client.id}] Pausing partition 0 of topic Topic on offset 12"
     end
     let(:payload) do
       {
@@ -97,7 +97,7 @@ RSpec.describe_current do
 
     let(:client) { instance_double(Karafka::Connection::Client, id: SecureRandom.hex(6)) }
     let(:message) do
-      "[#{client.id}] Resuming partition 0 of topic Topic."
+      "[#{client.id}] Resuming partition 0 of topic Topic"
     end
     let(:payload) do
       {
@@ -161,7 +161,7 @@ RSpec.describe_current do
     subject(:trigger) { listener.on_app_quieting(event) }
 
     let(:payload) { {} }
-    let(:message) { 'Switching to quiet mode. New messages will not be processed.' }
+    let(:message) { 'Switching to quiet mode. New messages will not be processed' }
 
     it 'expect logger to log server quiet' do
       expect(Karafka.logger).to have_received(:info).with(message).at_least(:once)
@@ -172,7 +172,7 @@ RSpec.describe_current do
     subject(:trigger) { listener.on_app_quiet(event) }
 
     let(:payload) { {} }
-    let(:message) { 'Reached quiet mode. No messages will be processed anymore.' }
+    let(:message) { 'Reached quiet mode. No messages will be processed anymore' }
 
     it 'expect logger to log server quiet' do
       expect(Karafka.logger).to have_received(:info).with(message).at_least(:once)

--- a/spec/lib/karafka/routing/subscription_group_spec.rb
+++ b/spec/lib/karafka/routing/subscription_group_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe_current do
     it { expect(group.topics).to eq([topic]) }
   end
 
+  describe '#consumer_group' do
+    it { expect(group.consumer_group).to eq(topic.consumer_group) }
+  end
+
   describe '#kafka' do
     it { expect(group.kafka[:'client.id']).to eq(Karafka::App.config.client_id) }
     it { expect(group.kafka[:'auto.offset.reset']).to eq('earliest') }


### PR DESCRIPTION
This PR introduces `client.pause` and `client.resume` notification hooks. We cannot use a consumer instance action because pausing and resuming can be beyond a consumer instance lifecycle.