### PR TITLE
Rename watermark_offsets method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Karafka framework changelog
 
 ## 2.0.38 (Unreleased)
-- [Improvement] Introduce `Karafka::Admin#watermark_offsets` to get low and high watermark offsets values.
+- [Improvement] Introduce `Karafka::Admin#read_watermark_offsets` to get low and high watermark offsets values.
 - [Improvement] Track active_job_id in instrumentation (#1372)
 - [Improvement] Improve `#read_topic` reading in case of a compacted partition, there the offset is beyond the low watermark offset. This should optimize reading and should not go beyond the low watermark offset.
 - [Improvement] Allow `#read_topic` to accept instance settings to overwrite any settings needed to customize reading behaviours.

--- a/lib/karafka/admin.rb
+++ b/lib/karafka/admin.rb
@@ -156,7 +156,7 @@ module Karafka
       # @param name [String, Symbol] topic name
       # @param partition [Integer] partition
       # @return [Array<Integer, Integer>] low watermark offset and high watermark offset
-      def watermark_offsets(name, partition)
+      def read_watermark_offsets(name, partition)
         with_consumer do |consumer|
           consumer.query_watermark_offsets(name, partition)
         end

--- a/spec/lib/karafka/admin_spec.rb
+++ b/spec/lib/karafka/admin_spec.rb
@@ -210,8 +210,8 @@ RSpec.describe_current do
     end
   end
 
-  describe '#watermark_offsets' do
-    subject(:offsets) { described_class.watermark_offsets(name, partition) }
+  describe '#read_watermark_offsets' do
+    subject(:offsets) { described_class.read_watermark_offsets(name, partition) }
 
     let(:name) { SecureRandom.hex(6) }
     let(:partition) { 0 }


### PR DESCRIPTION
This PR aligns the name to match other admin actions to prefix operation with command (create / delete / update / read) etc. for consistency.

It's not a breaking change because was not released yet.