### PR TITLE
Move marking to strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [Refactor] Put Pro strategies into namespaces to better organize multiple combinations.
 - [Refactor] Do not rely on messages metadata for internal topic and partition operations like `#seek` so they can run independently from the consumption flow.
 - [Refactor] Hold a single topic/partition reference on a coordinator instead of in executor, coordinator and consumer.
+- [Refactor] Move `#mark_as_consumed` and `#mark_as_consumed!`into `Strategies::Default` to be able to introduce marking for virtual partitions.
 
 ## 2.0.38 (2023-03-27)
 - [Improvement] Introduce `Karafka::Admin#read_watermark_offsets` to get low and high watermark offsets values.

--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -159,51 +159,6 @@ module Karafka
     # some teardown procedures (closing file handler, etc).
     def shutdown; end
 
-    # Marks message as consumed in an async way.
-    #
-    # @param message [Messages::Message] last successfully processed message.
-    # @return [Boolean] true if we were able to mark the offset, false otherwise. False indicates
-    #   that we were not able and that we have lost the partition.
-    #
-    # @note We keep track of this offset in case we would mark as consumed and got error when
-    #   processing another message. In case like this we do not pause on the message we've already
-    #   processed but rather at the next one. This applies to both sync and async versions of this
-    #   method.
-    def mark_as_consumed(message)
-      # Ignore earlier offsets than the one we already committed
-      return true if coordinator.seek_offset > message.offset
-
-      unless client.mark_as_consumed(message)
-        coordinator.revoke
-
-        return false
-      end
-
-      coordinator.seek_offset = message.offset + 1
-
-      true
-    end
-
-    # Marks message as consumed in a sync way.
-    #
-    # @param message [Messages::Message] last successfully processed message.
-    # @return [Boolean] true if we were able to mark the offset, false otherwise. False indicates
-    #   that we were not able and that we have lost the partition.
-    def mark_as_consumed!(message)
-      # Ignore earlier offsets than the one we already committed
-      return true if coordinator.seek_offset > message.offset
-
-      unless client.mark_as_consumed!(message)
-        coordinator.revoke
-
-        return false
-      end
-
-      coordinator.seek_offset = message.offset + 1
-
-      true
-    end
-
     # Pauses processing on a given offset for the current topic partition
     #
     # After given partition is resumed, it will continue processing from the given offset

--- a/lib/karafka/processing/strategies/default.rb
+++ b/lib/karafka/processing/strategies/default.rb
@@ -13,6 +13,51 @@ module Karafka
         # Apply strategy for a non-feature based flow
         FEATURES = %i[].freeze
 
+        # Marks message as consumed in an async way.
+        #
+        # @param message [Messages::Message] last successfully processed message.
+        # @return [Boolean] true if we were able to mark the offset, false otherwise.
+        #   False indicates that we were not able and that we have lost the partition.
+        #
+        # @note We keep track of this offset in case we would mark as consumed and got error when
+        #   processing another message. In case like this we do not pause on the message we've
+        #   already processed but rather at the next one. This applies to both sync and async
+        #   versions of this method.
+        def mark_as_consumed(message)
+          # Ignore earlier offsets than the one we already committed
+          return true if coordinator.seek_offset > message.offset
+
+          unless client.mark_as_consumed(message)
+            coordinator.revoke
+
+            return false
+          end
+
+          coordinator.seek_offset = message.offset + 1
+
+          true
+        end
+
+        # Marks message as consumed in a sync way.
+        #
+        # @param message [Messages::Message] last successfully processed message.
+        # @return [Boolean] true if we were able to mark the offset, false otherwise.
+        #   False indicates that we were not able and that we have lost the partition.
+        def mark_as_consumed!(message)
+          # Ignore earlier offsets than the one we already committed
+          return true if coordinator.seek_offset > message.offset
+
+          unless client.mark_as_consumed!(message)
+            coordinator.revoke
+
+            return false
+          end
+
+          coordinator.seek_offset = message.offset + 1
+
+          true
+        end
+
         # No actions needed for the standard flow here
         def handle_before_enqueue
           nil

--- a/spec/lib/karafka/active_job/consumer_spec.rb
+++ b/spec/lib/karafka/active_job/consumer_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe_current do
     consumer = described_class.new
     consumer.client = client
     consumer.coordinator = coordinator
+    consumer.singleton_class.include Karafka::Processing::Strategies::Default
     consumer
   end
 

--- a/spec/lib/karafka/base_consumer_spec.rb
+++ b/spec/lib/karafka/base_consumer_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe_current do
   subject(:consumer) do
     instance = working_class.new
     instance.coordinator = coordinator
+    instance.singleton_class.include Karafka::Processing::Strategies::Default
     instance
   end
 


### PR DESCRIPTION
Moving marking methods to strategies as their behaviour will differ in the future due to introduction of soft marking in virtual partitions.