### PR TITLE
Build empty metadata for Idle first jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.0.40 (Unreleased)
 - [Refactor] Require messages builder to accept partition and do not fetch it from messages.
-- [Refactor] Use empty messages set for internal APIs (Idle) (so there always is `Karafa::Messages::Messages`)
+- [Refactor] Use empty messages set for internal APIs (Idle) (so there always is `Karafka::Messages::Messages`)
 - [Refactor] Allow for empty messages set initialization with -1001 and -1 on metadata (similar to `librdkafka`)
 
 ## 2.0.39 (2023-04-11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Karafka framework changelog
 
+## 2.0.40 (Unreleased)
+- [Refactor] Require messages builder to accept partition and do not fetch it from messages.
+- [Refactor] Use empty messages set for internal APIs (Idle) (so there always is `Karafa::Messages::Messages`)
+- [Refactor] Allow for empty messages set initialization with -1001 and -1 on metadata (similar to `librdkafka`)
+
 ## 2.0.39 (2023-04-11)
 - **[Feature]** Provide ability to throttle/limit number of messages processed in a time unit (#1203)
 - **[Feature]** Provide Delayed Topics (#1000)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka (2.0.39)
+    karafka (2.0.40)
       karafka-core (>= 2.0.12, < 3.0.0)
       thor (>= 0.20)
       waterdrop (>= 2.4.10, < 3.0.0)

--- a/lib/karafka/messages/builders/batch_metadata.rb
+++ b/lib/karafka/messages/builders/batch_metadata.rb
@@ -10,22 +10,23 @@ module Karafka
           #
           # @param messages [Array<Karafka::Messages::Message>] messages array
           # @param topic [Karafka::Routing::Topic] topic for which we've fetched the batch
+          # @param partition [Integer] partition of this metadata
           # @param scheduled_at [Time] moment when the batch was scheduled for processing
           # @return [Karafka::Messages::BatchMetadata] batch metadata object
           #
           # @note We do not set `processed_at` as this needs to be assigned when the batch is
           #   picked up for processing.
-          def call(messages, topic, scheduled_at)
+          def call(messages, topic, partition, scheduled_at)
             Karafka::Messages::BatchMetadata.new(
               size: messages.count,
-              first_offset: messages.first.offset,
-              last_offset: messages.last.offset,
+              first_offset: messages.first&.offset || -1001,
+              last_offset: messages.last&.offset || -1001,
               deserializer: topic.deserializer,
-              partition: messages.first.partition,
+              partition: partition,
               topic: topic.name,
               # We go with the assumption that the creation of the whole batch is the last message
               # creation time
-              created_at: messages.last.timestamp,
+              created_at: messages.last&.timestamp || nil,
               # When this batch was built and scheduled for execution
               scheduled_at: scheduled_at,
               # This needs to be set to a correct value prior to processing starting

--- a/lib/karafka/messages/builders/messages.rb
+++ b/lib/karafka/messages/builders/messages.rb
@@ -11,14 +11,16 @@ module Karafka
           #
           # @param messages [Array<Karafka::Messages::Message>] karafka messages array
           # @param topic [Karafka::Routing::Topic] topic for which we're received messages
+          # @param partition [Integer] partition of those messages
           # @param received_at [Time] moment in time when the messages were received
           # @return [Karafka::Messages::Messages] messages batch object
-          def call(messages, topic, received_at)
+          def call(messages, topic, partition, received_at)
             # We cannot freeze the batch metadata because it is altered with the processed_at time
             # prior to the consumption. It is being frozen there
             metadata = BatchMetadata.call(
               messages,
               topic,
+              partition,
               received_at
             )
 

--- a/lib/karafka/processing/executor.rb
+++ b/lib/karafka/processing/executor.rb
@@ -83,7 +83,7 @@ module Karafka
       # This may include house-keeping or other state management changes that can occur but that
       # not mean there are any new messages available for the end user to process
       def idle
-        # Initializes the messages set in case idle operation would happeb before any processing
+        # Initializes the messages set in case idle operation would happen before any processing
         # This prevents us from having no messages object at all as the messages object and
         # its metadata may be used for statistics
         consumer.messages ||= Messages::Builders::Messages.call(

--- a/lib/karafka/processing/executor.rb
+++ b/lib/karafka/processing/executor.rb
@@ -44,10 +44,6 @@ module Karafka
       #
       # @param messages [Array<Karafka::Messages::Message>]
       def before_enqueue(messages)
-        # the moment we've received the batch or actually the moment we've enqueued it,
-        # but good enough
-        @enqueued_at = Time.now
-
         # Recreate consumer with each batch if persistence is not enabled
         # We reload the consumers with each batch instead of relying on some external signals
         # when needed for consistency. That way devs may have it on or off and not in this
@@ -57,8 +53,11 @@ module Karafka
         # First we build messages batch...
         consumer.messages = Messages::Builders::Messages.call(
           messages,
-          coordinator.topic,
-          @enqueued_at
+          topic,
+          partition,
+          # the moment we've received the batch or actually the moment we've enqueued it,
+          # but good enough
+          Time.now
         )
 
         consumer.on_before_enqueue
@@ -84,6 +83,16 @@ module Karafka
       # This may include house-keeping or other state management changes that can occur but that
       # not mean there are any new messages available for the end user to process
       def idle
+        # Initializes the messages set in case idle operation would happeb before any processing
+        # This prevents us from having no messages object at all as the messages object and
+        # its metadata may be used for statistics
+        consumer.messages ||= Messages::Builders::Messages.call(
+          [],
+          topic,
+          partition,
+          Time.now
+        )
+
         consumer.on_idle
       end
 

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '2.0.39'
+  VERSION = '2.0.40'
 end

--- a/spec/integrations/pro/instrumentation/first_idle_messages_metadata_spec.rb
+++ b/spec/integrations/pro/instrumentation/first_idle_messages_metadata_spec.rb
@@ -19,7 +19,6 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-
 draw_routes do
   topic DT.topics[0] do
     consumer Consumer

--- a/spec/integrations/pro/instrumentation/first_idle_messages_metadata_spec.rb
+++ b/spec/integrations/pro/instrumentation/first_idle_messages_metadata_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# When the idle job kicks in before we had a chance to process any data, it should still have
+# access to empty messages batch with proper offset positions (-1001) and no messages.
+
+setup_karafka
+
+Karafka.monitor.subscribe('filtering.throttled') do
+  DT[:done] << true
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[:consumed] << true
+  end
+
+  def shutdown
+    DT[:messages] << messages
+  end
+end
+
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    delay_by(60_000)
+  end
+end
+
+produce_many(DT.topic, DT.uuids(15))
+
+start_karafka_and_wait_until do
+  !DT[:done].empty?
+end
+
+assert DT[:consumed].empty?
+assert_equal DT[:messages].size, 1
+
+messages = DT[:messages].first
+
+assert_equal messages.metadata.first_offset, -1001
+assert_equal messages.metadata.last_offset, -1001
+assert_equal messages.metadata.partition, 0
+assert_equal messages.metadata.size, 0
+assert_equal messages.metadata.created_at, nil
+assert_equal messages.metadata.processed_at, nil

--- a/spec/lib/karafka/messages/builders/batch_metadata_spec.rb
+++ b/spec/lib/karafka/messages/builders/batch_metadata_spec.rb
@@ -6,9 +6,10 @@ RSpec.describe_current do
   let(:message2) { build(:kafka_fetched_message, timestamp: 3.seconds.ago) }
   let(:kafka_batch) { [message1, message2] }
   let(:scheduled_at) { Time.now - 1.second }
+  let(:partition) { rand(10) }
 
   describe '#call' do
-    subject(:result) { described_class.call(kafka_batch, routing_topic, scheduled_at) }
+    subject(:result) { described_class.call(kafka_batch, routing_topic, partition, scheduled_at) }
 
     let(:now) { Time.now }
 
@@ -16,7 +17,7 @@ RSpec.describe_current do
 
     it { is_expected.to be_a(Karafka::Messages::BatchMetadata) }
     it { expect(result.size).to eq kafka_batch.count }
-    it { expect(result.partition).to eq kafka_batch.first.partition }
+    it { expect(result.partition).to eq partition }
     it { expect(result.first_offset).to eq kafka_batch.first.offset }
     it { expect(result.last_offset).to eq kafka_batch.last.offset }
     it { expect(result.topic).to eq routing_topic.name }
@@ -32,6 +33,19 @@ RSpec.describe_current do
 
       it { expect(result.consumption_lag).to be_between(3000, 3100) }
       it { expect(result.processing_lag).to be_between(1000, 1100) }
+    end
+
+    context 'when there are no messages in the messages array' do
+      let(:kafka_batch) { [] }
+
+      it { is_expected.to be_a(Karafka::Messages::BatchMetadata) }
+      it { expect(result.size).to eq 0 }
+      it { expect(result.partition).to eq partition }
+      it { expect(result.first_offset).to eq -1001 }
+      it { expect(result.last_offset).to eq -1001 }
+      it { expect(result.topic).to eq routing_topic.name }
+      it { expect(result.deserializer).to eq routing_topic.deserializer }
+      it { expect(result.scheduled_at).to eq(scheduled_at) }
     end
   end
 end

--- a/spec/lib/karafka/messages/builders/batch_metadata_spec.rb
+++ b/spec/lib/karafka/messages/builders/batch_metadata_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe_current do
       it { is_expected.to be_a(Karafka::Messages::BatchMetadata) }
       it { expect(result.size).to eq 0 }
       it { expect(result.partition).to eq partition }
-      it { expect(result.first_offset).to eq -1001 }
-      it { expect(result.last_offset).to eq -1001 }
+      it { expect(result.first_offset).to eq(-1001) }
+      it { expect(result.last_offset).to eq(-1001) }
       it { expect(result.topic).to eq routing_topic.name }
       it { expect(result.deserializer).to eq routing_topic.deserializer }
       it { expect(result.scheduled_at).to eq(scheduled_at) }

--- a/spec/lib/karafka/messages/builders/messages_spec.rb
+++ b/spec/lib/karafka/messages/builders/messages_spec.rb
@@ -5,10 +5,13 @@ RSpec.describe_current do
   let(:message2) { build(:kafka_fetched_message) }
   let(:kafka_messages) { [message1, message2] }
   let(:routing_topic) { build(:routing_topic) }
+  let(:partition) { rand(10) }
   let(:received_at) { Time.new }
 
   describe '#call' do
-    subject(:result) { described_class.call(kafka_messages, routing_topic, received_at) }
+    subject(:result) do
+      described_class.call(kafka_messages, routing_topic, partition, received_at)
+    end
 
     it { is_expected.to be_a(Karafka::Messages::Messages) }
   end

--- a/spec/lib/karafka/messages/messages_spec.rb
+++ b/spec/lib/karafka/messages/messages_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe_current do
   subject(:messages) do
-    Karafka::Messages::Builders::Messages.call(messages_array, topic, received_at)
+    Karafka::Messages::Builders::Messages.call(messages_array, topic, 0, received_at)
   end
 
   let(:deserialized_payload) { { rand.to_s => rand.to_s } }


### PR DESCRIPTION
 This PR aligns how we build metadata and messages to make sure, that upon idle job which can run before we run `#consume`, the empty batch with metadata is accessible.

This aligns the behaviour of always having the batch, even if empty.
