### PR TITLE
Support Rails 7.1 batch AJ jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka framework changelog
 
 ## 2.0.33 (Unreleased)
+- [Feature] Support `perform_all_later` in ActiveJob adapter for Rails `7.1+`
 - [Fix] Karafka monitor is prematurely cached (#1314)
 - [Improvement] Make `::Karafka::Instrumentation::Notifications::EVENTS` list public for anyone wanting to re-bind those into a different notification bus.
 - [Improvement] Set `fetch.message.max.bytes` for `Karafka::Admin` to `5MB` to make sure that all data is fetched correctly for Web UI under heavy load (many consumers).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,10 +64,9 @@ GEM
     waterdrop (2.4.10)
       karafka-core (>= 2.0.9, < 3.0.0)
       zeitwerk (~> 2.3)
-    zeitwerk (2.6.6)
+    zeitwerk (2.6.7)
 
 PLATFORMS
-  arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -57,6 +57,7 @@ en:
     job_options:
       missing: needs to be present
       dispatch_method_format: needs to be either :produce_async or :produce_sync
+      dispatch_many_method_format: needs to be either :produce_many_async or :produce_many_sync
       partitioner_format: 'needs to respond to #call'
       partition_key_type_format: 'needs to be either :key or :partition_key'
 

--- a/lib/active_job/queue_adapters/karafka_adapter.rb
+++ b/lib/active_job/queue_adapters/karafka_adapter.rb
@@ -11,7 +11,13 @@ module ActiveJob
       #
       # @param job [Object] job that should be enqueued
       def enqueue(job)
-        ::Karafka::App.config.internal.active_job.dispatcher.call(job)
+        ::Karafka::App.config.internal.active_job.dispatcher.dispatch(job)
+      end
+
+      # Enqueues multiple jobs in one go
+      # @param jobs [Array<Object>] jobs that we want to enqueue
+      def enqueue_all(jobs)
+        ::Karafka::App.config.internal.active_job.dispatcher.dispatch_many(jobs)
       end
 
       # Raises info, that Karafka backend does not support scheduling jobs

--- a/lib/karafka/active_job/dispatcher.rb
+++ b/lib/karafka/active_job/dispatcher.rb
@@ -7,18 +7,43 @@ module Karafka
       # Defaults for dispatching
       # The can be updated by using `#karafka_options` on the job
       DEFAULTS = {
-        dispatch_method: :produce_async
+        dispatch_method: :produce_async,
+        dispatch_many_method: :produce_many_async
       }.freeze
 
       private_constant :DEFAULTS
 
       # @param job [ActiveJob::Base] job
-      def call(job)
+      def dispatch(job)
         ::Karafka.producer.public_send(
           fetch_option(job, :dispatch_method, DEFAULTS),
           topic: job.queue_name,
           payload: ::ActiveSupport::JSON.encode(job.serialize)
         )
+      end
+
+      # Bulk dispatches multiple jobs using the Rails 7.1+ API
+      # @param jobs [Array<ActiveJob::Base>] jobs we want to dispatch
+      def dispatch_many(jobs)
+        # Group jobs by their desired dispatch method
+        # It can be configured per job class, so we need to make sure we divide them
+        dispatches = Hash.new { |hash, key| hash[key] = [] }
+
+        jobs.each do |job|
+          d_method = fetch_option(job, :dispatch_many_method, DEFAULTS)
+
+          dispatches[d_method] << {
+            topic: job.queue_name,
+            payload: ::ActiveSupport::JSON.encode(job.serialize)
+          }
+        end
+
+        dispatches.each do |type, messages|
+          ::Karafka.producer.public_send(
+            type,
+            messages
+          )
+        end
       end
 
       private

--- a/lib/karafka/active_job/job_options_contract.rb
+++ b/lib/karafka/active_job/job_options_contract.rb
@@ -15,7 +15,18 @@ module Karafka
         ).fetch('en').fetch('validations').fetch('job_options')
       end
 
-      optional(:dispatch_method) { |val| %i[produce_async produce_sync].include?(val) }
+      optional(:dispatch_method) do |val|
+        %i[
+          produce_async
+          produce_sync
+        ].include?(val)
+      end
+      optional(:dispatch_many_method) do |val|
+        %i[
+          produce_many_async
+          produce_many_sync
+        ].include?(val)
+      end
     end
   end
 end

