### PR TITLE
VP + DLQ collapse of the collective state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Karafka framework changelog
 
 ## 2.0.28 (Unreleased)
+- **[Feature]** Provide the ability to use Dead Letter Queue with Virtual Partitions.
+- [Improvement] Collapse Virtual Partitions upon retryable error to a single partition. This allows dead letter queue to operate and mitigate issues arising from work virtualization. This removes uncertainties upon errors that can be retried and processed. Affects given topic partition virtualization only for multi-topic and mulit-partition parallelization. It also minimizes potential "flickering" where given data set has potentially many corrupted messages. The collapse will last until all the messages from the collective corrupted batch are processed. After that, virtualization will resume.
+- [Improvement] Introduce `#collapsed?` consumer method available for consumers using Virtual Partitions.
 - [Improvement] Allow for customization of DLQ dispatched message details in Pro (#1266) via the `#enhance_dlq_message` consumer method.
-- Include `original_consumer_group` in the DLQ dispatched messages in Pro.
-- Use Karafka `client_id` as kafka `client.id` value by default
-- Change Pro DLQ dispatch `key` default value to mitigate a scenario where one DLQ topic is used to pipe all the dead messages from multiple topics and all the data goes to one partition.
+- [Improvement] Include `original_consumer_group` in the DLQ dispatched messages in Pro.
+- [Improvement] Use Karafka `client_id` as kafka `client.id` value by default
+- [Improvement] Change Pro DLQ dispatch `key` default value to mitigate a scenario where one DLQ topic is used to pipe all the dead messages from multiple topics and all the data goes to one partition.
+- [Improvement]
 
 ### Upgrade notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@
 - [Improvement] Allow for customization of DLQ dispatched message details in Pro (#1266) via the `#enhance_dlq_message` consumer method.
 - [Improvement] Include `original_consumer_group` in the DLQ dispatched messages in Pro.
 - [Improvement] Use Karafka `client_id` as kafka `client.id` value by default
-- [Improvement] Change Pro DLQ dispatch `key` default value to mitigate a scenario where one DLQ topic is used to pipe all the dead messages from multiple topics and all the data goes to one partition.
-- [Improvement]
 
 ### Upgrade notes
 
@@ -21,21 +19,6 @@ class KarafkaApp < Karafka::App
     config.kafka = {
       'client.id': 'karafka'
     }
-```
-
-
-You can use the pro `#enhance_dlq_message` to remap the key back to how it was before this release:
-
-```ruby
-class DataConsumer < Karafka::BaseConsumer
-  # Rest of the code
-
-  private
-
-  def enhance_dlq_message(dlq_message_hash, skippable_message)
-    dlq_message_hash[:key] = skippable_message.partition.to_s
-  end
-end
 ```
 
 ## 2.0.27 (2023-01-11)

--- a/config/locales/pro_errors.yml
+++ b/config/locales/pro_errors.yml
@@ -5,7 +5,7 @@ en:
       virtual_partitions.max_partitions_format: needs to be equal or more than 1
       manual_offset_management_not_with_virtual_partitions: cannot be used together with Virtual Partitions
       long_running_job.active_format: needs to be either true or false
-      dead_letter_queue_not_with_virtual_partitions: cannot be used together with Virtual Partitions
+      dead_letter_queue_with_virtual_partitions: when using Dead Letter Queue with Virtual Partitions, at least one retry is required.
 
     config:
       encryption.active_format: 'needs to be either true or false'

--- a/lib/karafka/connection/listener.rb
+++ b/lib/karafka/connection/listener.rb
@@ -267,7 +267,7 @@ module Karafka
           # Start work coordination for this topic partition
           coordinator.start(messages)
 
-          @partitioner.call(topic, messages) do |group_id, partition_messages|
+          @partitioner.call(topic, messages, coordinator) do |group_id, partition_messages|
             # Count the job we're going to create here
             coordinator.increment
             executor = @executors.find_or_create(topic, partition, group_id)

--- a/lib/karafka/pro/active_job/consumer.rb
+++ b/lib/karafka/pro/active_job/consumer.rb
@@ -36,8 +36,9 @@ module Karafka
             )
 
             # We cannot mark jobs as done after each if there are virtual partitions. Otherwise
-            # this could create random markings
-            next if topic.virtual_partitions?
+            # this could create random markings.
+            # The exception here is the collapsed state where we can move one after another
+            next if topic.virtual_partitions? && !collapsed?
 
             mark_as_consumed(message)
           end

--- a/lib/karafka/pro/processing/collapser.rb
+++ b/lib/karafka/pro/processing/collapser.rb
@@ -41,7 +41,6 @@ module Karafka
         # @param offset [Integer] offset until which we keep the collapse
         def collapse_until!(offset)
           @mutex.synchronize do
-            @collapsed = true
             # We check it here in case after a pause and re-fetch we would get less messages and
             # one of them would cause an error. We do not want to overwrite the offset here unless
             # it is bigger.

--- a/lib/karafka/pro/processing/collapser.rb
+++ b/lib/karafka/pro/processing/collapser.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Processing
+      # Manages the collapse of virtual partitions
+      # Since any non-virtual partition is actually a virtual partition of size one, we can use
+      # it in a generic manner without having to distinguish between those cases.
+      #
+      # We need to have notion of the offset until we want to collapse because upon pause and retry
+      # rdkafka may purge the buffer. This means, that we may end up with smaller or bigger
+      # (different) dataset and without tracking the end of collapse, there would be a chance for
+      # things to flicker. Tracking allows us to ensure, that collapse is happening until all the
+      # messages from the corrupted batch are processed.
+      class Collapser
+        # When initialized, nothing is collapsed
+        def initialize
+          @collapsed = false
+          @until_offset = -1
+          @mutex = Mutex.new
+        end
+
+        # @return [Boolean] Should we collapse into a single consumer
+        def collapsed?
+          @collapsed
+        end
+
+        # Collapse until given offset. Until given offset is encountered or offset bigger than that
+        # we keep collapsing.
+        # @param offset [Integer] offset until which we keep the collapse
+        def collapse_until!(offset)
+          @mutex.synchronize do
+            @collapsed = true
+            # We check it here in case after a pause and re-fetch we would get less messages and
+            # one of them would cause an error. We do not want to overwrite the offset here unless
+            # it is bigger.
+            @until_offset = offset if offset > @until_offset
+          end
+        end
+
+        # Sets the collapse state based on the first collective offset that we are going to process
+        # and makes the decision whether or not we need to still keep the collapse.
+        # @param first_offset [Integer] first offset from a collective batch
+        def refresh!(first_offset)
+          @mutex.synchronize do
+            @collapsed = first_offset < @until_offset
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/processing/strategies/aj_dlq_lrj_mom_vp.rb
+++ b/lib/karafka/pro/processing/strategies/aj_dlq_lrj_mom_vp.rb
@@ -36,6 +36,7 @@ module Karafka
             virtual_partitions
           ].freeze
 
+          # This strategy is pretty much as non VP one because of the collapse
           def handle_after_consume
             coordinator.on_finished do |last_group_message|
               if coordinator.success?

--- a/lib/karafka/pro/processing/strategies/aj_dlq_mom_vp.rb
+++ b/lib/karafka/pro/processing/strategies/aj_dlq_mom_vp.rb
@@ -18,13 +18,15 @@ module Karafka
         # ActiveJob enabled
         # Manual offset management enabled
         # Virtual Partitions enabled
-        module AjMomVp
+        module AjDlqMomVp
+          include Dlq
           include Vp
           include Default
 
           # Features for this strategy
           FEATURES = %i[
             active_job
+            dead_letter_queue
             manual_offset_management
             virtual_partitions
           ].freeze
@@ -43,15 +45,19 @@ module Karafka
                 # processed.
                 # For a non virtual partitions case, the flow is regular and state is marked after
                 # each successfully processed job
-                #
-                # We can mark and we do mark intermediate jobs in the collapsed mode when running
-                # VPs
                 return if revoked?
                 return if Karafka::App.stopping?
 
                 mark_as_consumed(last_group_message)
-              else
+              elsif coordinator.pause_tracker.attempt <= topic.dead_letter_queue.max_retries
                 retry_after_pause
