### PR TITLE
Report ten slowest integration specs after execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka framework changelog
 
+## 2.0.41 (Unreleased)
+- [Improvement] Report ten longest integration specs after the suite execution.
+
 ## 2.0.40 (2023-04-13)
 - [Improvement] Introduce `Karafka::Messages::Messages#empty?` method to handle Idle related cases where shutdown or revocation would be called on an empty messages set. This method allows for checking if there are any messages in the messages batch.
 - [Refactor] Require messages builder to accept partition and do not fetch it from messages.

--- a/bin/integrations
+++ b/bin/integrations
@@ -152,8 +152,14 @@ class Scenario
     end
   end
 
+  # @return [Float] number of seconds that a given spec took to run
+  def time_taken
+    @finished_at - @started_at
+  end
+
   # Close all the files that are open, so they do not pile up
   def close
+    @finished_at = current_time
     @stdin.close
     @stdout.close
     @stderr.close
@@ -262,13 +268,22 @@ while finished_scenarios.size < scenarios.size
   sleep(0.1)
 end
 
+# Report longest scenarios
+puts
+puts "\nLongest scenarios:\n\n"
+
+finished_scenarios.sort_by(&:time_taken).reverse.first(10).each do |long_scenario|
+  puts "[#{'%6.2f' % long_scenario.time_taken}] #{long_scenario.name}"
+end
+
 failed_scenarios = finished_scenarios.reject(&:success?)
 
-# Report once more on the failed jobs
-# This will only list scenarios that failed without printing their stdout here.
 if failed_scenarios.empty?
   puts
 else
+  # Report once more on the failed jobs
+  # This will only list scenarios that failed without printing their stdout here.
+  puts
   puts "\nFailed scenarios:\n\n"
 
   failed_scenarios.each do |scenario|


### PR DESCRIPTION
This PR prints 10 slowests specs after suite is executed. Useful for future optimizations. 