--- a/lib/karafka/pro/active_job/dispatcher.rb
+++ b/lib/karafka/pro/active_job/dispatcher.rb
@@ -23,6 +23,7 @@ module Karafka
         # They can be updated by using `#karafka_options` on the job
         DEFAULTS = {
           dispatch_method: :produce_async,
+          dispatch_many_method: :produce_many_async,
           # We don't create a dummy proc based partitioner as we would have to evaluate it with
           # each job.
           partitioner: nil,
@@ -33,7 +34,7 @@ module Karafka
         private_constant :DEFAULTS
 
         # @param job [ActiveJob::Base] job
-        def call(job)
+        def dispatch(job)
           ::Karafka.producer.public_send(
             fetch_option(job, :dispatch_method, DEFAULTS),
             dispatch_details(job).merge!(
@@ -41,6 +42,28 @@ module Karafka
               payload: ::ActiveSupport::JSON.encode(job.serialize)
             )
           )
+        end
+
+        # Bulk dispatches multiple jobs using the Rails 7.1+ API
+        # @param jobs [Array<ActiveJob::Base>] jobs we want to dispatch
+        def dispatch_many(jobs)
+          dispatches = Hash.new { |hash, key| hash[key] = [] }
+
+          jobs.each do |job|
+            d_method = fetch_option(job, :dispatch_many_method, DEFAULTS)
+
+            dispatches[d_method] << dispatch_details(job).merge!(
+              topic: job.queue_name,
+              payload: ::ActiveSupport::JSON.encode(job.serialize)
+            )
+          end
+
+          dispatches.each do |type, messages|
+            ::Karafka.producer.public_send(
+              type,
+              messages
+            )
+          end
         end
 
         private

--- a/lib/karafka/pro/active_job/job_options_contract.rb
+++ b/lib/karafka/pro/active_job/job_options_contract.rb
@@ -25,9 +25,20 @@ module Karafka
           ).fetch('en').fetch('validations').fetch('job_options')
         end
 
-        optional(:dispatch_method) { |val| %i[produce_async produce_sync].include?(val) }
         optional(:partitioner) { |val| val.respond_to?(:call) }
         optional(:partition_key_type) { |val| %i[key partition_key].include?(val) }
+        optional(:dispatch_method) do |val|
+          %i[
+            produce_async
+            produce_sync
+          ].include?(val)
+        end
+        optional(:dispatch_many_method) do |val|
+          %i[
+            produce_many_async
+            produce_many_sync
+          ].include?(val)
+        end
       end
     end
   end

--- a/spec/lib/active_job/queue_adapters/karafka_adapter_spec.rb
+++ b/spec/lib/active_job/queue_adapters/karafka_adapter_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe_current do
   subject(:adapter) { ActiveJob::QueueAdapters::KarafkaAdapter.new }
 
   let(:job) { ActiveJob::Base.new }
+  let(:dispatcher) { Karafka::App.config.internal.active_job.dispatcher }
 
   describe '#enqueue_at' do
     it 'expect to indicate, that it is not supported' do
@@ -13,12 +14,25 @@ RSpec.describe_current do
 
   describe '#enqueue' do
     before do
-      allow(Karafka::App.config.internal.active_job.dispatcher).to receive(:call).with(job)
+      allow(dispatcher).to receive(:dispatch).with(job)
     end
 
     it 'expect to delegate to a proper dispatcher based on the configuration' do
       adapter.enqueue(job)
-      expect(Karafka::App.config.internal.active_job.dispatcher).to have_received(:call).with(job)
+      expect(dispatcher).to have_received(:dispatch).with(job)
+    end
+  end
+
+  describe '#enqueue_all' do
+    let(:jobs) { [ActiveJob::Base.new, ActiveJob::Base.new] }
+
+    before do
+      allow(dispatcher).to receive(:dispatch_many).with(jobs)
+    end
+
+    it 'expect to delegate to a proper dispatcher based on the configuration' do
+      adapter.enqueue_all(jobs)
+      expect(dispatcher).to have_received(:dispatch_many).with(jobs)
     end
   end
 end

--- a/spec/lib/karafka/active_job/dispatcher_spec.rb
+++ b/spec/lib/karafka/active_job/dispatcher_spec.rb
@@ -9,38 +9,117 @@ RSpec.describe_current do
     end
   end
 
