### PR TITLE
Revoke and shutdown refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [Improvement] Replace `LoggerListener` pause notification with one based on `client.pause` instead of `consumer.consuming.pause`.
 - [Improvement] Expand `LoggerListener` with `client.resume` notification.
 - [Improvement] Replace random anonymous subscription groups ids with stable once.
+- [Improvement] Add `consumer.consume` and `consumer.revoke` notification events and move the revocation logic calling to strategies.
 - [Fix] Fix proctitle listener state changes reporting on new states.
 - [Fix] Make sure all files descriptors are closed in the integration specs.
 - [Fix] Fix a case where empty subscription groups could leak into the execution flow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - [Improvement] Replace `LoggerListener` pause notification with one based on `client.pause` instead of `consumer.consuming.pause`.
 - [Improvement] Expand `LoggerListener` with `client.resume` notification.
 - [Improvement] Replace random anonymous subscription groups ids with stable once.
-- [Improvement] Add `consumer.consume` and `consumer.revoke` notification events and move the revocation logic calling to strategies.
+- [Improvement] Add `consumer.consume`, `consumer.revoke` and `consumer.shutting_down` notification events and move the revocation logic calling to strategies.
 - [Fix] Fix proctitle listener state changes reporting on new states.
 - [Fix] Make sure all files descriptors are closed in the integration specs.
 - [Fix] Fix a case where empty subscription groups could leak into the execution flow.

--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -99,10 +99,6 @@ module Karafka
     # @private
     def on_revoked
       handle_revoked
