### PR TITLE
Run previous signal handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [Fix] Make sure all files descriptors are closed in the integration specs.
 - [Fix] Fix a case where empty subscription groups could leak into the execution flow.
 - [Fix] Fix `LoggerListener` reporting so it does not end with `.`.
+- [Fix] Run previously defined (if any) signal traps created prior to Karafka signals traps.
 
 ## 2.0.24 (2022-12-19)
 - **[Feature]** Provide out of the box encryption support for Pro.

--- a/lib/karafka/process.rb
+++ b/lib/karafka/process.rb
@@ -53,12 +53,14 @@ module Karafka
     # trap context s some things may not work there as expected, that is why we spawn a separate
     # thread to handle the signals process
     def trap_signal(signal)
-      trap(signal) do
+      previous_handler = ::Signal.trap(signal) do
         Thread.new do
           notice_signal(signal)
 
           (@callbacks[signal] || []).each(&:call)
         end
+
+        previous_handler.call if previous_handler.respond_to?(:call)
       end
     end
 

--- a/spec/integrations/embedding/puma_poro/Gemfile
+++ b/spec/integrations/embedding/puma_poro/Gemfile
@@ -4,4 +4,4 @@ source 'https://rubygems.org'
 
 gem 'karafka', path: ENV.fetch('KARAFKA_GEM_DIR'), require: true
 gem 'puma', '6.0.1', require: true
-gem 'sinatra', '3.0.3', require: true
+gem 'sinatra', '3.0.4', require: true

--- a/spec/lib/karafka/process_spec.rb
+++ b/spec/lib/karafka/process_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe_current do
 
     before do
       process.instance_variable_set(:'@callbacks', signal => [callback])
-      allow(process).to receive(:trap).with(signal).and_yield
+      allow(::Signal).to receive(:trap).with(signal).and_yield
     end
 
     it 'traps signals, log it and run callbacks if defined' do


### PR DESCRIPTION
This PR fixes a case where previous signal handlers would defined but would not be called because of Karafka intercept.