+  let(:job_class2) do
+    Class.new(ActiveJob::Base) do
+      extend ::Karafka::ActiveJob::JobExtensions
+
+      queue_as :test2
+
+      karafka_options(dispatch_many_method: :produce_many_sync)
+    end
+  end
+
   let(:job) { job_class.new }
   let(:serialized_payload) { ActiveSupport::JSON.encode(job.serialize) }
   let(:time_now) { Time.now }
 
   before { allow(Time).to receive(:now).and_return(time_now) }
 
-  context 'when we dispatch without any changes to the defaults' do
-    before { allow(::Karafka.producer).to receive(:produce_async) }
+  describe '#dispatch' do
+    context 'when we dispatch without any changes to the defaults' do
+      before { allow(::Karafka.producer).to receive(:produce_async) }
 
-    it 'expect to use proper encoder and async producer to dispatch the job' do
-      dispatcher.call(job)
+      it 'expect to use proper encoder and async producer to dispatch the job' do
+        dispatcher.dispatch(job)
 
-      expect(::Karafka.producer).to have_received(:produce_async).with(
-        topic: job.queue_name,
-        payload: serialized_payload
-      )
+        expect(::Karafka.producer).to have_received(:produce_async).with(
+          topic: job.queue_name,
+          payload: serialized_payload
+        )
+      end
+    end
+
+    context 'when we want to dispatch sync' do
+      before do
+        job_class.karafka_options(dispatch_method: :produce_sync)
+        allow(::Karafka.producer).to receive(:produce_sync)
+      end
+
+      it 'expect to use proper encoder and sync producer to dispatch the job' do
+        dispatcher.dispatch(job)
+
+        expect(::Karafka.producer).to have_received(:produce_sync).with(
+          topic: job.queue_name,
+          payload: serialized_payload
+        )
+      end
     end
   end
 
-  context 'when we want to dispatch sync' do
-    before do
-      job_class.karafka_options(dispatch_method: :produce_sync)
-      allow(::Karafka.producer).to receive(:produce_sync)
+  describe '#dispatch_many' do
+    let(:jobs) { [job_class.new, job_class.new] }
+    let(:jobs_messages) do
+      [
+        {
+          topic: jobs[0].queue_name,
+          payload: ActiveSupport::JSON.encode(jobs[0].serialize)
+        },
+        {
+          topic: jobs[1].queue_name,
+          payload: ActiveSupport::JSON.encode(jobs[1].serialize)
+        }
+      ]
     end
 
-    it 'expect to use proper encoder and sync producer to dispatch the job' do
-      dispatcher.call(job)
+    context 'when we dispatch without any changes to the defaults' do
+      before { allow(::Karafka.producer).to receive(:produce_many_async) }
 
-      expect(::Karafka.producer).to have_received(:produce_sync).with(
-        topic: job.queue_name,
-        payload: serialized_payload
-      )
+      it 'expect to use proper encoder and async producer to dispatch the jobs' do
+        dispatcher.dispatch_many(jobs)
+
+        expect(::Karafka.producer).to have_received(:produce_many_async).with(jobs_messages)
+      end
+    end
+
+    context 'when we want to dispatch sync' do
+      before do
+        job_class.karafka_options(dispatch_many_method: :produce_many_sync)
+        allow(::Karafka.producer).to receive(:produce_many_sync)
+      end
+
+      it 'expect to use proper encoder and sync producer to dispatch the jobs' do
+        dispatcher.dispatch_many(jobs)
+
+        expect(::Karafka.producer).to have_received(:produce_many_sync).with(jobs_messages)
+      end
+    end
+
+    context 'when jobs have different dispatch many methods' do
+      let(:jobs) { [job_class.new, job_class2.new] }
+      let(:jobs_messages) do
+        [
+          {
+            topic: jobs[0].queue_name,
+            payload: ActiveSupport::JSON.encode(jobs[0].serialize)
+          },
+          {
+            topic: jobs[1].queue_name,
+            payload: ActiveSupport::JSON.encode(jobs[1].serialize)
+          }
+        ]
+      end
+
+      before do
+        allow(::Karafka.producer).to receive(:produce_many_async)
+        allow(::Karafka.producer).to receive(:produce_many_sync)
+      end
+
+      it 'expect to dispatch them with correct dispatching methods' do
+        dispatcher.dispatch_many(jobs)
+
+        expect(::Karafka.producer).to have_received(:produce_many_async).with([jobs_messages[0]])
+        expect(::Karafka.producer).to have_received(:produce_many_sync).with([jobs_messages[1]])
+      end
     end
   end
 end