+              else
+                # Here we are in a collapsed state, hence we can apply the same logic as AjDlqMom
+                coordinator.pause_tracker.reset
+                skippable_message = find_skippable_message
+                dispatch_to_dlq(skippable_message) if dispatch_to_dlq?
+                mark_as_consumed(skippable_message)
+                pause(coordinator.seek_offset, nil, false)
               end
             end
           end

--- a/lib/karafka/pro/processing/strategies/aj_lrj_mom_vp.rb
+++ b/lib/karafka/pro/processing/strategies/aj_lrj_mom_vp.rb
@@ -21,6 +21,7 @@ module Karafka
         # Virtual Partitions enabled
         module AjLrjMomVp
           include Default
+          include Vp
 
           # Features for this strategy
           FEATURES = %i[

--- a/lib/karafka/pro/processing/strategies/aj_mom_vp.rb
+++ b/lib/karafka/pro/processing/strategies/aj_mom_vp.rb
@@ -19,6 +19,7 @@ module Karafka
         # Manual offset management enabled
         # Virtual Partitions enabled
         module AjMomVp
+          include Vp
           include Default
 
           # Features for this strategy

--- a/lib/karafka/pro/processing/strategies/default.rb
+++ b/lib/karafka/pro/processing/strategies/default.rb
@@ -53,10 +53,10 @@ module Karafka
             end
 
             # Mark job as successful
-            coordinator.consumption(self).success!
+            coordinator.success!(self)
           rescue StandardError => e
             # If failed, mark as failed
-            coordinator.consumption(self).failure!(e)
+            coordinator.failure!(self, e)
 
             # Re-raise so reported in the consumer
             raise e

--- a/lib/karafka/pro/processing/strategies/dlq.rb
+++ b/lib/karafka/pro/processing/strategies/dlq.rb
@@ -81,23 +81,14 @@ module Karafka
           # @param skippable_message [Array<Karafka::Messages::Message>]
           # @return [Hash] dispatch DLQ message
           def build_dlq_message(skippable_message)
-            original_topic = topic.name
             original_partition = skippable_message.partition.to_s
 
             dlq_message = {
               topic: topic.dead_letter_queue.topic,
-              # We use topic and partition to always dispatch data to the same partition in the DLQ
-              # We do not use only partition in case many DLQ dispatches would happen from many
-              # topics to the same DLQ topic partition.
-              #
-              # This handles a case where there is one DLQ topic for many topics and a lot of data
-              # goes there.
-              #
-              # We use the key in a format similar to one we use in the web-UI for consistency
-              key: "#{original_topic}: #{original_partition}",
+              key: original_partition,
               payload: skippable_message.raw_payload,
               headers: skippable_message.headers.merge(
-                'original_topic' => original_topic,
+                'original_topic' => topic.name,
                 'original_partition' => original_partition,
                 'original_offset' => skippable_message.offset.to_s,
                 'original_consumer_group' => topic.consumer_group.id

--- a/lib/karafka/pro/processing/strategies/dlq_lrj_vp.rb
+++ b/lib/karafka/pro/processing/strategies/dlq_lrj_vp.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Processing
+      module Strategies
+        # Dead-Letter Queue enabled
+        # Long-Running Job enabled
+        # Virtual Partitions enabled
+        module DlqLrjVp
+          # Same flow as the Dlq Lrj because VP collapses on errors, so DlqLrj can kick in
+          include Vp
+          include DlqLrj
+
+          # Features for this strategy
+          FEATURES = %i[
+            dead_letter_queue
+            long_running_job
+            virtual_partitions
+          ].freeze
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/processing/strategies/dlq_vp.rb
+++ b/lib/karafka/pro/processing/strategies/dlq_vp.rb
@@ -15,23 +15,21 @@ module Karafka
   module Pro
     module Processing
       module Strategies
-        # Just Virtual Partitions enabled
-        module Vp
-          # This flow is exactly the same as the default one because the default one is wrapper
-          # with `coordinator#on_finished`
-          include Default
-
+        # Dead Letter Queue enabled
+        # Virtual Partitions enabled
+        #
+        # In general because we collapse processing in virtual partitions to one on errors, there
+        # is no special action that needs to be taken because we warranty that even with VPs
+        # on errors a retry collapses into a single state.
+        module DlqVp
           # Features for this strategy
           FEATURES = %i[
+            dead_letter_queue
             virtual_partitions
           ].freeze
 
-          # @return [Boolean] is the virtual processing collapsed in the context of given consumer.
-          # @note Collapsed means, that we do not run virtual parallelization for a given batch
-          #   because of previous processing errors and a retry (hence attempt > 1)
-          def collapsed?
-            coordinator.pause_tracker.attempt > 1
-          end
+          include Dlq
+          include Vp
         end
       end
     end

--- a/lib/karafka/pro/processing/strategies/lrj_vp.rb
+++ b/lib/karafka/pro/processing/strategies/lrj_vp.rb
@@ -19,6 +19,7 @@ module Karafka
         # Virtual Partitions enabled
         module LrjVp
           # Same flow as the standard Lrj
+          include Vp
           include Lrj
 
           # Features for this strategy

--- a/lib/karafka/pro/processing/strategies/vp.rb
+++ b/lib/karafka/pro/processing/strategies/vp.rb
@@ -27,10 +27,8 @@ module Karafka
           ].freeze
 
           # @return [Boolean] is the virtual processing collapsed in the context of given consumer.
-          # @note Collapsed means, that we do not run virtual parallelization for a given batch
-          #   because of previous processing errors and a retry (hence attempt > 1)
           def collapsed?
-            coordinator.pause_tracker.attempt > 1
+            coordinator.collapsed?
           end
         end
       end

--- a/lib/karafka/processing/partitioner.rb
+++ b/lib/karafka/processing/partitioner.rb
@@ -12,9 +12,11 @@ module Karafka
 
       # @param _topic [String] topic name
       # @param messages [Array<Karafka::Messages::Message>] karafka messages
+      # @param _coordinator [Karafka::Processing::Coordinator] processing coordinator that will
+      #   be used with those messages
       # @yieldparam [Integer] group id
       # @yieldparam [Array<Karafka::Messages::Message>] karafka messages
-      def call(_topic, messages)
+      def call(_topic, messages, _coordinator)
         yield(0, messages)
       end
     end

--- a/lib/karafka/processing/strategies/default.rb
+++ b/lib/karafka/processing/strategies/default.rb
@@ -31,10 +31,9 @@ module Karafka
           end
 
           # Mark job as successful
-          coordinator.consumption(self).success!
+          coordinator.success!(self)
         rescue StandardError => e
-          # If failed, mark as failed
-          coordinator.consumption(self).failure!(e)
+          coordinator.failure!(self, e)
 
           # Re-raise so reported in the consumer
           raise e

--- a/spec/integrations/consumption/strategies/aj_mom/backoff_and_retry_on_error_spec.rb
+++ b/spec/integrations/consumption/strategies/aj_mom/backoff_and_retry_on_error_spec.rb
@@ -15,7 +15,7 @@ class Job < ActiveJob::Base
   queue_as DT.topic
 
   def perform
-    if DT[0].size.zero?
+    if DT[0].empty?
       DT[0] << '1'
       raise StandardError
     else

--- a/spec/integrations/consumption/strategies/dlq_mom/multi_partition_source_target_flow_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/multi_partition_source_target_flow_spec.rb
@@ -4,8 +4,8 @@
 
 setup_karafka(allow_errors: %w[consumer.consume.error])
 
-create_topic(name: DT.topics[0], partitions: 10)
-create_topic(name: DT.topics[1], partitions: 10)
+create_topic(name: DT.topics[0], partitions: 100)
+create_topic(name: DT.topics[1], partitions: 100)
 
 class Consumer < Karafka::BaseConsumer
   def consume
@@ -38,7 +38,7 @@ draw_routes do
   end
 end
 
-10.times do |i|
+100.times do |i|
   elements = DT.uuids(100)
   produce_many(DT.topic, elements, partition: i)
 end

--- a/spec/integrations/pro/consumption/strategies/aj_dlq_lrj_mom_vp/with_non_recoverable_job_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj_dlq_lrj_mom_vp/with_non_recoverable_job_error_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# Karafka should allow to run long AJ jobs with MOM, VPs and LRJ because we collapse upon errors.
+
+class Listener
+  def on_error_occurred(event)
+    DT[:errors] << event
+  end
+end
+
+SAMPLES = (0..1_000).to_a.map(&:to_s)
+
+setup_active_job
+
+Karafka.monitor.subscribe(Listener.new)
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 10
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+end
+
+class DlqConsumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[1] << message.headers['original_offset'].to_i
+    end
+  end
+end
+
+class Job < ActiveJob::Base
+  queue_as DT.topic
+
+  def perform(value)
+    # Make the 0 value last longer for consistency of this spec
+    sleep(15) if value.zero? && !DT[0].include?(0)
+    DT[0] << value
+    raise StandardError
+  end
+end
+
+draw_routes do
+  consumer_group DT.consumer_group do
+    active_job_topic DT.topic do
+      dead_letter_queue topic: DT.topics[1], max_retries: 4
+      # mom is enabled automatically
+      virtual_partitions(
+        partitioner: ->(_) { SAMPLES.pop }
+      )
+      long_running_job true
+    end
+
+    topic DT.topics[1] do
+      consumer DlqConsumer
+    end
+  end
+end
+
+5.times { |value| Job.perform_later(value) }
+
+start_karafka_and_wait_until do
+  DT[0].size >= 10 && DT[1].size >= 5
+end
+
+assert_equal (0..4).to_a, DT[1], DT[1]
+
+first_zero = DT[0].index(0)
+
+# We should skip and continue processing with each job after 4 retries
+DT[0][first_zero..24].each_slice(5).with_index do |slice, index|
+  assert_equal 1, slice.uniq.size, DT[0]
+  assert_equal index, slice.first, DT[0]
+end

--- a/spec/integrations/pro/consumption/strategies/aj_dlq_mom_vp/with_non_recoverable_job_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj_dlq_mom_vp/with_non_recoverable_job_error_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# Karafka should run the same strategy for AJ DLQ MOM VP as for AJ DLQ MOM as we collapse the
+# state and can move in a linear manner.
+
+class Listener
+  def on_error_occurred(event)
+    DT[:errors] << event
+  end
+end
+
+SAMPLES = (0..1_000).to_a.map(&:to_s)
+
+setup_active_job
+
+Karafka.monitor.subscribe(Listener.new)
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 10
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+end
+
+class DlqConsumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[1] << message.headers['original_offset'].to_i
+    end
+  end
+end
+
+class Job < ActiveJob::Base
+  queue_as DT.topic
+
+  def perform(value)
+    # Make the 0 value last longer for consistency of this spec
+    sleep(5) if value.zero? && !DT[0].include?(0)
+    DT[0] << value
+    raise StandardError
+  end
+end
+
+draw_routes do
+  consumer_group DT.consumer_group do
+    active_job_topic DT.topic do
+      dead_letter_queue topic: DT.topics[1], max_retries: 4
+      # mom is enabled automatically
+      virtual_partitions(
+        partitioner: ->(_) { SAMPLES.pop }
+      )
+    end
+
+    topic DT.topics[1] do
+      consumer DlqConsumer
+    end
+  end
+end
+
+5.times { |value| Job.perform_later(value) }
+
+start_karafka_and_wait_until do
+  DT[0].size >= 10 && DT[1].size >= 5
+end
+
+assert_equal (0..4).to_a, DT[1], DT[1]
+
+first_zero = DT[0].index(0)
+
+# We should skip and continue processing with each job after 4 retries
+DT[0][first_zero..24].each_slice(5).with_index do |slice, index|
+  assert_equal 1, slice.uniq.size, DT[0]
+  assert_equal index, slice.first, DT[0]
+end

--- a/spec/integrations/pro/consumption/strategies/dlq_lrj_vp/with_non_recoverable_slow_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_lrj_vp/with_non_recoverable_slow_error_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Karafka should be able to recover from non-critical error when using lrj with VP the same way
+# as any normal consumer and after few incidents it should move data to the DLQ and just continue
+# We collapse VP and retry in a collapsed mode, thus reducing this strategy to DlqLrj
+
+class Listener
+  def on_error_occurred(event)
+    DT[:errors] << event
+  end
+end
+
+Karafka.monitor.subscribe(Listener.new)
+
+setup_karafka(allow_errors: true) do |config|
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    sleep 15
+
+    messages.each do |message|
+      raise StandardError if messages.first.offset == 0
+
+      DT[0] << message.offset
+
+      mark_as_consumed(message) if collapsed?
+    end
+  end
+end
+
+class DlqConsumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[1] << message.headers['original_offset'].to_i
+    end
+  end
+end
+
+draw_routes do
+  consumer_group DT.consumer_group do
+    topic DT.topics[0] do
+      consumer Consumer
+      long_running_job true
+      dead_letter_queue topic: DT.topics[1]
+      virtual_partitions(
+        partitioner: ->(message) { message.raw_payload }
+      )
+    end
+
+    topic DT.topics[1] do
+      consumer DlqConsumer
+    end
+  end
+end
+
+produce_many(DT.topics[0], DT.uuids(5))
+
+start_karafka_and_wait_until do
+  !DT[1].empty?
+end
+
+assert_equal 4, DT[:errors].size
+assert_equal 0, DT[1].first
+assert_equal 1, DT[1].size

--- a/spec/integrations/pro/consumption/strategies/dlq_vp/collapse_and_continuity_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_vp/collapse_and_continuity_spec.rb
@@ -16,14 +16,14 @@ MUTEX = Mutex.new
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    messages.each do |message|
-      DT[:flow] << [message.offset, object_id, collapsed?]
-    end
-
     entered = false
 
     MUTEX.synchronize do
-      if DT[:raised].empty? && DT[:flow].count >= 9
+      messages.each do |message|
+        DT[:flow] << [message.offset, object_id, collapsed?]
+      end
+
+      if DT[:raised].empty? && DT[:flow].count >= 11
         DT[:raised] << true
         entered = true
       end

--- a/spec/integrations/pro/consumption/strategies/dlq_vp/collapse_and_continuity_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_vp/collapse_and_continuity_spec.rb
@@ -23,7 +23,7 @@ class Consumer < Karafka::BaseConsumer
         DT[:flow] << [message.offset, object_id, collapsed?]
       end
 
-      if DT[:raised].empty? && DT[:flow].count >= 9
+      if DT[:raised].empty? && DT[:flow].count >= 10
         DT[:raised] << true
         entered = true
       end
@@ -68,7 +68,9 @@ start_karafka_and_wait_until do
   sleep(0.1) until DT[:raised].empty?
   sleep(2)
 
-  sleep(0.1) until DT[:flow].count >= 20
+  # 10 from original + at least one from restart with collapse (which indicates all) + one
+  # tat indicates the moment (symbol one)
+  sleep(0.1) until DT[:flow].count >= 12
 
   produce_many(DT.topic, (0..9).to_a.map(&:to_s).shuffle)
 

--- a/spec/integrations/pro/consumption/strategies/dlq_vp/collapse_and_continuity_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_vp/collapse_and_continuity_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+# Karafka when with VP upon error should collapse the whole collective batch and should continue
+# processing in the collapsed mode after a back-off until all the "infected" messages are done.
+# After that, VPs should be resumed.
+#
+# In regards to DLQ, unless errors are persistent, DLQ should not kick in, so in this example
+# DLQ should not kick in
+
+setup_karafka(allow_errors: true) do |config|
+  config.concurrency = 5
+  config.max_messages = 100
+end
+
+MUTEX = Mutex.new
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[:flow] << [message.offset, object_id, collapsed?]
+    end
+
+    entered = false
+
+    MUTEX.synchronize do
+      if DT[:raised].empty? && DT[:flow].count >= 9
+        DT[:raised] << true
+        entered = true
+      end
+    end
+
+    if entered
+      sleep(2)
+      DT[:flow] << [:post_collapsed]
+      raise StandardError
+    end
+  end
+end
+
+class DlqConsumer < Karafka::BaseConsumer
+  def consume
+    exit 8
+  end
+end
+
+draw_routes do
+  consumer_group DT.consumer_group do
+    topic DT.topic do
+      consumer Consumer
+      virtual_partitions(
+        partitioner: ->(message) { message.raw_payload }
+      )
+      dead_letter_queue(
+        topic: DT.topics[1],
+        max_retries: 5
+      )
+    end
+
+    topic DT.topics[1] do
+      consumer DlqConsumer
+    end
+  end
+end
+
+start_karafka_and_wait_until do
+  produce_many(DT.topic, (0..9).to_a.map(&:to_s).shuffle)
+
+  sleep(0.1) until DT[:raised].empty?
+  sleep(2)
+
+  sleep(0.1) until DT[:flow].count >= 20
+
+  produce_many(DT.topic, (0..9).to_a.map(&:to_s).shuffle)
+
+  sleep(0.1) until DT[:flow].count >= 20
+
+  true
+end
+
+pre_collapse_index = DT[:flow].index { |row| row.first == :post_collapsed }
+pre_collapse = DT[:flow][0..(pre_collapse_index - 1)]
+pre_collapse_offsets = pre_collapse.map(&:first)
+
+# Pre collapse should process all from start till crash
+# We sort because order is not deterministic
+previous = nil
+pre_collapse_offsets.sort.each do |offset|
+  unless previous
+    previous = offset
+    next
+  end
+
+  assert_equal previous + 1, offset
+  previous = offset
+end
+
+# Pre collapse should run in multiple threads
+assert pre_collapse.map { |row| row[1] }.uniq.count >= 2
+
+# None of pre-collapse should be marked as collapsed
+assert pre_collapse.none? { |row| row.last }
+
+collapsed = []
+flipped = false
+flipped_index = nil
+last_collapsed_index = nil
+
+DT[:flow].each_with_index do |row, index|
+  next unless row.last
+  next if row.first.is_a?(Symbol)
+
+  collapsed << row
+  last_collapsed_index = index
+
+  if row.last == false
+    flipped = true
+    flipped_index = index
+  end
+end
+
+# Once we stop getting collapsed data, it should not appear again
+assert !flipped
+assert_equal nil, flipped_index
+
+# Collapsed should run in a single thread
+assert_equal 1, collapsed.map { |row| row[1] }.uniq.count
+
+# All collapsed need to be in the pre collapsed because of retry
+assert (collapsed.map(&:first) - pre_collapse_offsets).empty?
+
+# All collapsed must be in order
+previous = nil
+collapsed.map(&:first).each do |offset|
+  unless previous
+    previous = offset
+    next
+  end
+
+  assert_equal previous + 1, offset
+  previous = offset
+end
+
+uncollapsed = DT[:flow][(last_collapsed_index + 1)..]
+
+# All post-collapse should not be collapsed
+assert uncollapsed.none?(&:last)
+
+# Post collapse should run in multiple threads
+assert uncollapsed.map { |row| row[1] }.uniq.count >= 2
+
+# None of those processed later in parallel should be in the previous sets
+assert (uncollapsed.map(&:first) & collapsed.map(&:first)).empty?
+assert (uncollapsed.map(&:first) & pre_collapse.map(&:first)).empty?

--- a/spec/integrations/pro/consumption/strategies/dlq_vp/collapse_and_continuity_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_vp/collapse_and_continuity_spec.rb
@@ -23,7 +23,7 @@ class Consumer < Karafka::BaseConsumer
         DT[:flow] << [message.offset, object_id, collapsed?]
       end
 
-      if DT[:raised].empty? && DT[:flow].count >= 11
+      if DT[:raised].empty? && DT[:flow].count >= 9
         DT[:raised] << true
         entered = true
       end

--- a/spec/integrations/pro/consumption/strategies/dlq_vp/collapse_and_continuity_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_vp/collapse_and_continuity_spec.rb
@@ -66,15 +66,17 @@ start_karafka_and_wait_until do
   produce_many(DT.topic, (0..9).to_a.map(&:to_s).shuffle)
 
   sleep(0.1) until DT[:raised].empty?
-  sleep(2)
+  sleep(5)
 
   # 10 from original + at least one from restart with collapse (which indicates all) + one
   # tat indicates the moment (symbol one)
   sleep(0.1) until DT[:flow].count >= 12
+  sleep(5)
 
   produce_many(DT.topic, (0..9).to_a.map(&:to_s).shuffle)
 
   sleep(0.1) until DT[:flow].count >= 20
+  sleep(5)
 
   true
 end

--- a/spec/integrations/pro/consumption/strategies/dlq_vp/skip_after_collapse_many_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_vp/skip_after_collapse_many_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# DLQ in the VP mode should collapse and skip when error occurs again in a collapsed mode also
+# when there are many errors in the same collective batch. In a scenario like this, we should
+# collapse and skip one after another.
+
+setup_karafka(allow_errors: true) do |config|
+  config.concurrency = 10
+  config.max_messages = 100
+end
+
+MUTEX = Mutex.new
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      # Simulates a broken message that for example one that cannot be deserialized
+      raise StandardError if message.raw_payload.to_i <= 9
+
+      # Mark only in a collapsed mode
+      mark_as_consumed(message) if collapsed?
+
+      DT[:flow] << [message.offset, object_id, collapsed?]
+
+      next if DT[:post].empty?
+
+      DT[:flow2] << [message.offset, object_id, collapsed?]
+    end
+  end
+end
+
+class DlqConsumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[:dlq] << message
+    end
+  end
+end
+
+draw_routes do
+  consumer_group DT.consumer_group do
+    topic DT.topic do
+      consumer Consumer
+      virtual_partitions(
+        partitioner: ->(message) { message.raw_payload }
+      )
+      dead_letter_queue(
+        topic: DT.topics[1],
+        max_retries: 1
+      )
+    end
+
+    topic DT.topics[1] do
+      consumer DlqConsumer
+    end
+  end
+end
+
+produce_many(DT.topic, (0..99).to_a.map(&:to_s))
+
+start_karafka_and_wait_until do
+  if DT[:dlq].size >= 10 && DT[:flow].size >= 90
+    produce_many(DT.topic, (100..109).to_a.map(&:to_s)) if DT[:post].empty?
+    DT[:post] << true
+    DT[:flow2].size >= 10
+  else
+    false
+  end
+end
+
+# In the DLQ we should have all the skipped in the correct order because of the collapse-skip
+assert_equal 10, DT[:dlq].size
+assert_equal (0..9).to_a, DT[:dlq].map { |message| message.raw_payload.to_i }
+
+# Skipped should not be in the flow at all
+assert DT[:flow].none? { |row| row.first <= 9 }
+
+# A batch dispatched after the recovery should use VP back
+assert DT[:flow2].none?(&:last)
+
+threads = DT[:flow2].map { |row| row[1] }.uniq.count
+assert threads >= 2

--- a/spec/integrations/pro/consumption/strategies/dlq_vp/skip_after_collapse_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_vp/skip_after_collapse_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# DLQ in the VP mode should collapse and allow to skip when error occurs again in a collapsed mode
+# DLQ in the VP mode should collapse and skip when error occurs again in a collapsed mode
 
 setup_karafka(allow_errors: true) do |config|
   config.concurrency = 5
@@ -12,6 +12,7 @@ MUTEX = Mutex.new
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
+      # Simulates a broken message that for example cannot be deserialized
       raise StandardError if message.raw_payload == '5'
 
       # Mark only in a collapsed mode

--- a/spec/integrations/pro/consumption/strategies/dlq_vp/skip_after_collapse_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_vp/skip_after_collapse_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # DLQ in the VP mode should collapse and skip when error occurs again in a collapsed mode
+# After that, we should move to processing in a non-collapsed mode again
 
 setup_karafka(allow_errors: true) do |config|
   config.concurrency = 5
@@ -12,8 +13,8 @@ MUTEX = Mutex.new
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      # Simulates a broken message that for example cannot be deserialized
-      raise StandardError if message.raw_payload == '5'
+      # Simulates a broken message that for example one that cannot be deserialized
+      raise StandardError if message.offset == 5
 
       # Mark only in a collapsed mode
       mark_as_consumed(message) if collapsed?
@@ -53,9 +54,30 @@ end
 produce_many(DT.topic, (0..9).to_a.map(&:to_s))
 
 start_karafka_and_wait_until do
-  !DT[:dlq].empty?
+  if !DT[:dlq].empty? && !DT[:flow].include?([:post_dlq])
+    sleep(5)
+    DT[:flow] << [:post_dlq]
+    produce_many(DT.topic, (10..19).to_a.map(&:to_s))
+  end
+
+  DT[:flow].size >= 20
 end
 
-p DT[:dlq]
+# We should not have in our data message with offset 5 as it failed
+assert DT[:flow].none? { |row| row.first == 5 }
 
-p DT[:flow]
+# It should be moved to DLQ
+assert_equal 5, DT[:dlq].first.headers['original_offset'].to_i
+
+# One message should be moved
+assert_equal 1, DT[:dlq].size
+
+# After we got back to running VPs, all should run in VP
+uncollapsed_index = DT[:flow].index { |row| row == [:post_dlq] }
+uncollapsed = DT[:flow][(uncollapsed_index + 1)..100]
+
+# All post-collapse should not be collapsed
+assert uncollapsed.none?(&:last)
+
+# Post collapse should run in multiple threads
+assert uncollapsed.map { |row| row[1] }.uniq.count >= 2

--- a/spec/integrations/pro/consumption/strategies/dlq_vp/skip_after_collapse_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_vp/skip_after_collapse_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# DLQ in the VP mode should collapse and allow to skip when error occurs again in a collapsed mode
+
+setup_karafka(allow_errors: true) do |config|
+  config.concurrency = 5
+  config.max_messages = 100
+end
+
+MUTEX = Mutex.new
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      raise StandardError if message.raw_payload == '5'
+
+      # Mark only in a collapsed mode
+      mark_as_consumed(message) if collapsed?
+
+      DT[:flow] << [message.offset, object_id, collapsed?]
+    end
+  end
+end
+
+class DlqConsumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[:dlq] << message
+    end
+  end
+end
+
+draw_routes do
+  consumer_group DT.consumer_group do
+    topic DT.topic do
+      consumer Consumer
+      virtual_partitions(
+        partitioner: ->(message) { message.raw_payload }
+      )
+      dead_letter_queue(
+        topic: DT.topics[1],
+        max_retries: 1
+      )
+    end
+
+    topic DT.topics[1] do
+      consumer DlqConsumer
+    end
+  end
+end
+
+produce_many(DT.topic, (0..9).to_a.map(&:to_s))
+
+start_karafka_and_wait_until do
+  !DT[:dlq].empty?
+end
+
+p DT[:dlq]
+
+p DT[:flow]

--- a/spec/integrations/pro/consumption/strategies/dlq_vp/skip_after_collapse_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_vp/skip_after_collapse_spec.rb
@@ -64,7 +64,7 @@ start_karafka_and_wait_until do
 end
 
 # We should not have in our data message with offset 5 as it failed
-assert DT[:flow].none? { |row| row.first == 5 }
+assert(DT[:flow].none? { |row| row.first == 5 })
 
 # It should be moved to DLQ
 assert_equal 5, DT[:dlq].first.headers['original_offset'].to_i

--- a/spec/integrations/pro/consumption/strategies/vp/collapse_and_continuity_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/collapse_and_continuity_spec.rb
@@ -20,16 +20,13 @@ class Consumer < Karafka::BaseConsumer
         DT[:flow] << [message.offset, object_id, collapsed?]
       end
 
-      if DT[:raised].empty? && DT[:flow].count >= 9
+      if DT[:raised].empty? && DT[:flow].count >= 10
         DT[:raised] << true
         entered = true
+        sleep(2)
+        DT[:flow] << [:post_collapsed]
+        raise StandardError
       end
-    end
-
-    if entered
-      sleep(2)
-      DT[:flow] << [:post_collapsed]
-      raise StandardError
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/vp/collapse_and_continuity_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/collapse_and_continuity_spec.rb
@@ -13,13 +13,13 @@ MUTEX = Mutex.new
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    messages.each do |message|
-      DT[:flow] << [message.offset, object_id, collapsed?]
-    end
-
     entered = false
 
     MUTEX.synchronize do
+      messages.each do |message|
+        DT[:flow] << [message.offset, object_id, collapsed?]
+      end
+
       if DT[:raised].empty? && DT[:flow].count >= 9
         DT[:raised] << true
         entered = true

--- a/spec/integrations/pro/consumption/strategies/vp/collapse_and_continuity_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/collapse_and_continuity_spec.rb
@@ -7,10 +7,11 @@
 setup_karafka(allow_errors: true) do |config|
   config.concurrency = 5
   config.max_messages = 100
+  config.max_wait_time = 10_000
 end
 
 MUTEX = Mutex.new
-SLEEP = 10
+SLEEP = 30
 
 class Consumer < Karafka::BaseConsumer
   def consume

--- a/spec/integrations/pro/consumption/strategies/vp/collapse_and_continuity_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/collapse_and_continuity_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# Karafka when with VP upon error should collapse the whole collective batch and should continue
+# processing in the collapsed mode after a back-off until all the "infected" messages are done.
+# After that, VPs should be resumed.
+
+setup_karafka(allow_errors: true) do |config|
+  config.concurrency = 5
+  config.max_messages = 100
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    return if messages.count == 1
+    return if DT[:post_warmup].empty?
+
+    unless DT[:post_collapse_run].empty?
+      messages.each do |message|
+        DT[:post_collapse] << [message.offset, object_id, collapsed?]
+      end
+
+      return
+    end
+
+    if collapsed?
+      messages.each do |message|
+        DT[:collapsed] << [message.offset, object_id]
+      end
+    else
+      messages.each do |message|
+        DT[:not_collapsed] << [message.offset, object_id]
+      end
+
+      if DT[:raised].empty?
+        DT[:raised] << true
+        raise StandardError
+      end
+    end
+  end
+end
+
+draw_routes do
+  consumer_group DT.consumer_group do
+    topic DT.topic do
+      consumer Consumer
+      virtual_partitions(
+        partitioner: ->(message) { message.raw_payload }
+      )
+    end
+  end
+end
+
+warmup = false
+
+start_karafka_and_wait_until do
+  unless warmup
+    warmup = true
+    produce_many(DT.topic, %w[0])
+    DT[:post_warmup] << true
+  end
+
+  produce_many(DT.topic, (0..9).to_a.map(&:to_s).shuffle)
+
+  sleep(10)
+
+  produce_many(DT.topic, (0..9).to_a.map(&:to_s).shuffle)
+
+  sleep(10)
+
+  DT[:post_collapse_run] << true
+
+  produce_many(DT.topic, (0..9).to_a.map(&:to_s).shuffle)
+
+  sleep(0.1) until DT[:post_collapse].size >= 10
+
+  true
+end
+
+assert_equal 20, DT[:not_collapsed].size
+assert_equal 10, DT[:collapsed].size
+assert_equal 10, DT[:post_collapse].size

--- a/spec/integrations/pro/consumption/strategies/vp/collapse_and_continuity_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/collapse_and_continuity_spec.rb
@@ -49,13 +49,17 @@ start_karafka_and_wait_until do
   produce_many(DT.topic, (0..9).to_a.map(&:to_s).shuffle)
 
   sleep(0.1) until DT[:raised].empty?
-  sleep(2)
+  sleep(5)
 
-  sleep(0.1) until DT[:flow].count >= 20
+  # 10 from original + at least one from restart with collapse (which indicates all) + one
+  # tat indicates the moment (symbol one)
+  sleep(0.1) until DT[:flow].count >= 12
+  sleep(5)
 
   produce_many(DT.topic, (0..9).to_a.map(&:to_s).shuffle)
 
   sleep(0.1) until DT[:flow].count >= 20
+  sleep(5)
 
   true
 end

--- a/spec/integrations/pro/consumption/strategies/vp/collapse_and_continuity_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/collapse_and_continuity_spec.rb
@@ -9,23 +9,30 @@ setup_karafka(allow_errors: true) do |config|
   config.max_messages = 100
 end
 
-MUTEX = Mutex.new
-
 class Consumer < Karafka::BaseConsumer
   def consume
-    entered = false
+    messages.each do |message|
+      DT[:flow] << [message.offset, object_id, collapsed?]
+    end
 
-    MUTEX.synchronize do
-      messages.each do |message|
-        DT[:flow] << [message.offset, object_id, collapsed?]
-      end
+    messages.each do |message|
+      next unless message.raw_payload.to_i == 9
 
-      if DT[:raised].empty? && DT[:flow].count >= 10
-        DT[:raised] << true
-        entered = true
+      if DT[:raised].empty?
+        # Sleep needed to make sure all other VPs are done
         sleep(2)
-        DT[:flow] << [:post_collapsed]
+        DT[:flow] << [:collapsed]
+        DT[:raised] << true
+
         raise StandardError
+      else
+        DT[:flow] << [:post_collapsed]
+
+        Thread.new do
+          sleep(2)
+
+          produce_many(DT.topic, (10..19).to_a.map(&:to_s))
+        end
       end
     end
   end
@@ -42,27 +49,17 @@ draw_routes do
   end
 end
 
+produce_many(DT.topic, (0..9).to_a.map(&:to_s))
+
 start_karafka_and_wait_until do
-  produce_many(DT.topic, (0..9).to_a.map(&:to_s).shuffle)
+  step = (DT[:flow].last || []).first
 
-  sleep(0.1) until DT[:raised].empty?
-  sleep(5)
-
-  # 10 from original + at least one from restart with collapse (which indicates all) + one
-  # tat indicates the moment (symbol one)
-  sleep(0.1) until DT[:flow].count >= 12
-  sleep(5)
-
-  produce_many(DT.topic, (0..9).to_a.map(&:to_s).shuffle)
-
-  sleep(0.1) until DT[:flow].count >= 20
-  sleep(5)
-
-  true
+  # 20 messages + 2 control records
+  DT[:flow].any? { |row| row.first == 19 && row.last == false } && DT[:flow].count >= 22
 end
 
-pre_collapse_index = DT[:flow].index { |row| row.first == :post_collapsed }
-pre_collapse = DT[:flow][0..(pre_collapse_index - 1)]
+pre_collapse_index = DT[:flow].index { |row| row.last } - 1
+pre_collapse = DT[:flow][0..pre_collapse_index]
 pre_collapse_offsets = pre_collapse.map(&:first)
 
 # Pre collapse should process all from start till crash
@@ -124,7 +121,8 @@ collapsed.map(&:first).each do |offset|
   previous = offset
 end
 
-uncollapsed = DT[:flow][(last_collapsed_index + 1)..]
+uncollapsed_index = DT[:flow].index { |row| row == [:post_collapsed] }
+uncollapsed = DT[:flow][(uncollapsed_index + 1)..100]
 
 # All post-collapse should not be collapsed
 assert uncollapsed.none?(&:last)

--- a/spec/integrations/pro/consumption/strategies/vp/custom_partitioning_engine_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/custom_partitioning_engine_spec.rb
@@ -14,7 +14,7 @@ REGULAR_TOPIC = DT.topics[1]
 become_pro!
 
 class CustomPartitioner < Karafka::Pro::Processing::Partitioner
-  def call(topic_name, messages, &block)
+  def call(topic_name, messages, coordinator, &block)
     if topic_name == SPECIAL_TOPIC
       balanced_strategy(messages, &block)
     else

--- a/spec/integrations/pro/consumption/strategies/vp/with_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/with_error_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 # When Karafka consumes in the VP mode and error happens in any of the processing units we allow
-# the rest to finish the work and we restart the processing from the first offset on a batch.
+# the rest to finish the work and we restart the processing from the first offset on a batch
+# in a collapsed mode.
+#
 # This spec raises only one error once
 
 class Listener
@@ -51,9 +53,8 @@ start_karafka_and_wait_until do
   DT[0].size >= 6
 end
 
-assert DT[0].size >= 6
+assert DT[0].size >= 6, DT[0]
 # It should parallelize work
-assert DT[1].uniq.size >= 2
 assert_equal 1, DT[:errors].size
 assert_equal StandardError, DT[:errors].first[:error].class
 assert_equal 'consumer.consume.error', DT[:errors].first[:type]

--- a/spec/integrations/pro/consumption/strategies/vp/with_pause_on_collapsed_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/with_pause_on_collapsed_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# While VPs do not support pausing in the regular flow, we can pause while running VP when
+# collapsed. This can be used to provide a manual back-off if we would want.
+
+setup_karafka(allow_errors: true) do |config|
+  config.concurrency = 10
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each { |message| DT[0] << [message.offset, collapsed?, Time.now.to_f] }
+
+    if collapsed?
+      pause(messages.last.offset - 1, 10_000)
+    elsif DT[:raised].empty?
+      DT[:raised] << true
+      raise StandardError
+    end
+  end
+end
+
+draw_routes do
+  consumer_group DT.consumer_group do
+    topic DT.topic do
+      consumer Consumer
+      virtual_partitions(
+        partitioner: ->(msg) { msg.raw_payload }
+      )
+    end
+  end
+end
+
+produce_many(DT.topic, DT.uuids(5))
+
+start_karafka_and_wait_until do
+  DT[0].size >= 7
+end
+
+# We should have two messages next to each other in the flow that are distanced by at least 10
+# seconds, which will be the equivalent of the pause.
+
+previous = nil
+distances = []
+
+DT[0].each do |row|
+  unless previous
+    previous = row
+    next
+  end
+
+  distances << row.last - previous.last
+
+  previous = row
+end
+
+assert distances.max >= 10

--- a/spec/integrations/pro/consumption/strategies/vp/with_pause_on_collapsed_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/with_pause_on_collapsed_spec.rb
@@ -12,7 +12,7 @@ class Consumer < Karafka::BaseConsumer
     messages.each { |message| DT[0] << [message.offset, collapsed?, Time.now.to_f] }
 
     if collapsed?
-      pause(messages.last.offset - 1, 10_000)
+      pause(3, 10_000)
     elsif DT[:raised].empty?
       DT[:raised] << true
       raise StandardError

--- a/spec/integrations/pro/rails/active_job/long_running_jobs/with_error_spec.rb
+++ b/spec/integrations/pro/rails/active_job/long_running_jobs/with_error_spec.rb
@@ -20,7 +20,7 @@ class Job < ActiveJob::Base
   def perform
     sleep 5
 
-    if DT[0].size.zero?
+    if DT[0].empty?
       DT[0] << '1'
       raise StandardError
     else

--- a/spec/integrations/pro/rails/active_job/long_running_jobs/with_shutdown_pickup_spec.rb
+++ b/spec/integrations/pro/rails/active_job/long_running_jobs/with_shutdown_pickup_spec.rb
@@ -30,7 +30,7 @@ class Job < ActiveJob::Base
 
   def perform(value)
     # We add sleep to simulate work being done, so it ain't done too fast before we shutdown
-    if DT[:stopping].size.zero?
+    if DT[:stopping].empty?
       DT[:stopping] << true
       sleep(5)
     end
@@ -42,7 +42,7 @@ end
 5.times { |value| Job.perform_later(value) }
 
 start_karafka_and_wait_until do
-  !DT[:stopping].size.zero?
+  !DT[:stopping].empty?
 end
 
 # Give Karafka time to finalize everything

--- a/spec/integrations/pro/rails/active_job/processing_few_on_shutdown_lrj_spec.rb
+++ b/spec/integrations/pro/rails/active_job/processing_few_on_shutdown_lrj_spec.rb
@@ -29,7 +29,7 @@ class Job < ActiveJob::Base
 
   def perform(value)
     # We add sleep to simulate work being done, so it ain't done too fast before we shutdown
-    if DT[:stopping].size.zero?
+    if DT[:stopping].empty?
       DT[:stopping] << true
       sleep(5)
     end
@@ -41,7 +41,7 @@ end
 5.times { |value| Job.perform_later(value) }
 
 start_karafka_and_wait_until do
-  !DT[:stopping].size.zero?
+  !DT[:stopping].empty?
 end
 
 assert_equal 1, DT[0].size

--- a/spec/integrations/pro/rails/active_job/processing_few_on_shutdown_spec.rb
+++ b/spec/integrations/pro/rails/active_job/processing_few_on_shutdown_spec.rb
@@ -26,7 +26,7 @@ class Job < ActiveJob::Base
 
   def perform(value)
     # We add sleep to simulate work being done, so it ain't done too fast before we shutdown
-    if DT[:stopping].size.zero?
+    if DT[:stopping].empty?
       DT[:stopping] << true
       sleep(5)
     end
@@ -38,7 +38,7 @@ end
 5.times { |value| Job.perform_later(value) }
 
 start_karafka_and_wait_until do
-  !DT[:stopping].size.zero?
+  !DT[:stopping].empty?
 end
 
 assert_equal 1, DT[0].size

--- a/spec/integrations/pro/rails/active_job/virtual_partitions/with_error_spec.rb
+++ b/spec/integrations/pro/rails/active_job/virtual_partitions/with_error_spec.rb
@@ -23,7 +23,7 @@ class Job < ActiveJob::Base
   queue_as DT.topic
 
   def perform
-    if DT[0].size.zero?
+    if DT[0].empty?
       DT[0] << '1'
       raise StandardError
     else

--- a/spec/integrations/pro/routing/dlq_with_vp_spec.rb
+++ b/spec/integrations/pro/routing/dlq_with_vp_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Karafka should not allow for using VP with DLQ
+# Karafka should not allow for using VP with DLQ without retries
 
 setup_karafka do |config|
   config.concurrency = 10
@@ -16,7 +16,10 @@ begin
         virtual_partitions(
           partitioner: ->(msg) { msg.raw_payload }
         )
-        dead_letter_queue topic: 'test'
+        dead_letter_queue(
+          topic: 'test',
+          max_retries: 0
+        )
       end
     end
   end

--- a/spec/lib/karafka/pro/active_job/consumer_spec.rb
+++ b/spec/lib/karafka/pro/active_job/consumer_spec.rb
@@ -82,6 +82,8 @@ RSpec.describe_current do
     end
 
     context 'when messages are available to the consumer and it is virtual partition' do
+      let(:strategy) { Karafka::Pro::Processing::Strategies::AjMomVp }
+
       before do
         consumer.messages = messages
 

--- a/spec/lib/karafka/pro/processing/collapser_spec.rb
+++ b/spec/lib/karafka/pro/processing/collapser_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  pending
+end

--- a/spec/lib/karafka/pro/processing/collapser_spec.rb
+++ b/spec/lib/karafka/pro/processing/collapser_spec.rb
@@ -1,5 +1,72 @@
 # frozen_string_literal: true
 
 RSpec.describe_current do
-  pending
+  subject(:collapser) { described_class.new }
+
+  it 'expect not to be collapsed by default' do
+    expect(collapser.collapsed?).to eq(false)
+  end
+
+  context 'when no changes to until by default and reset' do
+    before { collapser.refresh!(100) }
+
+    it { expect(collapser.collapsed?).to eq(false) }
+  end
+
+  context 'when collapsed until previous offset' do
+    before do
+      collapser.collapse_until!(10)
+      collapser.refresh!(100)
+    end
+
+    it { expect(collapser.collapsed?).to eq(false) }
+  end
+
+  context 'when collapsed until future offset' do
+    before do
+      collapser.collapse_until!(10000)
+      collapser.refresh!(100)
+    end
+
+    it { expect(collapser.collapsed?).to eq(true) }
+  end
+
+  context 'when collapsed until the offset' do
+    before do
+      collapser.collapse_until!(100)
+      collapser.refresh!(100)
+    end
+
+    it { expect(collapser.collapsed?).to eq(false) }
+  end
+
+  context 'when collapsed but not refreshed' do
+    before { collapser.collapse_until!(100) }
+
+    it { expect(collapser.collapsed?).to eq(false) }
+  end
+
+  context 'when collapsed multiple times with earlier offsets' do
+    before do
+      collapser.collapse_until!(100)
+      collapser.collapse_until!(10)
+      collapser.collapse_until!(1)
+
+      collapser.refresh!(99)
+    end
+
+    it { expect(collapser.collapsed?).to eq(true) }
+  end
+
+  context 'when collapsed multiple times with earlier offsets and refresh with younger' do
+    before do
+      collapser.collapse_until!(100)
+      collapser.collapse_until!(10)
+      collapser.collapse_until!(1)
+
+      collapser.refresh!(101)
+    end
+
+    it { expect(collapser.collapsed?).to eq(false) }
+  end
 end

--- a/spec/lib/karafka/pro/processing/collapser_spec.rb
+++ b/spec/lib/karafka/pro/processing/collapser_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe_current do
 
   context 'when collapsed until future offset' do
     before do
-      collapser.collapse_until!(10000)
+      collapser.collapse_until!(10_000)
       collapser.refresh!(100)
     end
 

--- a/spec/lib/karafka/pro/processing/coordinator_spec.rb
+++ b/spec/lib/karafka/pro/processing/coordinator_spec.rb
@@ -103,10 +103,18 @@ RSpec.describe_current do
   end
 
   describe '#failure!' do
-    before { coordinator.failure!(consumer, StandardError.new) }
+    context 'when there is a failure' do
+      before { coordinator.failure!(consumer, StandardError.new) }
 
-    it 'expect to collapse' do
-      expect(coordinator.collapsed?).to eq(true)
+      it 'expect not to collapse immediately after it' do
+        expect(coordinator.collapsed?).to eq(false)
+      end
+
+      context 'when we start again after it' do
+        before { coordinator.start(messages) }
+
+        it { expect(coordinator.collapsed?).to eq(true) }
+      end
     end
   end
 end

--- a/spec/lib/karafka/pro/processing/coordinator_spec.rb
+++ b/spec/lib/karafka/pro/processing/coordinator_spec.rb
@@ -6,10 +6,38 @@ RSpec.describe_current do
   let(:pause_tracker) { build(:time_trackers_pause) }
   let(:last_message) { build(:messages_message) }
   let(:messages) { [last_message] }
+  let(:consumer) { instance_double(Karafka::BaseConsumer, messages: messages) }
 
   it { expect(described_class).to be < Karafka::Processing::Coordinator }
+  it { expect(coordinator.collapsed?).to eq(false) }
 
   before { coordinator.start(messages) }
+
+  describe '#start' do
+    context 'when we start in a non-collapsed state' do
+      before { coordinator.start(messages) }
+
+      it { expect(coordinator.collapsed?).to eq(false) }
+    end
+
+    context 'when we start in a collapsed state that lapses' do
+      before do
+        coordinator.failure!(consumer, StandardError.new)
+        coordinator.start(messages)
+      end
+
+      it { expect(coordinator.collapsed?).to eq(true) }
+    end
+
+    context 'when we start in a collapsed state that does not lapse' do
+      before do
+        coordinator.failure!(consumer, StandardError.new)
+        coordinator.start([build(:messages_message)])
+      end
+
+      it { expect(coordinator.collapsed?).to eq(false) }
+    end
+  end
 
   describe '#finished?' do
     context 'when no jobs are running' do
@@ -71,6 +99,14 @@ RSpec.describe_current do
       it 'expect not to run again' do
         expect { |block| coordinator.on_finished(&block) }.not_to yield_control
       end
+    end
+  end
+
+  describe '#failure!' do
+    before { coordinator.failure!(consumer, StandardError.new) }
+
+    it 'expect to collapse' do
+      expect(coordinator.collapsed?).to eq(true)
     end
   end
 end

--- a/spec/lib/karafka/pro/processing/partitioner_spec.rb
+++ b/spec/lib/karafka/pro/processing/partitioner_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe_current do
 
   let(:subscription_group) { build(:routing_subscription_group) }
   let(:concurrency) { 1 }
+  let(:coordinator) { build(:processing_coordinator_pro) }
   let(:topic) { subscription_group.topics.first }
   let(:messages) { Array.new(100) { build(:messages_message) } }
 
@@ -16,7 +17,7 @@ RSpec.describe_current do
 
   context 'when we do not use virtual partitions' do
     it 'expect to yield with 0 and input messages' do
-      expect { |block| partitioner.call(topic.name, messages, &block) }
+      expect { |block| partitioner.call(topic.name, messages, coordinator, &block) }
         .to yield_with_args(0, messages)
     end
   end
@@ -25,7 +26,7 @@ RSpec.describe_current do
     before { topic.virtual_partitions(partitioner: ->(_) { rand }) }
 
     it 'expect to yield with 0 and input messages' do
-      expect { |block| partitioner.call(topic.name, messages, &block) }
+      expect { |block| partitioner.call(topic.name, messages, coordinator, &block) }
         .to yield_with_args(0, messages)
     end
   end
@@ -34,7 +35,7 @@ RSpec.describe_current do
     let(:concurrency) { 5 }
     let(:yielded) do
       yielded = []
-      partitioner.call(topic.name, messages) { |*args| yielded << args }
+      partitioner.call(topic.name, messages, coordinator) { |*args| yielded << args }
       yielded
     end
 
@@ -65,7 +66,7 @@ RSpec.describe_current do
     let(:concurrency) { 5 }
     let(:yielded) do
       yielded = []
-      partitioner.call(topic.name, messages) { |*args| yielded << args }
+      partitioner.call(topic.name, messages, coordinator) { |*args| yielded << args }
       yielded
     end
 

--- a/spec/lib/karafka/pro/processing/strategies/aj_dlq_lrj_mom_vp_spec.rb
+++ b/spec/lib/karafka/pro/processing/strategies/aj_dlq_lrj_mom_vp_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  let(:combination) do
+    %i[
+      active_job
+      long_running_job
+      manual_offset_management
+      dead_letter_queue
+      virtual_partitions
+    ]
+  end
+
+  it { expect(described_class::FEATURES).to eq(combination) }
+end

--- a/spec/lib/karafka/pro/processing/strategies/aj_dlq_mom_vp_spec.rb
+++ b/spec/lib/karafka/pro/processing/strategies/aj_dlq_mom_vp_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  let(:combination) do
+    %i[
+      active_job
+      dead_letter_queue
+      manual_offset_management
+      virtual_partitions
+    ]
+  end
+
+  it { expect(described_class::FEATURES).to eq(combination) }
+end

--- a/spec/lib/karafka/pro/processing/strategies/dlq_lrj_vp_spec.rb
+++ b/spec/lib/karafka/pro/processing/strategies/dlq_lrj_vp_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  let(:combination) do
+    %i[
+      dead_letter_queue
+      long_running_job
+      virtual_partitions
+    ]
+  end
+
+  it { expect(described_class::FEATURES).to eq(combination) }
+end

--- a/spec/lib/karafka/pro/processing/strategies/dlq_vp_spec.rb
+++ b/spec/lib/karafka/pro/processing/strategies/dlq_vp_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  let(:combination) do
+    %i[
+      dead_letter_queue
+      virtual_partitions
+    ]
+  end
+
+  it { expect(described_class::FEATURES).to eq(combination) }
+end

--- a/spec/lib/karafka/pro/processing/strategy_selector_spec.rb
+++ b/spec/lib/karafka/pro/processing/strategy_selector_spec.rb
@@ -138,6 +138,17 @@ RSpec.describe_current do
     it { expect(selected_strategy).to eq(Karafka::Pro::Processing::Strategies::AjDlqMom) }
   end
 
+  context 'when aj, dlq, mom and vp is enabled' do
+    before do
+      topic.virtual_partitions(partitioner: true)
+      topic.dead_letter_queue(topic: 'test')
+      topic.manual_offset_management(true)
+      topic.active_job(true)
+    end
+
+    it { expect(selected_strategy).to eq(Karafka::Pro::Processing::Strategies::AjDlqMomVp) }
+  end
+
   context 'when aj, dlq, mom and lrj is enabled' do
     before do
       topic.dead_letter_queue(topic: 'test')

--- a/spec/lib/karafka/pro/processing/strategy_selector_spec.rb
+++ b/spec/lib/karafka/pro/processing/strategy_selector_spec.rb
@@ -100,6 +100,15 @@ RSpec.describe_current do
     it { expect(selected_strategy).to eq(Karafka::Pro::Processing::Strategies::Dlq) }
   end
 
+  context 'when dlq with vp is enabled' do
+    before do
+      topic.dead_letter_queue(topic: 'test')
+      topic.virtual_partitions(partitioner: true)
+    end
+
+    it { expect(selected_strategy).to eq(Karafka::Pro::Processing::Strategies::DlqVp) }
+  end
+
   context 'when dlq with mom is enabled' do
     before do
       topic.dead_letter_queue(topic: 'test')

--- a/spec/lib/karafka/pro/routing/features/dead_letter_queue/contract_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/dead_letter_queue/contract_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe_current do
   let(:config) do
     {
       dead_letter_queue: {
-        active: true
+        active: true,
+        max_retries: 1
       },
       virtual_partitions: {
         active: false
@@ -18,8 +19,11 @@ RSpec.describe_current do
     it { expect(check).to be_success }
   end
 
-  context 'when trying to use DLQ with VP' do
-    before { config[:virtual_partitions][:active] = true }
+  context 'when trying to use DLQ with VP without any retries' do
+    before do
+      config[:virtual_partitions][:active] = true
+      config[:dead_letter_queue][:max_retries] = 0
+    end
 
     it { expect(check).not_to be_success }
   end

--- a/spec/lib/karafka/processing/coordinator_spec.rb
+++ b/spec/lib/karafka/processing/coordinator_spec.rb
@@ -67,10 +67,6 @@ RSpec.describe_current do
     end
   end
 
-  describe '#consumption' do
-    it { expect(coordinator.consumption(self)).to be_a(Karafka::Processing::Result) }
-  end
-
   describe '#success?' do
     context 'when there were no jobs' do
       it { expect(coordinator.success?).to eq(true) }
@@ -83,14 +79,14 @@ RSpec.describe_current do
     end
 
     context 'when there are no jobs running and all the finished are success' do
-      before { coordinator.consumption(0).success! }
+      before { coordinator.success!(0) }
 
       it { expect(coordinator.success?).to eq(true) }
     end
 
     context 'when there are jobs running and all the finished are success' do
       before do
-        coordinator.consumption(0).success!
+        coordinator.success!(0)
         coordinator.increment
       end
 
@@ -99,8 +95,8 @@ RSpec.describe_current do
 
     context 'when there are no jobs running and not all the jobs finished with success' do
       before do
-        coordinator.consumption(0).success!
-        coordinator.consumption(1).failure!(StandardError.new)
+        coordinator.success!(0)
+        coordinator.failure!(1, StandardError.new)
       end
 
       it { expect(coordinator.success?).to eq(false) }

--- a/spec/lib/karafka/processing/partitioner_spec.rb
+++ b/spec/lib/karafka/processing/partitioner_spec.rb
@@ -4,13 +4,16 @@ RSpec.describe_current do
   subject(:partitioner) { described_class.new(subscription_group) }
 
   let(:subscription_group) { build(:routing_subscription_group) }
+  let(:coordinator) { build(:processing_coordinator) }
 
   describe '#call' do
     let(:topic) { 'topic-name' }
     let(:messages) { [build(:messages_message)] }
 
     it 'expect to yield with 0 and input messages' do
-      expect { |block| partitioner.call(topic, messages, &block) }.to yield_with_args(0, messages)
+      expect do |block|
+        partitioner.call(topic, messages, coordinator, &block)
+      end.to yield_with_args(0, messages)
     end
   end
 end


### PR DESCRIPTION
This PR introduces a few things:
- an enhancement to Virtual Partitions called "collapsing". Collapsing is a process of temporarily disabling virtual partitions to a single partition upon errors. This removes the "uncertainties" related to running VPs unit the offset of the original errored batch is passed.
- A rollback of assignment of anything more than partition key as DLQ key was causing issues when topics would have similar names. This was never released, hence rollback is here.
- Few more specs around virtual partitions
- Specs stability improvements
