### PR TITLE
`#retrying?` and `#failing?` consumer API + specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - **[Feature]** Provide Delayed Topics (#1000)
 - **[Feature]** Provide ability to expire messages (expiring topics)
 - **[Feature]** Provide ability to apply filters after messages are polled and before enqueued. This is a generic filter API for any usage.
+- [Improvement] When using ActiveJob with Virtual Partitions, Karafka will stop if collectively VPs are failing. This minimizes number of jobs that will be collectively re-processed.
+- [Improvement] `#retrying?` method has been added to consumers to provide ability to check, that we're reprocessing data after a failure. This is useful for branching out processing based on errors.
 - [Improvement] Track active_job_id in instrumentation (#1372)
 - [Improvement] Introduce new housekeeping job type called `Idle` for non-consumption execution flows.
 - [Improvement] Change how a manual offset management works with Long-Running Jobs. Use the last message offset to move forward instead of relying on the last message marked as consumed for a scenario where no message is marked.

--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -221,6 +221,13 @@ module Karafka
       coordinator.revoked?
     end
 
+    # @return [Boolean] are we retrying processing after an error. This can be used to provide a
+    #   different flow after there is an error, for example for resources cleanup, small manual
+    #   backoff or different instrumentation tracking.
+    def retrying?
+      coordinator.pause_tracker.attempt > 0
+    end
+
     # Pauses the processing from the last offset to retry on given message
     # @private
     def retry_after_pause

--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -225,7 +225,7 @@ module Karafka
     #   different flow after there is an error, for example for resources cleanup, small manual
     #   backoff or different instrumentation tracking.
     def retrying?
-      coordinator.pause_tracker.attempt > 0
+      coordinator.pause_tracker.attempt.positive?
     end
 
     # Pauses the processing from the last offset to retry on given message

--- a/lib/karafka/pro/active_job/consumer.rb
+++ b/lib/karafka/pro/active_job/consumer.rb
@@ -35,7 +35,7 @@ module Karafka
             # double-processing
             break if Karafka::App.stopping? && !topic.virtual_partitions?
 
-            # Break if we already know, that one of virtual partitions have failed and we will
+            # Break if we already know, that one of virtual partitions has failed and we will
             # be restarting processing all together after all VPs are done. This will minimize
             # number of jobs that will be re-processed
             break if topic.virtual_partitions? && failing?

--- a/lib/karafka/pro/active_job/consumer.rb
+++ b/lib/karafka/pro/active_job/consumer.rb
@@ -35,6 +35,11 @@ module Karafka
             # double-processing
             break if Karafka::App.stopping? && !topic.virtual_partitions?
 
+            # Break if we already know, that one of virtual partitions have failed and we will
+            # be restarting processing all together after all VPs are done. This will minimize
+            # number of jobs that will be re-processed
+            break if topic.virtual_partitions? && failing?
+
             consume_job(message)
 
             # We cannot mark jobs as done after each if there are virtual partitions. Otherwise

--- a/lib/karafka/pro/processing/strategies.rb
+++ b/lib/karafka/pro/processing/strategies.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Processing
+      # Pro processing strategies namespace
+      module Strategies
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/processing/strategies/lrj/ftr_vp.rb
+++ b/lib/karafka/pro/processing/strategies/lrj/ftr_vp.rb
@@ -22,6 +22,7 @@ module Karafka
           #
           # Behaves same as non-VP because of the aggregated flow in the coordinator.
           module FtrVp
+            include Strategies::Vp::Default
             include Strategies::Lrj::Ftr
 
             # Features for this strategy

--- a/lib/karafka/pro/processing/strategies/vp/default.rb
+++ b/lib/karafka/pro/processing/strategies/vp/default.rb
@@ -36,7 +36,7 @@ module Karafka
 
             # @return [Boolean] true if any of virtual partition we're operating in the entangled
             #   mode has already failed and we know we are failing collectively.
-            #   Useful for early stop to minimize number of reprocessings.
+            #   Useful for early stop to minimize number of things processed twice.
             #
             # @note We've named it `#failing?` instead of `#failure?`  because it aims to be used
             #   from within virtual partitions where we want to have notion of collective failing

--- a/lib/karafka/pro/processing/strategies/vp/default.rb
+++ b/lib/karafka/pro/processing/strategies/vp/default.rb
@@ -33,6 +33,18 @@ module Karafka
             def collapsed?
               coordinator.collapsed?
             end
+
+            # @return [Boolean] true if any of virtual partition we're operating in the entangled
+            #   mode has already failed and we know we are failing collectively.
+            #   Useful for early stop to minimize number of reprocessings.
+            #
+            # @note We've named it `#failing?` instead of `#failure?`  because it aims to be used
+            #   from within virtual partitions where we want to have notion of collective failing
+            #   not just "local" to our processing. We "are" failing with other virtual partitions
+            #   raising an error, but locally we are still processing.
+            def failing?
+              coordinator.failure?
+            end
           end
         end
       end

--- a/lib/karafka/processing/result.rb
+++ b/lib/karafka/processing/result.rb
@@ -32,6 +32,11 @@ module Karafka
         @success = false
         @cause = cause
       end
+
+      # @return [Boolean] true if processing failed
+      def failure?
+        !@success
+      end
     end
   end
 end

--- a/spec/integrations/consumption/with_branching_logic_on_retry.rb
+++ b/spec/integrations/consumption/with_branching_logic_on_retry.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# We should be able to apply custom logic flow, when re-processing data after an error.
+
+setup_karafka(allow_errors: true)
+
+SuperException = Class.new(Exception)
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+
+      raise if message.offset == 5 && !retrying?
+
+      DT[:offsets] << message.offset
+
+      mark_as_consumed(message)
+    end
+  end
+end
+
+draw_routes(Consumer)
+
+produce_many(DT.topic, DT.uuids(10))
+
+start_karafka_and_wait_until do
+  DT[:offsets].count >= 10
+end
+
+assert_equal DT[:offsets], (0..9).to_a

--- a/spec/integrations/consumption/with_branching_logic_on_retry.rb
+++ b/spec/integrations/consumption/with_branching_logic_on_retry.rb
@@ -9,7 +9,6 @@ SuperException = Class.new(Exception)
 class Consumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-
       raise if message.offset == 5 && !retrying?
 
       DT[:offsets] << message.offset

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_lrj_mom_vp/with_non_recoverable_job_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_lrj_mom_vp/with_non_recoverable_job_error_spec.rb
@@ -7,6 +7,7 @@ SAMPLES = (0..1_000).to_a.map(&:to_s)
 setup_active_job
 
 setup_karafka(allow_errors: true) do |config|
+  config.concurrency = 1
   config.max_messages = 10
   config.kafka[:'max.poll.interval.ms'] = 10_000
   config.kafka[:'session.timeout.ms'] = 10_000

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_mom_vp/with_non_recoverable_job_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_mom_vp/with_non_recoverable_job_error_spec.rb
@@ -9,6 +9,8 @@ setup_active_job
 
 setup_karafka(allow_errors: true) do |config|
   config.max_messages = 10
+  # Having one partition will remove the unpredictability of VP+AJ early return on failing
+  config.concurrency = 1
   config.kafka[:'max.poll.interval.ms'] = 10_000
   config.kafka[:'session.timeout.ms'] = 10_000
 end

--- a/spec/integrations/pro/consumption/strategies/aj/mom_vp/no_execution_on_failing_saturated_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/mom_vp/no_execution_on_failing_saturated_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Karafka when running VPs with AJ and being saturated, should not run further jobs if the first
+# job in the queue failed. This saves on double processing.
+
+setup_active_job
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 100
+  # Force saturation by not having enough threads
+  config.concurrency = 1
+end
+
+class Job < ActiveJob::Base
+  queue_as DT.topic
+
+  def perform(value)
+    DT[0] << value
+
+    return if value == 0
+
+    raise StandardError
+  end
+end
+
+draw_routes do
+  active_job_topic DT.topic do
+    virtual_partitions(
+      partitioner: ->(message) { message.offset % 10 },
+      max_partitions: 10
+    )
+  end
+end
+
+100.times { |value| Job.perform_later(value) }
+
+start_karafka_and_wait_until do
+  DT[0].size >= 10
+end
+
+# There is a bit of unpredictability here, but without early break on collective fail, a lot more
+# offsets would be present here
+assert(DT[0].uniq.count <= 5)

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr/pipeline_with_delayed_dlq.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr/pipeline_with_delayed_dlq.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# With delayed jobs with should be able to build a pipeline where we delay re-processing of
+# messages when their processing fails and they are moved to DLQ.
+
+setup_karafka(allow_errors: %w[consumer.consume.error])
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      if message.offset == 10
+        DT[:errored] << Time.now
+        raise StandardError
+      end
+
+      mark_as_consumed message
+    end
+  end
+end
+
+class DlqConsumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[:retried] << Time.now
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    dead_letter_queue(topic: DT.topics[1], max_retries: 0)
+  end
+
+  topic DT.topics[1] do
+    consumer DlqConsumer
+    # 15 seconds
+    delay_by(15_000)
+  end
+end
+
+elements = DT.uuids(15)
+produce_many(DT.topic, elements)
+
+start_karafka_and_wait_until do
+  DT[:retried].size >= 1
+end
+
+assert DT[:retried].first - DT[:errored].first > 15

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr/pipeline_with_delayed_dlq.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr/pipeline_with_delayed_dlq.rb
@@ -20,9 +20,7 @@ end
 
 class DlqConsumer < Karafka::BaseConsumer
   def consume
-    messages.each do |message|
-      DT[:retried] << Time.now
-    end
+    DT[:retried] << Time.now
   end
 end
 

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/with_continuous_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/with_continuous_error_spec.rb
@@ -50,7 +50,7 @@ consumer = setup_rdkafka_consumer
 consumer.subscribe(DT.topic)
 
 consumer.each do |message|
-  assert_equal 0, message.offset
+  assert_equal 0, message.offset, message.offset
   break
 end
 

--- a/spec/lib/karafka/pro/processing/strategies_spec.rb
+++ b/spec/lib/karafka/pro/processing/strategies_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  strategies = Karafka::Pro::Processing::StrategySelector.new.strategies
+
+  strategies
+    .select { |strategy| strategy::FEATURES.include?(:virtual_partitions) }
+    .each do |strategy|
+      context "when having strategy #{strategy}" do
+        it 'expect all of them to have #collapsed? method' do
+          expect(strategy.method_defined?(:collapsed?)).to eq(true)
+        end
+
+        it 'expect all of them to have #failing? method' do
+          expect(strategy.method_defined?(:failing?)).to eq(true)
+        end
+      end
+    end
+end


### PR DESCRIPTION
This PR:
- adds few more examples inluding delayed DLQ example
- When using ActiveJob with Virtual Partitions, Karafka will stop if collectively VPs are failing. This minimizes number of jobs that will be collectively re-processed.
- `#retrying?` method has been added to consumers to provide ability to check, that we're reprocessing data after a failure. This is useful for branching out processing based on errors.

close https://github.com/karafka/karafka/issues/1402