### PR TITLE
rely on shared core ruby version limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka framework changelog
 
+## 2.0.27 (Unreleased)
+- Do not lock Ruby version in Karafka in favour of `karafka-core`.
+
 ## 2.0.26 (2023-01-10)
 - **[Feature]** Allow for disabling given topics by setting `active` to false. It will exclude them from consumption but will allow to have their definitions for using admin APIs, etc.
 - [Improvement] Early terminate on `read_topic` when reaching the last offset available on the request time.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka (2.0.26)
+    karafka (2.0.27)
       karafka-core (>= 2.0.8, < 3.0.0)
       thor (>= 0.20)
       waterdrop (>= 2.4.7, < 3.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,10 +45,10 @@ GEM
       rspec-mocks (~> 3.12.0)
     rspec-core (3.12.0)
       rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.1)
+    rspec-expectations (3.12.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.1)
+    rspec-mocks (3.12.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
@@ -61,14 +61,12 @@ GEM
     thor (1.2.1)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
-    waterdrop (2.4.7)
-      karafka-core (>= 2.0.7, < 3.0.0)
+    waterdrop (2.4.8)
+      karafka-core (>= 2.0.8, < 3.0.0)
       zeitwerk (~> 2.3)
     zeitwerk (2.6.6)
 
 PLATFORMS
-  arm64-darwin-21
-  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/karafka.gemspec
+++ b/karafka.gemspec
@@ -26,8 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'waterdrop', '>= 2.4.7', '< 3.0.0'
   spec.add_dependency 'zeitwerk', '~> 2.3'
 
-  spec.required_ruby_version = '>= 2.7.0'
-
   if $PROGRAM_NAME.end_with?('gem')
     spec.signing_key = File.expand_path('~/.ssh/gem-private_key.pem')
   end

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '2.0.26'
+  VERSION = '2.0.27'
 end


### PR DESCRIPTION
Lets keep ruby version only in core as it's collective for the whole ecosystem (same will be applied to waterdrop)