### PR TITLE
Prevent deadlock on statistics crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.0.41 (Unreleased)
 - [Improvement] Report ten longest integration specs after the suite execution.
+- [Improvement] Prevent user originating errors related to statistics processing after listener loop crash from potentially crashing the listener loop and hanging Karafka process.
 
 ## 2.0.40 (2023-04-13)
 - [Improvement] Introduce `Karafka::Messages::Messages#empty?` method to handle Idle related cases where shutdown or revocation would be called on an empty messages set. This method allows for checking if there are any messages in the messages batch.

--- a/lib/karafka/instrumentation/callbacks/statistics.rb
+++ b/lib/karafka/instrumentation/callbacks/statistics.rb
@@ -35,14 +35,14 @@ module Karafka
         # We need to catch and handle any potential errors coming from the instrumentation pipeline
         # as otherwise, in case of statistics which run in the main librdkafka thread, any crash
         # will hang the whole process.
-        rescue StandardError => error
+        rescue StandardError => e
           ::Karafka.monitor.instrument(
             'error.occurred',
             caller: self,
             subscription_group_id: @subscription_group_id,
             consumer_group_id: @consumer_group_id,
             type: 'statistics.emitted.error',
-            error: error
+            error: e
           )
         end
       end

--- a/lib/karafka/instrumentation/logger_listener.rb
+++ b/lib/karafka/instrumentation/logger_listener.rb
@@ -261,6 +261,12 @@ module Karafka
         when 'librdkafka.error'
           error "librdkafka internal error occurred: #{error}"
           error details
+        # Those can occur when emitted statistics are consumed by the end user and the processing
+        # of statistics fails. The statistics are emitted from librdkafka main loop thread and
+        # any errors there crash the whole thread
+        when 'statistics.emitted.error'
+          error "statistics.emitted processing failed due to an error: #{error}"
+          error details
         # Those will only occur when retries in the client fail and when they did not stop after
         # back-offs
         when 'connection.client.poll.error'

--- a/spec/integrations/instrumentation/statistics_callback_with_crashing_subscription_spec.rb
+++ b/spec/integrations/instrumentation/statistics_callback_with_crashing_subscription_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Karafka should not hang or crash when we receive the statistics processing error. It should
+# recover and be responsive.
+
+setup_karafka(allow_errors: true)
+
+Consumer = Class.new(Karafka::BaseConsumer)
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+  end
+end
+
+class Listener
+  def on_statistics_emitted(event)
+    DT[:statistics_events] << event
+
+    raise StandardError
+  end
+
+  def on_error_occurred(event)
+    DT[:error_events] << event
+  end
+end
+
+Karafka::App.monitor.subscribe(Listener.new)
+
+produce_many(DT.topic, DT.uuids(100))
+
+start_karafka_and_wait_until do
+  DT[:statistics_events].size >= 5 && DT[:error_events].size >= 5
+end
+
+p DT[:error_events].count

--- a/spec/integrations_helper.rb
+++ b/spec/integrations_helper.rb
@@ -111,6 +111,7 @@ def setup_web
   end
 
   Karafka::Web.enable!
+  Karafka::Web::Installer.new.bootstrap!
 end
 
 # Switches specs into a Pro mode

--- a/spec/lib/karafka/instrumentation/callbacks/statistics_spec.rb
+++ b/spec/lib/karafka/instrumentation/callbacks/statistics_spec.rb
@@ -71,4 +71,29 @@ RSpec.describe_current do
     it { expect(event[:statistics]).to eq(statistics) }
     it { expect(event[:statistics]['val_d']).to eq(0) }
   end
+
+  describe 'behavior on errors' do
+    context 'when an error occurs in the call' do
+      let(:events) { [] }
+      let(:event) { events.first }
+      let(:statistics) { { 'name' => client_name } }
+
+      before do
+        monitor.subscribe('statistics.emitted') do
+          raise StandardError
+        end
+
+        monitor.subscribe('error.occurred') do |event|
+          events << event
+        end
+      end
+
+      it { expect { callback.call(statistics) }.not_to raise_error }
+
+      it 'expect to catch it and pipe to the instrumentation errors' do
+        callback.call(statistics)
+        expect(events).not_to be_empty
+      end
+    end
+  end
 end

--- a/spec/lib/karafka/instrumentation/logger_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/logger_listener_spec.rb
@@ -363,6 +363,13 @@ RSpec.describe_current do
       it { expect(Karafka.logger).to have_received(:error).with(message) }
     end
 
+    context 'when it is a statistics.emitted.error' do
+      let(:type) { 'statistics.emitted.error' }
+      let(:message) { "statistics.emitted processing failed due to an error: #{error}" }
+
+      it { expect(Karafka.logger).to have_received(:error).with(message) }
+    end
+
     context 'when it is an unsupported error type' do
       subject(:error_trigger) { listener.on_error_occurred(event) }
 


### PR DESCRIPTION
librdkafka crashes if upon statistics dispatch there is an error. This PR fixes that by handling this error via the standard errors bus.

close https://github.com/karafka/karafka/issues/1419