### PR TITLE
Improve non-critical error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Karafka framework changelog
 
+## 2.0.32 (Unreleased)
+- [Fix] Many non-existing topic subscriptions propagate poll errors beyond client
+- [Improvement] Ignore `unknown_topic_or_part` errors in dev when `allow.auto.create.topics` is on.
+- [Improvement] Optimize temporary errors handling in polling for a better backoff policy
+
 ## 2.0.31 (2022-02-12)
 - [Feature] Allow for adding partitions via `Admin#create_partitions` API.
 - [Fix] Do not ignore admin errors upon invalid configuration (#1254)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka (2.0.31)
+    karafka (2.0.32)
       karafka-core (>= 2.0.11, < 3.0.0)
       thor (>= 0.20)
       waterdrop (>= 2.4.10, < 3.0.0)

--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -381,6 +381,14 @@ module Karafka
           early_report = true
         when :transport # -195
           early_report = true
+        # @see
+        # https://github.com/confluentinc/confluent-kafka-dotnet/issues/1366#issuecomment-821842990
+        # This will be raised each time poll detects a non-existing topic. When auto creation is
+        # on, we can safely ignore it
+        when :unknown_topic_or_part # 3
+          return nil if @subscription_group.kafka[:'allow.auto.create.topics']
+
+          early_report = true
         end
 
         retryable = time_poll.attempts <= MAX_POLL_RETRIES && time_poll.retryable?

--- a/lib/karafka/time_trackers/poll.rb
+++ b/lib/karafka/time_trackers/poll.rb
@@ -51,6 +51,9 @@ module Karafka
       # Sleeps for amount of time matching attempt, so we sleep more with each attempt in case of
       #   a retry.
       def backoff
+        # backoff should not be included in the remaining time computation, otherwise it runs
+        # shortly, never back-offing beyond a small number because of the sleep
+        @remaining += backoff_interval
         # Sleep requires seconds not ms
         sleep(backoff_interval / 1_000.0)
       end

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '2.0.31'
+  VERSION = '2.0.32'
 end

--- a/spec/integrations/consumption/with_non_existing_topics_auto_create_spec.rb
+++ b/spec/integrations/consumption/with_non_existing_topics_auto_create_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Karafka should be able to poll on non-existing topics when auto-create is on and should not
+# raise an error about it
+
+setup_karafka do |config|
+  config.kafka[:'allow.auto.create.topics'] = true
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[message.metadata.partition] << message.raw_payload
+    end
+  end
+end
+
+draw_routes(create_topics: false) do
+  100.times do |i|
+    topic "#{DT.topic}#{i}" do
+      consumer Consumer
+    end
+  end
+
+  topic DT.topic do
+    consumer Consumer
+  end
+end
+
+elements = DT.uuids(100)
+produce_many(DT.topic, elements)
+
+start_karafka_and_wait_until do
+  DT[0].count >= 100 && sleep(5)
+end
+
+assert_equal elements, DT[0]
+assert_equal 1, DT.data.size

--- a/spec/integrations/consumption/with_non_existing_topics_no_auto_create_spec.rb
+++ b/spec/integrations/consumption/with_non_existing_topics_no_auto_create_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Karafka should raise an error when it encounters non-existing topic and no auto topic creation
+
+# We need to allow errors so we can track them and check the propagation
+setup_karafka(allow_errors: true) do |config|
+  config.kafka[:'allow.auto.create.topics'] = false
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[message.metadata.partition] << message.raw_payload
+    end
+  end
+end
+
+draw_routes(create_topics: false) do
+  100.times do |i|
+    topic "#{DT.topic}#{i}" do
+      consumer Consumer
+    end
+  end
+
+  topic DT.topic do
+    consumer Consumer
+  end
+end
+
+Karafka.monitor.subscribe('error.occurred') do |event|
+  DT[:events] << event
+end
+
+elements = DT.uuids(100)
+produce_many(DT.topic, elements)
+
+start_karafka_and_wait_until do
+  DT[:events].count >= 1
+end
+
+payload = DT[:events].last.payload
+
+assert_equal Karafka::Connection::Client, payload[:caller].class
+assert_equal 'connection.client.poll.error', payload[:type]
+assert_equal :unknown_topic_or_part, payload[:error].code


### PR DESCRIPTION
Improves how we handle non-critical errors.

- Do not include the sleep time in the internal poll time tracking (it would always run out after 1 or 2 attempts)
- Ignore `unknown_topic_or_part` when auto topic creation is on (as recommended by librdkafka authors)

Integration specs for this are included.

close https://github.com/karafka/karafka/issues/1310
