### PR TITLE
#1325 Lift the strict topic naming convention limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [Fix] Karafka monitor is prematurely cached (#1314)
 - [Improvement] Make `::Karafka::Instrumentation::Notifications::EVENTS` list public for anyone wanting to re-bind those into a different notification bus.
 - [Improvement] Set `fetch.message.max.bytes` for `Karafka::Admin` to `5MB` to make sure that all data is fetched correctly for Web UI under heavy load (many consumers).
+- [Fix] Remove inconsistent topic naming validation check. It was causing problems for many production grade systems already using certain internal naming conventions.
 
 ## 2.0.32 (2022-02-13)
 - [Fix] Many non-existing topic subscriptions propagate poll errors beyond client

--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -45,7 +45,6 @@ en:
       dead_letter_queue.topic_format: 'needs to be a string with a Kafka accepted format'
       dead_letter_queue.active_format: needs to be either true or false
       active_format: needs to be either true or false
-      inconsistent_namespacing: needs to be consistent namespacing style
 
     consumer_group:
       missing: needs to be present

--- a/lib/karafka/contracts/topic.rb
+++ b/lib/karafka/contracts/topic.rb
@@ -48,17 +48,6 @@ module Karafka
           [[%w[kafka], e.message]]
         end
       end
-
-      virtual do |data, errors|
-        next unless errors.empty?
-
-        value = data.fetch(:name)
-        namespacing_chars_count = value.chars.find_all { |c| ['.', '_'].include?(c) }.uniq.count
-
-        next if namespacing_chars_count <= 1
-
-        [[%w[name], :inconsistent_namespacing]]
-      end
     end
   end
 end

--- a/spec/lib/karafka/contracts/topic_spec.rb
+++ b/spec/lib/karafka/contracts/topic_spec.rb
@@ -60,28 +60,6 @@ RSpec.describe_current do
 
       it { expect(check).not_to be_success }
     end
-
-    context 'when considering namespaces' do
-      context 'with consistent namespacing style' do
-        context 'with dot style' do
-          before { config[:name] = 'yc.auth.cmd.shopper-registrations.1' }
-
-          it { expect(check).to be_success }
-        end
-
-        context 'with underscore style' do
-          before { config[:name] = 'yc_auth_cmd_shopper-registrations_1' }
-
-          it { expect(check).to be_success }
-        end
-      end
-
-      context 'with inconsistent namespacing style' do
-        before { config[:name] = 'yc.auth.cmd.shopper-registrations_1' }
-
-        it { expect(check).not_to be_success }
-      end
-    end
   end
 
   context 'when we subscription_group' do


### PR DESCRIPTION
This PR relaxes the topic naming validation. Many people argued that the newly introduced naming validation needs to be more relaxed. 

While I understand the need to ensure users follow good patterns, many users using external sink tools encounter problems because of this validation. It was reported several times. I'm lifting this validation in favour of usability with other tooling that generates topics names out of the box and to make sure Karafka can be easily integrated into already existing Kafka systems.

close https://github.com/karafka/karafka/issues/1325