### PR TITLE
Introduce stable subscription groups ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [Improvement] Introduce `client.pause` and `client.resume` instrumentation hooks for tracking client topic partition pausing and resuming. This is alongside of `consumer.consuming.pause` that can be used to track both manual and automatic pausing with more granular consumer related details. The `client.*` should be used for low level tracking.
 - [Improvement] Replace `LoggerListener` pause notification with one based on `client.pause` instead of `consumer.consuming.pause`.
 - [Improvement] Expand `LoggerListener` with `client.resume` notification.
+- [Improvement] Replace random anonymous subscription groups ids with stable once.
 - [Fix] Fix proctitle listener state changes reporting on new states.
 - [Fix] Make sure all files descriptors are closed in the integration specs.
 - [Fix] Fix a case where empty subscription groups could leak into the execution flow.

--- a/lib/karafka.rb
+++ b/lib/karafka.rb
@@ -14,7 +14,9 @@
   base64
   date
   singleton
+  digest
   zeitwerk
+  concurrent/atomic/atomic_fixnum
 ].each(&method(:require))
 
 # Karafka framework main namespace

--- a/lib/karafka/routing/builder.rb
+++ b/lib/karafka/routing/builder.rb
@@ -80,7 +80,7 @@ module Karafka
       # @param subscription_group_name [String, Symbol] subscription group id. When not provided,
       #   a random uuid will be used
       # @param block [Proc] further topics definitions
-      def subscription_group(subscription_group_name = SecureRandom.hex(6), &block)
+      def subscription_group(subscription_group_name = SubscriptionGroup.id, &block)
         consumer_group('app') do
           target.public_send(:subscription_group=, subscription_group_name.to_s, &block)
         end

--- a/lib/karafka/routing/consumer_group.rb
+++ b/lib/karafka/routing/consumer_group.rb
@@ -26,7 +26,7 @@ module Karafka
         @topics = Topics.new([])
         # Initialize the subscription group so there's always a value for it, since even if not
         # defined directly, a subscription group will be created
-        @current_subscription_group_id = SecureRandom.hex(6)
+        @current_subscription_group_id = SubscriptionGroup.id
       end
 
       # @return [Boolean] true if this consumer group should be active in our current process
@@ -55,7 +55,7 @@ module Karafka
       # topic definition
       # @param name [String, Symbol] name of the current subscription group
       # @param block [Proc] block that may include topics definitions
-      def subscription_group=(name = SecureRandom.hex(6), &block)
+      def subscription_group=(name = SubscriptionGroup.id, &block)
         # We cast it here, so the routing supports symbol based but that's anyhow later on
         # validated as a string
         @current_subscription_group_id = name
@@ -64,7 +64,7 @@ module Karafka
 
         # We need to reset the current subscription group after it is used, so it won't leak
         # outside to other topics that would be defined without a defined subscription group
-        @current_subscription_group_id = SecureRandom.hex(6)
+        @current_subscription_group_id = SubscriptionGroup.id
       end
 
       # @return [Array<Routing::SubscriptionGroup>] all the subscription groups build based on

--- a/lib/karafka/routing/subscription_group.rb
+++ b/lib/karafka/routing/subscription_group.rb
@@ -10,6 +10,21 @@ module Karafka
     class SubscriptionGroup
       attr_reader :id, :name, :topics, :kafka, :consumer_group
 
+      GROUP_COUNT = Concurrent::AtomicFixnum.new
+
+      private_constant :GROUP_COUNT
+
+      class << self
+        # Generates new subscription group id that will be used in case of anonymous subscription
+        #   groups
+        # @return [String] hex(6) compatible reproducable id
+        def id
+          ::Digest::MD5.hexdigest(
+            GROUP_COUNT.increment.to_s
+          )[0..11]
+        end
+      end
+
       # @param position [Integer] position of this subscription group in all the subscriptions
       #   groups array. We need to have this value for sake of static group memberships, where
       #   we need a "in-between" restarts unique identifier

--- a/lib/karafka/routing/subscription_group.rb
+++ b/lib/karafka/routing/subscription_group.rb
@@ -10,6 +10,7 @@ module Karafka
     class SubscriptionGroup
       attr_reader :id, :name, :topics, :kafka, :consumer_group
 
+      # Numeric for counting groups
       GROUP_COUNT = Concurrent::AtomicFixnum.new
 
       private_constant :GROUP_COUNT
@@ -17,7 +18,7 @@ module Karafka
       class << self
         # Generates new subscription group id that will be used in case of anonymous subscription
         #   groups
-        # @return [String] hex(6) compatible reproducable id
+        # @return [String] hex(6) compatible reproducible id
         def id
           ::Digest::MD5.hexdigest(
             GROUP_COUNT.increment.to_s

--- a/spec/integrations/offset_management/rebalance_commit_spec.rb
+++ b/spec/integrations/offset_management/rebalance_commit_spec.rb
@@ -39,6 +39,10 @@ consumer = setup_rdkafka_consumer
 other = Thread.new do
   sleep(1) until DT.data.size >= 2
 
+  # Give it enough time to actually finish the work and mark offset before triggering rebalance
+  # This is useful on the CI because the CI sometimes lags
+  sleep(1)
+
   consumer.subscribe(DT.topic)
 
   consumer.each do |message|


### PR DESCRIPTION
This PR introduces a stable subscription groups instead of random. That way we can use them in the UI.