--- a/spec/lib/karafka/active_job/job_options_contract_spec.rb
+++ b/spec/lib/karafka/active_job/job_options_contract_spec.rb
@@ -24,4 +24,16 @@ RSpec.describe_current do
 
     it { expect(contract.call(config)).not_to be_success }
   end
+
+  context 'when there is no dispath many method' do
+    before { config.delete(:dispatch_many_method) }
+
+    it { expect(contract.call(config)).to be_success }
+  end
+
+  context 'when dispatch many method is not valid' do
+    before { config[:dispatch_many_method] = rand.to_s }
+
+    it { expect(contract.call(config)).not_to be_success }
+  end
 end

--- a/spec/lib/karafka/pro/active_job/dispatcher_spec.rb
+++ b/spec/lib/karafka/pro/active_job/dispatcher_spec.rb
@@ -13,78 +13,157 @@ RSpec.describe_current do
     end
   end
 
+  let(:job_class2) do
+    Class.new(ActiveJob::Base) do
+      extend ::Karafka::ActiveJob::JobExtensions
+
+      queue_as :test2
+
+      karafka_options(dispatch_many_method: :produce_many_sync)
+    end
+  end
+
   let(:job) { job_class.new }
   let(:serialized_payload) { ActiveSupport::JSON.encode(job.serialize) }
 
-  context 'when we dispatch without any changes to the defaults' do
-    before { allow(::Karafka.producer).to receive(:produce_async) }
+  describe '#dispatch' do
+    context 'when we dispatch without any changes to the defaults' do
+      before { allow(::Karafka.producer).to receive(:produce_async) }
 
-    it 'expect to use proper encoder and async producer to dispatch the job' do
-      dispatcher.call(job)
+      it 'expect to use proper encoder and async producer to dispatch the job' do
+        dispatcher.dispatch(job)
 
-      expect(::Karafka.producer).to have_received(:produce_async).with(
-        topic: job.queue_name,
-        payload: serialized_payload
-      )
+        expect(::Karafka.producer).to have_received(:produce_async).with(
+          topic: job.queue_name,
+          payload: serialized_payload
+        )
+      end
+    end
+
+    context 'when we want to dispatch sync' do
+      before do
+        job_class.karafka_options(dispatch_method: :produce_sync)
+        allow(::Karafka.producer).to receive(:produce_sync)
+      end
+
+      it 'expect to use proper encoder and sync producer to dispatch the job' do
+        dispatcher.dispatch(job)
+
+        expect(::Karafka.producer).to have_received(:produce_sync).with(
+          topic: job.queue_name,
+          payload: serialized_payload
+        )
+      end
+    end
+
+    context 'when we want to dispatch with partitioner using key' do
+      let(:expected_args) do
+        {
+          topic: job.queue_name,
+          payload: serialized_payload,
+          key: job.job_id
+        }
+      end
+
+      before do
+        job_class.karafka_options(partitioner: ->(job) { job.job_id })
+        allow(::Karafka.producer).to receive(:produce_async)
+      end
+
+      it 'expect to use its result alongside other options' do
+        dispatcher.dispatch(job)
+
+        expect(::Karafka.producer).to have_received(:produce_async).with(expected_args)
+      end
+    end
+
+    context 'when we want to dispatch with partitioner using partition_key' do
+      let(:expected_args) do
+        {
+          topic: job.queue_name,
+          payload: serialized_payload,
+          partition_key: job.job_id
+        }
+      end
+
+      before do
+        job_class.karafka_options(partitioner: ->(job) { job.job_id })
+        job_class.karafka_options(partition_key_type: :partition_key)
+        allow(::Karafka.producer).to receive(:produce_async)
+      end
+
+      it 'expect to use its result alongside other options' do
+        dispatcher.dispatch(job)
+
+        expect(::Karafka.producer).to have_received(:produce_async).with(expected_args)
+      end
     end
   end
 
-  context 'when we want to dispatch sync' do
-    before do
-      job_class.karafka_options(dispatch_method: :produce_sync)
-      allow(::Karafka.producer).to receive(:produce_sync)
+  describe '#dispatch_many' do
+    let(:jobs) { [job_class.new, job_class.new] }
+    let(:jobs_messages) do
+      [
+        {
+          topic: jobs[0].queue_name,
+          payload: ActiveSupport::JSON.encode(jobs[0].serialize)
+        },
+        {
+          topic: jobs[1].queue_name,
+          payload: ActiveSupport::JSON.encode(jobs[1].serialize)
+        }
+      ]
     end
 
