### PR TITLE
Extract cli loader command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.0.29 (Unreleased)
 - [Improvement] Make sure, that the `Karafka#producer` instance has the `LoggerListener` enabled in the install template, so Karafka by default prints both consumer and producer info.
+- [Improvement] Extract the code loading capabilities of Karafka console from the executable, so web can use it to provide CLI commands.
 - [Fix] Fix for: running karafka console results in NameError with Rails (#1280)
 - [Fix] Make sure, that the `caller` for async errors is being published.
 

--- a/bin/karafka
+++ b/bin/karafka
@@ -6,24 +6,6 @@ require 'karafka'
 # our bin/karafka cli
 ENV['KARAFKA_CLI'] = 'true'
 
-# If there is a boot file, we need to require it as we expect it to contain
-# Karafka app setup, routes, etc
-if File.exist?(Karafka.boot_file)
-  rails_env_rb = File.join(Dir.pwd, 'config/environment.rb')
-
-  # Load Rails environment file that starts Rails, so we can reference consumers and other things
-  # from `karafka.rb` file. This will work only for Rails, for non-rails a manual setup is needed
-  require rails_env_rb if Kernel.const_defined?(:Rails) && File.exist?(rails_env_rb)
-
-  require Karafka.boot_file.to_s
-else
-  # However when it is unavailable, we still want to be able to run help command
-  # and install command as they don't require configured app itself to run
-  raise(
-    Karafka::Errors::MissingBootFileError,
-    Karafka.boot_file
-  ) unless %w[-h install].include?(ARGV[0])
-end
-
+Karafka::Cli::Base.load
 Karafka::Cli.prepare
 Karafka::Cli.start

--- a/lib/karafka/cli/base.rb
+++ b/lib/karafka/cli/base.rb
@@ -34,6 +34,29 @@ module Karafka
       end
 
       class << self
+        # Loads prope environment with what is needed to run the CLI
+        def load
+          # If there is a boot file, we need to require it as we expect it to contain
+          # Karafka app setup, routes, etc
+          if File.exist?(::Karafka.boot_file)
+            rails_env_rb = File.join(Dir.pwd, 'config/environment.rb')
+
+            # Load Rails environment file that starts Rails, so we can reference consumers and
+            # other things from `karafka.rb` file. This will work only for Rails, for non-rails
+            # a manual setup is needed
+            require rails_env_rb if Kernel.const_defined?(:Rails) && File.exist?(rails_env_rb)
+
+            require Karafka.boot_file.to_s
+          else
+            # However when it is unavailable, we still want to be able to run help command
+            # and install command as they don't require configured app itself to run
+            raise(
+              ::Karafka::Errors::MissingBootFileError,
+              ::Karafka.boot_file
+            ) unless %w[-h install].include?(ARGV[0])
+          end
+        end
+
         # Allows to set options for Thor cli
         # @see https://github.com/erikhuda/thor
         # @param option Single option details

--- a/lib/karafka/cli/base.rb
+++ b/lib/karafka/cli/base.rb
@@ -34,7 +34,7 @@ module Karafka
       end
 
       class << self
-        # Loads prope environment with what is needed to run the CLI
+        # Loads proper environment with what is needed to run the CLI
         def load
           # If there is a boot file, we need to require it as we expect it to contain
           # Karafka app setup, routes, etc
@@ -47,13 +47,10 @@ module Karafka
             require rails_env_rb if Kernel.const_defined?(:Rails) && File.exist?(rails_env_rb)
 
             require Karafka.boot_file.to_s
-          else
-            # However when it is unavailable, we still want to be able to run help command
-            # and install command as they don't require configured app itself to run
-            raise(
-              ::Karafka::Errors::MissingBootFileError,
-              ::Karafka.boot_file
-            ) unless %w[-h install].include?(ARGV[0])
+          # However when it is unavailable, we still want to be able to run help command
+          # and install command as they don't require configured app itself to run
+          elsif %w[-h install].none? { |cmd| cmd == ARGV[0] }
+            raise ::Karafka::Errors::MissingBootFileError, ::Karafka.boot_file
           end
         end
 


### PR DESCRIPTION
This PR moves the code loading from the karafka bin executable, so the same code can be used on the web to load code before install command execution.