### PR TITLE
Fix AJ + DLQ + MOM + LRJ is pausing indefinitely after the first job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.0.36 (Unreleased)
 - [Refactor] Rename internal naming of `Structurable` to `Declaratives` for declarative topics feature.
+- [Fix] AJ + DLQ + MOM + LRJ is pausing indefinitely after the first job (#1362)
 
 ## 2.0.35 (2023-03-13)
 - **[Feature]** Allow for defining topics config via the DSL and its automatic creation via CLI command.

--- a/lib/karafka/pro/processing/strategies/aj_dlq_lrj_mom.rb
+++ b/lib/karafka/pro/processing/strategies/aj_dlq_lrj_mom.rb
@@ -23,8 +23,10 @@ module Karafka
         # This case is a bit of special. Please see the `AjDlqMom` for explanation on how the
         # offset management works in this case.
         module AjDlqLrjMom
-          include AjLrjMom
-          include AjDlqMom
+          # We can use the same code as for VP because non VP behaves like:
+          # - with one virtual partition
+          # - with "never ending" collapse
+          include AjDlqLrjMomVp
 
           # Features for this strategy
           FEATURES = %i[

--- a/spec/integrations/pro/consumption/strategies/aj_dlq_lrj_mom/regular_processing_one_by_one_without_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj_dlq_lrj_mom/regular_processing_one_by_one_without_errors_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Karafka should be able to just process all the jobs one after another
+setup_active_job
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 1
+end
+
+class Job < ActiveJob::Base
+  queue_as DT.topic
+
+  def perform(value)
+    DT[0] << value
+  end
+end
+
+draw_routes do
+  consumer_group DT.consumer_group do
+    active_job_topic DT.topic do
+      max_messages 1
+      long_running_job true
+      dead_letter_queue topic: DT.topics[1], max_retries: 4
+    end
+  end
+end
+
+5.times { |value| Job.perform_later(value) }
+
+start_karafka_and_wait_until do
+  DT[0].size >= 5
+end
+
+assert DT[0].size >= 5

--- a/spec/integrations/pro/consumption/strategies/aj_dlq_lrj_mom/with_recoverable_slow_jobs_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj_dlq_lrj_mom/with_recoverable_slow_jobs_error_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# Karafka should recover from this error and move on without publishing anything to the DLQ
+
+class Listener
+  def on_error_occurred(event)
+    DT[:errors] << event
+  end
+end
+
+setup_active_job
+
+Karafka.monitor.subscribe(Listener.new)
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 10
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+end
+
+class DlqConsumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[1] << message.headers['original_offset'].to_i
+    end
+  end
+end
+
+class Job < ActiveJob::Base
+  queue_as DT.topic
+
+  def perform(value)
+    DT[0] << value
+    sleep(value.to_f / 20)
+    raise StandardError if DT[0].size < 10
+  end
+end
+
+draw_routes do
+  consumer_group DT.consumer_group do
+    active_job_topic DT.topic do
+      # We set it to 100k so it never reaches it and always recovers
+      dead_letter_queue topic: DT.topics[1], max_retries: 100_000
+      long_running_job true
+      # mom is enabled automatically
+    end
+
+    topic DT.topics[1] do
+      consumer DlqConsumer
+    end
+  end
+end
+
+5.times { |value| Job.perform_later(value) }
+
+start_karafka_and_wait_until do
+  DT[0].size >= 10
+end
+
+assert_equal 10, DT[0].count(&:zero?)
+assert DT[1].empty?

--- a/spec/integrations/pro/consumption/strategies/aj_dlq_lrj_mom_vp/regular_processing_one_by_one_without_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj_dlq_lrj_mom_vp/regular_processing_one_by_one_without_errors_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Karafka should be able to just process all the jobs one after another
+setup_active_job
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 1
+end
+
+class Job < ActiveJob::Base
+  queue_as DT.topic
+
+  def perform(value)
+    DT[0] << value
+  end
+end
+
+draw_routes do
+  consumer_group DT.consumer_group do
+    active_job_topic DT.topic do
+      max_messages 1
+      long_running_job true
+      dead_letter_queue topic: DT.topics[1], max_retries: 4
+      virtual_partitions(
+        partitioner: ->(_) { rand(10) }
+      )
+    end
+  end
+end
+
+5.times { |value| Job.perform_later(value) }
+
+start_karafka_and_wait_until do
+  DT[0].size >= 5
+end
+
+assert DT[0].size >= 5

--- a/spec/integrations/pro/consumption/strategies/aj_dlq_lrj_mom_vp/with_recoverable_slow_jobs_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj_dlq_lrj_mom_vp/with_recoverable_slow_jobs_error_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Karafka should recover from this error and move on without publishing anything to the DLQ
+
+class Listener
+  def on_error_occurred(event)
+    DT[:errors] << event
+  end
+end
+
+setup_active_job
+
+Karafka.monitor.subscribe(Listener.new)
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 10
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+end
+
+class DlqConsumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[1] << message.headers['original_offset'].to_i
+    end
+  end
+end
+
+class Job < ActiveJob::Base
+  queue_as DT.topic
+
+  def perform(value)
+    DT[0] << value
+    sleep(value.to_f / 20)
+    raise StandardError if DT[0].size < 10
+  end
+end
+
+draw_routes do
+  consumer_group DT.consumer_group do
+    active_job_topic DT.topic do
+      # We set it to 100k so it never reaches it and always recovers
+      dead_letter_queue topic: DT.topics[1], max_retries: 100_000
+      long_running_job true
+      virtual_partitions(
+        partitioner: ->(_) { rand(10) }
+      )
+    end
+
+    topic DT.topics[1] do
+      consumer DlqConsumer
+    end
+  end
+end
+
+5.times { |value| Job.perform_later(value) }
+
+start_karafka_and_wait_until do
+  DT[0].size >= 10
+end
+
+assert DT[1].empty?

--- a/spec/integrations/pro/consumption/strategies/aj_dlq_mom/regular_processing_one_by_one_without_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj_dlq_mom/regular_processing_one_by_one_without_errors_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Karafka should be able to just process all the jobs one after another
+setup_active_job
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 1
+end
+
+class Job < ActiveJob::Base
+  queue_as DT.topic
+
+  def perform(value)
+    DT[0] << value
+  end
+end
+
+draw_routes do
+  consumer_group DT.consumer_group do
+    active_job_topic DT.topic do
+      max_messages 1
+      long_running_job true
+    end
+  end
+end
+
+5.times { |value| Job.perform_later(value) }
+
+start_karafka_and_wait_until do
+  DT[0].size >= 5
+end
+
+assert DT[0].size >= 5

--- a/spec/integrations/pro/consumption/strategies/aj_dlq_mom/with_recoverable_jobs_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj_dlq_mom/with_recoverable_jobs_error_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Karafka should recover from this error and move on without publishing anything to the DLQ
+
+class Listener
+  def on_error_occurred(event)
+    DT[:errors] << event
+  end
+end
+
+setup_active_job
+
+Karafka.monitor.subscribe(Listener.new)
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 10
+end
+
+class DlqConsumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[1] << message.headers['original_offset'].to_i
+    end
+  end
+end
+
+class Job < ActiveJob::Base
+  queue_as DT.topic
+
+  def perform(value)
+    DT[0] << value
+    raise StandardError if DT[0].size < 10
+  end
+end
+
+draw_routes do
+  consumer_group DT.consumer_group do
+    active_job_topic DT.topic do
+      manual_offset_management true
+      # We set it to 100k so it never reaches it and always recovers
+      dead_letter_queue topic: DT.topics[1], max_retries: 100_000
+    end
+
+    topic DT.topics[1] do
+      consumer DlqConsumer
+    end
+  end
+end
+
+5.times { |value| Job.perform_later(value) }
+
+start_karafka_and_wait_until do
+  DT[0].size >= 10
+end
+
+assert_equal 10, DT[0].count(&:zero?)
+assert DT[1].empty?

--- a/spec/integrations/pro/consumption/strategies/aj_dlq_mom_vp/regular_processing_one_by_one_without_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj_dlq_mom_vp/regular_processing_one_by_one_without_errors_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Karafka should be able to just process all the jobs one after another
+setup_active_job
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 1
+end
+
+class Job < ActiveJob::Base
+  queue_as DT.topic
+
+  def perform(value)
+    DT[0] << value
+  end
+end
+
+draw_routes do
+  consumer_group DT.consumer_group do
+    active_job_topic DT.topic do
+      max_messages 1
+      dead_letter_queue topic: DT.topics[1], max_retries: 4
+      virtual_partitions(
+        partitioner: ->(_) { rand(10) }
+      )
+    end
+  end
+end
+
+5.times { |value| Job.perform_later(value) }
+
+start_karafka_and_wait_until do
+  DT[0].size >= 5
+end
+
+assert DT[0].size >= 5

--- a/spec/integrations/pro/consumption/strategies/aj_dlq_mom_vp/with_recoverable_jobs_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj_dlq_mom_vp/with_recoverable_jobs_error_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Karafka should recover from this error and move on without publishing anything to the DLQ
+
+class Listener
+  def on_error_occurred(event)
+    DT[:errors] << event
+  end
+end
+
+setup_active_job
+
+Karafka.monitor.subscribe(Listener.new)
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 10
+end
+
+class DlqConsumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[1] << message.headers['original_offset'].to_i
+    end
+  end
+end
+
+class Job < ActiveJob::Base
+  queue_as DT.topic
+
+  def perform(value)
+    DT[0] << value
+    raise StandardError if DT[0].size < 10
+  end
+end
+
+draw_routes do
+  consumer_group DT.consumer_group do
+    active_job_topic DT.topic do
+      manual_offset_management true
+      # We set it to 100k so it never reaches it and always recovers
+      dead_letter_queue topic: DT.topics[1], max_retries: 100_000
+      virtual_partitions(
+        partitioner: ->(_) { rand(10) }
+      )
+    end
+
+    topic DT.topics[1] do
+      consumer DlqConsumer
+    end
+  end
+end
+
+5.times { |value| Job.perform_later(value) }
+
+start_karafka_and_wait_until do
+  DT[0].size >= 10
+end
+
+assert DT[1].empty?

--- a/spec/integrations/pro/consumption/strategies/dlq_lrj/regular_processing_one_by_one_without_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_lrj/regular_processing_one_by_one_without_errors_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Karafka should be able to just process all the messages one after another
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 1
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[0] << true
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    max_messages 1
+    dead_letter_queue topic: DT.topics[1], max_retries: 4
+    long_running_job true
+  end
+end
+
+produce_many(DT.topic, DT.uuids(5))
+
+start_karafka_and_wait_until do
+  DT[0].size >= 5
+end
+
+assert DT[0].size >= 5

--- a/spec/integrations/pro/consumption/strategies/dlq_lrj_mom/regular_processing_one_by_one_without_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_lrj_mom/regular_processing_one_by_one_without_errors_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Karafka should be able to just process all the messages one after another
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 1
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[0] << true
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    max_messages 1
+    dead_letter_queue topic: DT.topics[1], max_retries: 4
+    long_running_job true
+    manual_offset_management true
+  end
+end
+
+produce_many(DT.topic, DT.uuids(5))
+
+start_karafka_and_wait_until do
+  DT[0].size >= 5
+end
+
+assert DT[0].size >= 5

--- a/spec/integrations/pro/consumption/strategies/dlq_lrj_vp/regular_processing_one_by_one_without_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_lrj_vp/regular_processing_one_by_one_without_errors_spec.rb
@@ -19,7 +19,7 @@ draw_routes do
     dead_letter_queue topic: DT.topics[1], max_retries: 4
     long_running_job true
     virtual_partitions(
-      partitioner: ->(message) { rand(10) }
+      partitioner: ->(_) { rand(10) }
     )
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq_lrj_vp/regular_processing_one_by_one_without_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_lrj_vp/regular_processing_one_by_one_without_errors_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Karafka should be able to just process all the messages one after another
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 1
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[0] << true
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    max_messages 1
+    dead_letter_queue topic: DT.topics[1], max_retries: 4
+    long_running_job true
+    virtual_partitions(
+      partitioner: ->(message) { rand(10) }
+    )
+  end
+end
+
+produce_many(DT.topic, DT.uuids(5))
+
+start_karafka_and_wait_until do
+  DT[0].size >= 5
+end
+
+assert DT[0].size >= 5

--- a/spec/integrations/pro/consumption/strategies/dlq_mom/regular_processing_one_by_one_without_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_mom/regular_processing_one_by_one_without_errors_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Karafka should be able to just process all the messages one after another
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 1
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[0] << true
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    max_messages 1
+    dead_letter_queue topic: DT.topics[1], max_retries: 4
+    manual_offset_management true
+  end
+end
+
+produce_many(DT.topic, DT.uuids(5))
+
+start_karafka_and_wait_until do
+  DT[0].size >= 5
+end
+
+assert DT[0].size >= 5

--- a/spec/integrations/pro/consumption/strategies/dlq_vp/regular_processing_one_by_one_without_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_vp/regular_processing_one_by_one_without_errors_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Karafka should be able to just process all the messages one after another
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 1
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[0] << true
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    max_messages 1
+    dead_letter_queue topic: DT.topics[1], max_retries: 4
+    virtual_partitions(
+      partitioner: ->(message) { rand(10) }
+    )
+  end
+end
+
+produce_many(DT.topic, DT.uuids(5))
+
+start_karafka_and_wait_until do
+  DT[0].size >= 5
+end
+
+assert DT[0].size >= 5

--- a/spec/integrations/pro/consumption/strategies/dlq_vp/regular_processing_one_by_one_without_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq_vp/regular_processing_one_by_one_without_errors_spec.rb
@@ -18,7 +18,7 @@ draw_routes do
     max_messages 1
     dead_letter_queue topic: DT.topics[1], max_retries: 4
     virtual_partitions(
-      partitioner: ->(message) { rand(10) }
+      partitioner: ->(_) { rand(10) }
     )
   end
 end

--- a/spec/integrations/pro/consumption/strategies/lrj/regular_processing_one_by_one_without_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/regular_processing_one_by_one_without_errors_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Karafka should be able to just process all the messages one after another
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 1
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[0] << true
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    max_messages 1
+    long_running_job true
+  end
+end
+
+produce_many(DT.topic, DT.uuids(5))
+
+start_karafka_and_wait_until do
+  DT[0].size >= 5
+end
+
+assert DT[0].size >= 5

--- a/spec/integrations/pro/consumption/strategies/lrj_vp/regular_processing_one_by_one_without_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj_vp/regular_processing_one_by_one_without_errors_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Karafka should be able to just process all the messages one after another
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 1
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[0] << true
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    max_messages 1
+    long_running_job true
+    virtual_partitions(
+      partitioner: ->(msg) { msg.raw_payload }
+    )
+  end
+end
+
+produce_many(DT.topic, DT.uuids(5))
+
+start_karafka_and_wait_until do
+  DT[0].size >= 5
+end
+
+assert DT[0].size >= 5

--- a/spec/integrations/pro/consumption/strategies/vp/regular_processing_one_by_one_without_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/regular_processing_one_by_one_without_errors_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Karafka should be able to just process all the messages one after another
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 1
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[0] << true
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    max_messages 1
+    virtual_partitions(
+      partitioner: ->(msg) { msg.raw_payload }
+    )
+  end
+end
+
+produce_many(DT.topic, DT.uuids(5))
+
+start_karafka_and_wait_until do
+  DT[0].size >= 5
+end
+
+assert DT[0].size >= 5


### PR DESCRIPTION
This PR:
- uses proper strategy for AJ + DLQ + MOM + LRJ combination that handles all the cases (same as for AJ + DLQ + MOM + LRJ + VP) - because from the outside, this is the same.
- adds regression integration spec to ALL potentially affected scenarios (other not affected but just to be sure in the future).

fix https://github.com/karafka/karafka/issues/1362