### PR TITLE
ensure caller is published

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.0.29 (Unreleased)
 - [Fix] Fix for: running karafka console results in NameError with Rails (#1280)
+- [Fix] Make sure, that the `caller` for async errors is being published.
 
 ## 2.0.28 (2023-01-25)
 - **[Feature]** Provide the ability to use Dead Letter Queue with Virtual Partitions.

--- a/lib/karafka/instrumentation/callbacks/error.rb
+++ b/lib/karafka/instrumentation/callbacks/error.rb
@@ -28,6 +28,7 @@ module Karafka
 
           @monitor.instrument(
             'error.occurred',
+            caller: self,
             subscription_group_id: @subscription_group_id,
             consumer_group_id: @consumer_group_id,
             type: 'librdkafka.error',


### PR DESCRIPTION
This PR adds a missing caller to make sure all error publishing locations have same api.