-    it 'expect to use proper encoder and sync producer to dispatch the job' do
-      dispatcher.call(job)
+    context 'when we dispatch without any changes to the defaults' do
+      before { allow(::Karafka.producer).to receive(:produce_many_async) }
 
-      expect(::Karafka.producer).to have_received(:produce_sync).with(
-        topic: job.queue_name,
-        payload: serialized_payload
-      )
-    end
-  end
+      it 'expect to use proper encoder and async producer to dispatch the jobs' do
+        dispatcher.dispatch_many(jobs)
 
-  context 'when we want to dispatch with partitioner using key' do
-    let(:expected_args) do
-      {
-        topic: job.queue_name,
-        payload: serialized_payload,
-        key: job.job_id
-      }
+        expect(::Karafka.producer).to have_received(:produce_many_async).with(jobs_messages)
+      end
     end
 
-    before do
-      job_class.karafka_options(partitioner: ->(job) { job.job_id })
-      allow(::Karafka.producer).to receive(:produce_async)
+    context 'when we want to dispatch sync' do
+      before do
+        job_class.karafka_options(dispatch_many_method: :produce_many_sync)
+        allow(::Karafka.producer).to receive(:produce_many_sync)
+      end
+
+      it 'expect to use proper encoder and sync producer to dispatch the jobs' do
+        dispatcher.dispatch_many(jobs)
+
+        expect(::Karafka.producer).to have_received(:produce_many_sync).with(jobs_messages)
+      end
     end
 
-    it 'expect to use its result alongside other options' do
-      dispatcher.call(job)
+    context 'when jobs have different dispatch many methods' do
+      let(:jobs) { [job_class.new, job_class2.new] }
+      let(:jobs_messages) do
+        [
+          {
+            topic: jobs[0].queue_name,
+            payload: ActiveSupport::JSON.encode(jobs[0].serialize)
+          },
+          {
+            topic: jobs[1].queue_name,
+            payload: ActiveSupport::JSON.encode(jobs[1].serialize)
+          }
+        ]
+      end
 
-      expect(::Karafka.producer).to have_received(:produce_async).with(expected_args)
-    end
-  end
+      before do
+        allow(::Karafka.producer).to receive(:produce_many_async)
+        allow(::Karafka.producer).to receive(:produce_many_sync)
+      end
 
-  context 'when we want to dispatch with partitioner using partition_key' do
-    let(:expected_args) do
-      {
-        topic: job.queue_name,
-        payload: serialized_payload,
-        partition_key: job.job_id
-      }
-    end
+      it 'expect to dispatch them with correct dispatching methods' do
+        dispatcher.dispatch_many(jobs)
 
-    before do
-      job_class.karafka_options(partitioner: ->(job) { job.job_id })
-      job_class.karafka_options(partition_key_type: :partition_key)
-      allow(::Karafka.producer).to receive(:produce_async)
-    end
-
-    it 'expect to use its result alongside other options' do
-      dispatcher.call(job)
-
-      expect(::Karafka.producer).to have_received(:produce_async).with(expected_args)
+        expect(::Karafka.producer).to have_received(:produce_many_async).with([jobs_messages[0]])
+        expect(::Karafka.producer).to have_received(:produce_many_sync).with([jobs_messages[1]])
+      end
     end
   end
 end

--- a/spec/lib/karafka/pro/active_job/job_options_contract_spec.rb
+++ b/spec/lib/karafka/pro/active_job/job_options_contract_spec.rb
@@ -38,6 +38,18 @@ RSpec.describe_current do
     it { expect(contract.call(config)).not_to be_success }
   end
 
+  context 'when there is no dispath many method' do
+    before { config.delete(:dispatch_many_method) }
+
+    it { expect(contract.call(config)).to be_success }
+  end
+
+  context 'when dispatch many method is not valid' do
+    before { config[:dispatch_many_method] = rand.to_s }
+
+    it { expect(contract.call(config)).not_to be_success }
+  end
+
   context 'when partitioner is not callable' do
     before { config[:partitioner] = 1 }
 


### PR DESCRIPTION
We cannot add integration specs because Rails 7.1 is not yet released. Those will be added after Rails 7.1. Functionality is based on Sidekiq adapter code and tested with units.

close https://github.com/karafka/karafka/issues/1327