### PR TITLE
Allow for disabling of strict_topics_namespacing validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [Fix] Karafka monitor is prematurely cached (#1314)
 - [Improvement] Make `::Karafka::Instrumentation::Notifications::EVENTS` list public for anyone wanting to re-bind those into a different notification bus.
 - [Improvement] Set `fetch.message.max.bytes` for `Karafka::Admin` to `5MB` to make sure that all data is fetched correctly for Web UI under heavy load (many consumers).
+- [Improvement] Introduce a `strict_topics_namespacing` config option to enable/disable the strict topics naming validations. This can be useful when working with pre-existing topics which we cannot or do not want to rename.
 
 ## 2.0.32 (2022-02-13)
 - [Fix] Many non-existing topic subscriptions propagate poll errors beyond client

--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -45,14 +45,18 @@ en:
       dead_letter_queue.topic_format: 'needs to be a string with a Kafka accepted format'
       dead_letter_queue.active_format: needs to be either true or false
       active_format: needs to be either true or false
-      inconsistent_namespacing: needs to be consistent namespacing style
+      inconsistent_namespacing: |
+        needs to be consistent namespacing style
+        disable this validation by setting config.strict_topics_namespacing to false
 
     consumer_group:
       missing: needs to be present
       topics_names_not_unique: all topic names within a single consumer group must be unique
-      topics_namespaced_names_not_unique: all topic names within a single consumer group must be unique considering namespacing styles
       id_format: 'needs to be a string with a Kafka accepted format'
       topics_format: needs to be a non-empty array
+      topics_namespaced_names_not_unique: |
+        all topic names within a single consumer group must be unique considering namespacing styles
+        disable this validation by setting config.strict_topics_namespacing to false
 
     job_options:
       missing: needs to be present

--- a/lib/karafka/contracts/consumer_group.rb
+++ b/lib/karafka/contracts/consumer_group.rb
@@ -27,6 +27,7 @@ module Karafka
 
       virtual do |data, errors|
         next unless errors.empty?
+        next unless ::Karafka::App.config.strict_topics_namespacing
 
         names = data.fetch(:topics).map { |topic| topic[:name] }
         names_hash = names.each_with_object({}) { |n, h| h[n] = true }

--- a/lib/karafka/contracts/topic.rb
+++ b/lib/karafka/contracts/topic.rb
@@ -51,6 +51,7 @@ module Karafka
 
       virtual do |data, errors|
         next unless errors.empty?
+        next unless ::Karafka::App.config.strict_topics_namespacing
 
         value = data.fetch(:name)
         namespacing_chars_count = value.chars.find_all { |c| ['.', '_'].include?(c) }.uniq.count

--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -89,6 +89,11 @@ module Karafka
       # option [::WaterDrop::Producer, nil]
       # Unless configured, will be created once Karafka is configured based on user Karafka setup
       setting :producer, default: nil
+      # option [Boolean] when set to true, Karafka will ensure that the routing topic naming
+      # convention is strict
+      # Disabling this may be needed in scenarios where we do not have control over topics names
+      # and/or we work with existing systems where we cannot change topics names.
+      setting :strict_topics_namespacing, default: true
 
       # rdkafka default options
       # @see https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md

--- a/spec/integrations/routing/with_namespace_collisions_without_strict_spec.rb
+++ b/spec/integrations/routing/with_namespace_collisions_without_strict_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Karafka should allow for topics that would have metrics namespace collisions if strict topic
+# names validation is off
+
+setup_karafka do |config|
+  config.strict_topics_namespacing = false
+end
+
+failed = false
+
+begin
+  draw_routes(create_topics: false) do
+    topic 'namespace_collision' do
+      consumer Class.new
+    end
+
+    topic 'namespace.collision' do
+      consumer Class.new
+    end
+  end
+rescue Karafka::Errors::InvalidConfigurationError
+  failed = true
+end
+
+assert !failed

--- a/spec/lib/karafka/contracts/consumer_group_spec.rb
+++ b/spec/lib/karafka/contracts/consumer_group_spec.rb
@@ -80,6 +80,18 @@ RSpec.describe_current do
 
         it { expect(check).not_to be_success }
       end
+
+      context 'when strict_topics_namespacing is set to false' do
+        before do
+          config[:topics][1] = config[:topics][0].dup
+          config[:topics][1][:name] = 'some_namespaced_topic-name'
+          ::Karafka::App.config.strict_topics_namespacing = false
+        end
+
+        after { ::Karafka::App.config.strict_topics_namespacing = true }
+
+        it { expect(check).to be_success }
+      end
     end
   end
 

--- a/spec/lib/karafka/contracts/topic_spec.rb
+++ b/spec/lib/karafka/contracts/topic_spec.rb
@@ -81,6 +81,17 @@ RSpec.describe_current do
 
         it { expect(check).not_to be_success }
       end
+
+      context 'when strict_topics_namespacing is set to false' do
+        before do
+          config[:name] = 'yc.auth.cmd.shopper-registrations_1'
+          ::Karafka::App.config.strict_topics_namespacing = false
+        end
+
+        after { ::Karafka::App.config.strict_topics_namespacing = true }
+
+        it { expect(check).to be_success }
+      end
     end
   end
 


### PR DESCRIPTION
This PR introduces a config flag to disable strict topic naming validation.

@nijikon decided to introduce it at the root level not to introduce a new concept (setting namespaces) to the config. When we end up with more config settings we can decide to extract them to proper namespaces for routing, processing, etc similar to how it is done for internals.

close https://github.com/karafka/karafka/issues/1325