### PR TITLE
better dlq keys strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Karafka framework changelog
 
 ## 2.0.28 (Unreleased)
-- Allow for customization of DLQ dispatched message details in Pro (#1266)
+- [Improvement] Allow for customization of DLQ dispatched message details in Pro (#1266) via the `#enhance_dlq_message` consumer method.
 - Include `original_consumer_group` in the DLQ dispatched messages in Pro.
 - Use Karafka `client_id` as kafka `client.id` value by default
+- Change Pro DLQ dispatch `key` default value to mitigate a scenario where one DLQ topic is used to pipe all the dead messages from multiple topics and all the data goes to one partition.
 
 ### Upgrade notes
 
@@ -16,6 +17,19 @@ class KarafkaApp < Karafka::App
     config.kafka = {
       'client.id': 'karafka'
     }
+```
+
+
+You can use the pro `#enhance_dlq_message` to remap the key back to how it was before this release:
+
+```ruby
+class DataConsumer < Karafka::BaseConsumer
+  # Rest of the code
+
+  private
+
+  def enhance_dlq_message(dlq_message_hash, skippable_message)
+    dlq_message_hash[:key] = skippable_message.partition.to_s
   end
 end
 ```

--- a/spec/integrations/pro/consumption/strategies/dlq/multi_topic_one_target_multi_partitions_flow_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/multi_topic_one_target_multi_partitions_flow_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# When using single DLQ to handle errors from multiple topics, the dispatched message key should
+# combine topic and partition to allow for good data distribution.
+
+setup_karafka(allow_errors: %w[consumer.consume.error])
+
+create_topic(name: DT.topics[0], partitions: 10)
+create_topic(name: DT.topics[1], partitions: 10)
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    raise StandardError
+  end
+end
+
+class DlqConsumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[0] << message.key
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    dead_letter_queue(topic: DT.topics[2], max_retries: 0)
+  end
+
+  topic DT.topics[1] do
+    consumer Consumer
+    dead_letter_queue(topic: DT.topics[2], max_retries: 0)
+  end
+
+  topic DT.topics[2] do
+    consumer DlqConsumer
+  end
+end
+
+elements = DT.uuids(10)
+produce_many(DT.topics[0], elements)
+produce_many(DT.topics[1], elements)
+
+start_karafka_and_wait_until do
+  DT[0].count >= 20
+end
+
+set = Set.new
+topics = [DT.topics[0], DT.topics[1]]
+
+DT[0].each do |key|
+  assert topics.any? do |topic|
+    key.start_with?("#{topic}: ")
+  end
+
+  set << key.split(': ').first
+end
+
+assert_equal 2, set.size


### PR DESCRIPTION
This PR changes the DLQ dispatch key to make the distribution better in case of multi-partition single DLQ topic.