-
-      Karafka.monitor.instrument('consumer.revoked', caller: self) do
-        revoked
-      end
     rescue StandardError => e
       Karafka.monitor.instrument(
         'error.occurred',
@@ -116,9 +112,7 @@ module Karafka
     #
     # @private
     def on_shutdown
-      Karafka.monitor.instrument('consumer.shutdown', caller: self) do
-        shutdown
-      end
+      handle_shutdown
     rescue StandardError => e
       Karafka.monitor.instrument(
         'error.occurred',

--- a/lib/karafka/instrumentation/notifications.rb
+++ b/lib/karafka/instrumentation/notifications.rb
@@ -32,9 +32,11 @@ module Karafka
         connection.listener.fetch_loop
         connection.listener.fetch_loop.received
 
-        consumer.consuming.pause
+        consumer.consume
         consumer.consumed
+        consumer.consuming.pause
         consumer.consuming.retry
+        consumer.revoke
         consumer.revoked
         consumer.shutdown
 

--- a/lib/karafka/instrumentation/notifications.rb
+++ b/lib/karafka/instrumentation/notifications.rb
@@ -38,6 +38,7 @@ module Karafka
         consumer.consuming.retry
         consumer.revoke
         consumer.revoked
+        consumer.shutting_down
         consumer.shutdown
 
         dead_letter_queue.dispatched

--- a/lib/karafka/pro/processing/strategies/aj_lrj_mom_vp.rb
+++ b/lib/karafka/pro/processing/strategies/aj_lrj_mom_vp.rb
@@ -61,6 +61,11 @@ module Karafka
             coordinator.on_revoked do
               coordinator.revoke
             end
+
+            Karafka.monitor.instrument('consumer.revoke', caller: self)
+            Karafka.monitor.instrument('consumer.revoked', caller: self) do
+              revoked
+            end
           end
         end
       end

--- a/lib/karafka/pro/processing/strategies/default.rb
+++ b/lib/karafka/pro/processing/strategies/default.rb
@@ -46,6 +46,7 @@ module Karafka
             # This can happen primarily when an LRJ job gets to the internal worker queue and
             # this partition is revoked prior processing.
             unless revoked?
+              Karafka.monitor.instrument('consumer.consume', caller: self)
               Karafka.monitor.instrument('consumer.consumed', caller: self) do
                 consume
               end
@@ -90,6 +91,11 @@ module Karafka
               resume
 
               coordinator.revoke
+            end
+
+            Karafka.monitor.instrument('consumer.revoke', caller: self)
+            Karafka.monitor.instrument('consumer.revoked', caller: self) do
+              revoked
             end
           end
         end

--- a/lib/karafka/pro/processing/strategies/lrj.rb
+++ b/lib/karafka/pro/processing/strategies/lrj.rb
@@ -70,6 +70,11 @@ module Karafka
               # a failure. Double non-blocking resume could cause problems in coordination.
               coordinator.revoke
             end
+
+            Karafka.monitor.instrument('consumer.revoke', caller: self)
+            Karafka.monitor.instrument('consumer.revoked', caller: self) do
+              revoked
+            end
           end
         end
       end

--- a/lib/karafka/pro/processing/strategies/lrj_mom.rb
+++ b/lib/karafka/pro/processing/strategies/lrj_mom.rb
@@ -60,6 +60,11 @@ module Karafka
             coordinator.on_revoked do
               coordinator.revoke
             end
+
+            Karafka.monitor.instrument('consumer.revoke', caller: self)
+            Karafka.monitor.instrument('consumer.revoked', caller: self) do
+              revoked
+            end
           end
         end
       end

--- a/lib/karafka/processing/strategies/base.rb
+++ b/lib/karafka/processing/strategies/base.rb
@@ -36,6 +36,11 @@ module Karafka
         def handle_revoked
           raise NotImplementedError, 'Implement in a subclass'
         end
+
+        # Shutdown handling
+        def handle_shutdown
+          raise NotImplementedError, 'Implement in a subclass'
+        end
       end
     end
   end

--- a/lib/karafka/processing/strategies/default.rb
+++ b/lib/karafka/processing/strategies/default.rb
@@ -80,6 +80,7 @@ module Karafka
 
         # Runs the shutdown code
         def handle_shutdown
+          Karafka.monitor.instrument('consumer.shutting_down', caller: self) do
           Karafka.monitor.instrument('consumer.shutdown', caller: self) do
             shutdown
           end

--- a/lib/karafka/processing/strategies/default.rb
+++ b/lib/karafka/processing/strategies/default.rb
@@ -80,7 +80,7 @@ module Karafka
 
         # Runs the shutdown code
         def handle_shutdown
-          Karafka.monitor.instrument('consumer.shutting_down', caller: self) do
+          Karafka.monitor.instrument('consumer.shutting_down', caller: self)
           Karafka.monitor.instrument('consumer.shutdown', caller: self) do
             shutdown
           end

--- a/lib/karafka/processing/strategies/default.rb
+++ b/lib/karafka/processing/strategies/default.rb
@@ -25,6 +25,7 @@ module Karafka
 
         # Run the user consumption code
         def handle_consume
+          Karafka.monitor.instrument('consumer.consume', caller: self)
           Karafka.monitor.instrument('consumer.consumed', caller: self) do
             consume
           end
@@ -70,6 +71,18 @@ module Karafka
           resume
 
           coordinator.revoke
+
+          Karafka.monitor.instrument('consumer.revoke', caller: self)
+          Karafka.monitor.instrument('consumer.revoked', caller: self) do
+            revoked
+          end
+        end
+
+        # Runs the shutdown code
+        def handle_shutdown
+          Karafka.monitor.instrument('consumer.shutdown', caller: self) do
+            shutdown
+          end
         end
       end
     end

--- a/lib/karafka/routing/consumer_mapper.rb
+++ b/lib/karafka/routing/consumer_mapper.rb
@@ -12,16 +12,6 @@ module Karafka
     #       raw_consumer_group_name
     #     end
     #   end
-    #
-    # @example Mapper for replacing "_" with "." in topic names
-    #   class MyMapper
-    #     def call(raw_consumer_group_name)
-    #       [
-    #         Karafka::Helpers::Inflector.map(Karafka::App.config.client_id.to_s),
-    #         raw_consumer_group_name
-    #       ].join('_').gsub('_', '.')
-    #     end
-    #   end
     class ConsumerMapper
       # @param raw_consumer_group_name [String, Symbol] string or symbolized consumer group name
       # @return [String] remapped final consumer group name

--- a/spec/integrations/instrumentation/consumption_event_vs_processing_spec.rb
+++ b/spec/integrations/instrumentation/consumption_event_vs_processing_spec.rb
@@ -10,6 +10,10 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
+Karafka::App.monitor.subscribe('consumer.consume') do |event|
+  DT[2] << event[:caller].messages.count
+end
+
 Karafka::App.monitor.subscribe('consumer.consumed') do |event|
   DT[1] << event[:caller].messages.count
 end
@@ -26,3 +30,4 @@ start_karafka_and_wait_until do
 end
 
 assert_equal DT[0], DT[1]
+assert_equal DT[1], DT[2]

--- a/spec/lib/karafka/base_consumer_spec.rb
+++ b/spec/lib/karafka/base_consumer_spec.rb
@@ -205,6 +205,8 @@ RSpec.describe_current do
   end
 
   describe '#on_shutdown' do
+    before { consumer.singleton_class.include(Karafka::Processing::Strategies::Default) }
+
     context 'when everything went ok on shutdown' do
       it { expect { consumer.on_shutdown }.not_to raise_error }
 
@@ -218,7 +220,7 @@ RSpec.describe_current do
 
       it 'expect not to run error instrumentation' do
         Karafka.monitor.subscribe('error.occurred') do |event|
-          expect(event.payload[:caller]).not_to eq(consumer)
+          expect(event.payload[:caller].object_id).not_to eq(consumer.object_id)
           expect(event.payload[:error]).not_to be_a(StandardError)
           expect(event.payload[:type]).to eq('consumer.shutdown.error')
         end

--- a/spec/lib/karafka/processing/strategies/base_spec.rb
+++ b/spec/lib/karafka/processing/strategies/base_spec.rb
@@ -26,4 +26,8 @@ RSpec.describe_current do
   describe '#handle_revoked' do
     it { expect { runner.handle_revoked }.to raise_error(NotImplementedError) }
   end
+
+  describe '#handle_shutdown' do
+    it { expect { runner.handle_shutdown }.to raise_error(NotImplementedError) }
+  end
 end


### PR DESCRIPTION
This PR adds pre-execution instrumentation for consumer related actions and moves revocation and shutdown operations to strategies.