### PR TITLE
More reliable admin operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka framework changelog
 
+## 2.0.32 (Unreleased)
+- [Improvement] Make sure, that `Karafka::Admin` operations actually finish before returning. 
+
 ## 2.0.31 (2022-02-12)
 - [Feature] Allow for adding partitions via `Admin#create_partitions` API.
 - [Fix] Do not ignore admin errors upon invalid configuration (#1254)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka (2.0.31)
+    karafka (2.0.32)
       karafka-core (>= 2.0.11, < 3.0.0)
       thor (>= 0.20)
       waterdrop (>= 2.4.10, < 3.0.0)

--- a/lib/karafka/admin.rb
+++ b/lib/karafka/admin.rb
@@ -182,6 +182,10 @@ module Karafka
         attempt += 1
 
         handler.call
+
+        # Kafka can make certain operations in the background even after the promise is
+        # materialized. This ensures, that even if all went well, the end goal is satisfied
+        sleep(0.2) until breaker.call
       rescue Rdkafka::AbstractHandle::WaitTimeoutError
         return if breaker.call
 

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '2.0.31'
+  VERSION = '2.0.32'
 end


### PR DESCRIPTION
There are cases where the create topic requests are queued in Kafka and not yet finished while the promise is materialized. This means we can create a topic and expect it to work but "it's not there" yet.