### PR TITLE
Virtual Offset Filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Karafka framework changelog
 
 ## 2.1.0 (Unreleased)
-- **[Feature]** Introduce collective Virtual Partitions offset management
+- **[Feature]** Introduce collective Virtual Partitions offset management.
+- **[Feature]** Use virtual offsets to filter out messages that would be re-processed upon retries.
 - [Improvement] Always use Virtual offset management for Pro ActiveJobs.
 - [Improvement] Do not attempt to mark offsets on already revoked partitions.
 - [Improvement] Make sure, that VP components are not injected into non VP strategies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.1.0 (Unreleased)
 - **[Feature]** Introduce collective Virtual Partitions offset management.
 - **[Feature]** Use virtual offsets to filter out messages that would be re-processed upon retries.
+- [Improvement] No longer break processing on failing parallel virtual partitions in ActiveJob because it is compensated by virtual marking.
 - [Improvement] Always use Virtual offset management for Pro ActiveJobs.
 - [Improvement] Do not attempt to mark offsets on already revoked partitions.
 - [Improvement] Make sure, that VP components are not injected into non VP strategies.

--- a/lib/karafka/pro/active_job/consumer.rb
+++ b/lib/karafka/pro/active_job/consumer.rb
@@ -35,11 +35,6 @@ module Karafka
             # double-processing
             break if Karafka::App.stopping? && !topic.virtual_partitions?
 
-            # Break if we already know, that one of virtual partitions has failed and we will
-            # be restarting processing all together after all VPs are done. This will minimize
-            # number of jobs that will be re-processed
-            break if topic.virtual_partitions? && failing?
-
             consume_job(message)
 
             # We can always mark because of the virtual offset management that we have in VPs

--- a/lib/karafka/pro/processing/filters/virtual_limiter.rb
+++ b/lib/karafka/pro/processing/filters/virtual_limiter.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Processing
+      module Filters
+        # Removes messages that are alredy marked as consumed in the virtual offset manager
+        # This should operate only when using virtual partitions.
+        #
+        # This cleaner prevents us from duplicated processing of messages that were virtually
+        # marked as consumed even if we could not mark them as consumed in Kafka. This allows us
+        # to limit reprocessings when errors occur drastically when operating with virtual
+        # partitions
+        #
+        # @note It should be registered only when VPs are used
+        class VirtualLimiter < Base
+          # @param manager [Processing::VirtualOffsetManager]
+          # @param collapser [Processing::Collapser]
+          def initialize(manager, collapser)
+            @manager = manager
+            @collapser = collapser
+
+            super()
+          end
+
+          # Remove messages that we already marked as virtually consumed. Does nothing if not in
+          # the collapsed mode.
+          #
+          # @param messages [Array<Karafka::Messages::Message>]
+          def apply!(messages)
+            return unless @collapser.collapsed?
+
+            marked = @manager.marked
+
+            messages.delete_if { |message| marked.include?(message.offset) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/processing/filters/virtual_limiter.rb
+++ b/lib/karafka/pro/processing/filters/virtual_limiter.rb
@@ -15,12 +15,12 @@ module Karafka
   module Pro
     module Processing
       module Filters
-        # Removes messages that are alredy marked as consumed in the virtual offset manager
+        # Removes messages that are already marked as consumed in the virtual offset manager
         # This should operate only when using virtual partitions.
         #
         # This cleaner prevents us from duplicated processing of messages that were virtually
         # marked as consumed even if we could not mark them as consumed in Kafka. This allows us
-        # to limit reprocessings when errors occur drastically when operating with virtual
+        # to limit reprocessing when errors occur drastically when operating with virtual
         # partitions
         #
         # @note It should be registered only when VPs are used

--- a/lib/karafka/pro/processing/filters_applier.rb
+++ b/lib/karafka/pro/processing/filters_applier.rb
@@ -21,6 +21,10 @@ module Karafka
       # This means that this is the API we expose as a single filter, allowing us to control
       # the filtering via many filters easily.
       class FiltersApplier
+        # @return [Array] registered filters array. Useful if we want to inject internal context
+        #   aware filters.
+        attr_reader :filters
+
         # @param coordinator [Pro::Coordinator] pro coordinator
         def initialize(coordinator)
           # Builds filters out of their factories

--- a/lib/karafka/pro/processing/strategies/dlq/mom.rb
+++ b/lib/karafka/pro/processing/strategies/dlq/mom.rb
@@ -47,7 +47,7 @@ module Karafka
                   # We reset the pause to indicate we will now consider it as "ok".
                   coordinator.pause_tracker.reset
 
-                  skippable_message, _ = find_skippable_message
+                  skippable_message, = find_skippable_message
                   dispatch_to_dlq(skippable_message) if dispatch_to_dlq?
 
                   # Save the next offset we want to go with after moving given message to DLQ

--- a/lib/karafka/pro/processing/virtual_offset_manager.rb
+++ b/lib/karafka/pro/processing/virtual_offset_manager.rb
@@ -88,15 +88,21 @@ module Karafka
           materialize_real_offset
         end
 
-        # Mark all messages as consumed
-        # Useful for post-consumption automatic offset management cases
-        def mark_all
-          @marked.transform_values! { true }
+        def mark_until(message)
+          mark(message)
+
+          @groups.each do |group|
+            group.each do |offset|
+              next if offset > message.offset
+
+              @marked[offset] = true
+            end
+          end
 
           materialize_real_offset
         end
 
-        # @return [Array<Integer>] Messages already marked as consumed virtually
+        # @return [Array<Integer>] Offsets of messages already marked as consumed virtually
         def marked
           @marked.select { |_, status| status }.map(&:first).sort
         end

--- a/lib/karafka/pro/processing/virtual_offset_manager.rb
+++ b/lib/karafka/pro/processing/virtual_offset_manager.rb
@@ -88,6 +88,9 @@ module Karafka
           materialize_real_offset
         end
 
+        # Mark all from all groups including the `message`.
+        # Useful when operating in a collapsed state for marking
+        # @param message [Karafka::Messages::Message]
         def mark_until(message)
           mark(message)
 

--- a/lib/karafka/processing/strategies/dlq_mom.rb
+++ b/lib/karafka/processing/strategies/dlq_mom.rb
@@ -29,7 +29,7 @@ module Karafka
             # We reset the pause to indicate we will now consider it as "ok".
             coordinator.pause_tracker.reset
 
-            skippable_message, _ = find_skippable_message
+            skippable_message, = find_skippable_message
 
             dispatch_to_dlq(skippable_message)
 

--- a/spec/integrations/pro/consumption/strategies/aj/mom_vp/execution_on_failing_saturated_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/mom_vp/execution_on_failing_saturated_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# Karafka when running VPs with AJ and being saturated, should not run further jobs if the first
-# job in the queue failed. This saves on double processing.
+# Karafka when running VPs with AJ and being saturated, should run further jobs if the first
+# job in the queue failed because we use virtual offset management for handling this scenario.
 
 setup_active_job
 
@@ -38,6 +38,4 @@ start_karafka_and_wait_until do
   DT[0].size >= 10
 end
 
-# There is a bit of unpredictability here, but without early break on collective fail, a lot more
-# offsets would be present here
-assert(DT[0].uniq.count <= 5)
+assert(DT[0].uniq.count >= 10)

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/at_most_once_skipping_on_error_poll_one_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/at_most_once_skipping_on_error_poll_one_spec.rb
@@ -45,7 +45,7 @@ elements = DT.uuids(20)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[0].count >= 20
+  DT[0].count >= 20 && DT[:broken].size >= 10
 end
 
 assert_equal (DT[0] + DT[:broken]).sort.uniq, (0..19).to_a

--- a/spec/integrations/pro/consumption/strategies/vp/collapse_with_intermediate_marking_filtering_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/collapse_with_intermediate_marking_filtering_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# After we collapse, we should skip messages we marked as consumed, except those that were not
+# processed.
+
+setup_karafka(allow_errors: true) do |config|
+  config.concurrency = 5
+  config.max_messages = 100
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      raise if message.offset == 49 && !collapsed?
+
+      mark_as_consumed(message) if message.offset > 10
+
+      DT[0] << message.offset
+    end
+  end
+end
+
+draw_routes do
+  consumer_group DT.consumer_group do
+    topic DT.topic do
+      manual_offset_management(true)
+      consumer Consumer
+      virtual_partitions(
+        partitioner: ->(message) { (message.offset < 20 || message.offset == 49) ? 0 : 1 }
+      )
+    end
+  end
+end
+
+produce_many(DT.topic, DT.uuids(50))
+
+start_karafka_and_wait_until do
+  DT[0].count >= 50
+end
+
+assert_equal DT[0].uniq.count, DT[0].count

--- a/spec/integrations/pro/consumption/strategies/vp/collapse_with_intermediate_marking_filtering_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/collapse_with_intermediate_marking_filtering_spec.rb
@@ -26,7 +26,7 @@ draw_routes do
       manual_offset_management(true)
       consumer Consumer
       virtual_partitions(
-        partitioner: ->(message) { (message.offset < 20 || message.offset == 49) ? 0 : 1 }
+        partitioner: ->(message) { message.offset < 20 || message.offset == 49 ? 0 : 1 }
       )
     end
   end

--- a/spec/integrations/pro/consumption/strategies/vp/continuous_retry_in_collabse_with_filtering_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/continuous_retry_in_collabse_with_filtering_spec.rb
@@ -4,7 +4,7 @@
 # filtered for as long as the collapse lasts.
 
 class Listener
-  def on_error_occurred(event)
+  def on_error_occurred(_event)
     DT[:errors] << true
   end
 end

--- a/spec/integrations/pro/consumption/strategies/vp/continuous_retry_in_collabse_with_filtering_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/continuous_retry_in_collabse_with_filtering_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# When we continue to have an error on the same event in the collapse mode, others should be
+# filtered for as long as the collapse lasts.
+
+class Listener
+  def on_error_occurred(event)
+    DT[:errors] << true
+  end
+end
+
+Karafka.monitor.subscribe(Listener.new)
+
+setup_karafka(allow_errors: true) do |config|
+  config.concurrency = 5
+  config.max_messages = 100
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    if collapsed?
+      messages.each do |message|
+        DT[1] << message.offset
+      end
+
+      raise if messages.map(&:offset).include?(10)
+    else
+      messages.each do |message|
+        DT[0] << message.offset
+
+        raise if message.offset == 10
+
+        mark_as_consumed(message)
+      end
+    end
+  end
+end
+
+draw_routes do
+  consumer_group DT.consumer_group do
+    topic DT.topic do
+      manual_offset_management(true)
+      consumer Consumer
+      virtual_partitions(
+        partitioner: ->(_) { rand(10) }
+      )
+    end
+  end
+end
+
+produce_many(DT.topic, DT.uuids(50))
+
+start_karafka_and_wait_until do
+  DT[:errors].size >= 5
+end
+
+assert_equal([10], (DT[0].sort.uniq & DT[1].sort.uniq))
+assert (DT[0] + DT[1]).count(10) >= 5

--- a/spec/integrations/pro/consumption/strategies/vp/pre_work_marking_retry_continuity_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/pre_work_marking_retry_continuity_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# After an error, in case we marked before the processing, we should just skip the broken and
+# move on as we should just filter out broken one.
+
+setup_karafka(allow_errors: true) do |config|
+  config.concurrency = 5
+  config.max_messages = 100
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      mark_as_consumed(message)
+      DT[:offsets] << message.offset
+
+      raise if message.offset == 49
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    virtual_partitions(
+      partitioner: ->(message) { message.raw_payload }
+    )
+  end
+end
+
+produce_many(DT.topic, DT.uuids(50))
+
+extra_produced = false
+
+start_karafka_and_wait_until do
+  if DT[:offsets].count > 50
+    true
+  elsif DT[:offsets].count == 50 && !extra_produced
+    extra_produced = true
+    produce_many(DT.topic, DT.uuids(1))
+    false
+  else
+    false
+  end
+end
+
+assert_equal DT[:offsets].uniq.size, DT[:offsets].size
+assert_equal DT[:offsets].sort, (0..50).to_a

--- a/spec/integrations/pro/consumption/strategies/vp/with_soft_marking_partial_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/with_soft_marking_partial_error_spec.rb
@@ -16,7 +16,7 @@ class Consumer < Karafka::BaseConsumer
 
       DT[:collapsed_offsets] << message.offset if collapsed?
 
-      mark_as_consumed(message)
+      mark_as_consumed(message) unless message.offset == 99
     end
   end
 end
@@ -37,5 +37,3 @@ produce_many(DT.topic, DT.uuids(100))
 start_karafka_and_wait_until do
   DT[:collapsed_offsets].include?(99)
 end
-
-p DT[:collapsed_offsets].sort

--- a/spec/lib/karafka/pro/active_job/consumer_spec.rb
+++ b/spec/lib/karafka/pro/active_job/consumer_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe_current do
   end
 
   let(:client) { instance_double(Karafka::Connection::Client, pause: true) }
-  let(:coordinator) { build(:processing_coordinator_pro) }
-  let(:topic) { coordinator.topic }
+  let(:coordinator) { build(:processing_coordinator_pro, topic: topic) }
+  let(:topic) { build(:routing_topic) }
   let(:messages) { [message1, message2] }
   let(:message1) { build(:messages_message, raw_payload: payload1.to_json) }
   let(:message2) { build(:messages_message, raw_payload: payload2.to_json) }
@@ -83,6 +83,12 @@ RSpec.describe_current do
     context 'when messages are available to the consumer and it is virtual partition' do
       let(:strategy) { Karafka::Pro::Processing::Strategies::Aj::MomVp }
 
+      let(:topic) do
+        topic = build(:routing_topic)
+        topic.virtual_partitions(partitioner: ->(_) {})
+        topic
+      end
+
       before do
         consumer.messages = messages
 
@@ -91,8 +97,6 @@ RSpec.describe_current do
 
         allow(ActiveJob::Base).to receive(:execute).with(payload1)
         allow(ActiveJob::Base).to receive(:execute).with(payload2)
-
-        topic.virtual_partitions(partitioner: ->(_) {})
       end
 
       it 'expect to decode them and run active job executor' do

--- a/spec/lib/karafka/pro/processing/filters/virtual_limiter_spec.rb
+++ b/spec/lib/karafka/pro/processing/filters/virtual_limiter_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe_current do
 
   context 'when not collapsed' do
     it 'expect not to filter anything' do
-      expect { limiter.apply!(messages) }.not_to change { messages }
+      expect { limiter.apply!(messages) }.not_to(change { messages })
     end
   end
 
@@ -24,7 +24,7 @@ RSpec.describe_current do
     end
 
     context 'when nothing marked' do
-      it { expect { limiter.apply!(messages) }.not_to change { messages } }
+      it { expect { limiter.apply!(messages) }.not_to(change { messages }) }
     end
 
     context 'when all marked' do

--- a/spec/lib/karafka/pro/processing/filters/virtual_limiter_spec.rb
+++ b/spec/lib/karafka/pro/processing/filters/virtual_limiter_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:limiter) { described_class.new(manager, collapser) }
+
+  pending
+end

--- a/spec/lib/karafka/pro/processing/filters/virtual_limiter_spec.rb
+++ b/spec/lib/karafka/pro/processing/filters/virtual_limiter_spec.rb
@@ -3,5 +3,49 @@
 RSpec.describe_current do
   subject(:limiter) { described_class.new(manager, collapser) }
 
-  pending
+  4.times { |i| let(:"message#{i + 1}") { build(:messages_message) } }
+
+  let(:messages) { [message1, message2, message3, message4] }
+  let(:manager) { Karafka::Pro::Processing::VirtualOffsetManager.new('topic', 0) }
+  let(:collapser) { Karafka::Pro::Processing::Collapser.new }
+
+  before { manager.register(messages.map(&:offset)) }
+
+  context 'when not collapsed' do
+    it 'expect not to filter anything' do
+      expect { limiter.apply!(messages) }.not_to change { messages }
+    end
+  end
+
+  context 'when collapsed' do
+    before do
+      collapser.collapse_until!(messages.last.offset)
+      collapser.refresh!(messages.first.offset)
+    end
+
+    context 'when nothing marked' do
+      it { expect { limiter.apply!(messages) }.not_to change { messages } }
+    end
+
+    context 'when all marked' do
+      before { manager.mark_until(messages.last) }
+
+      it 'expect to remove all' do
+        limiter.apply!(messages)
+        expect(messages).to eq([])
+      end
+    end
+
+    context 'when some marked' do
+      before do
+        manager.mark(messages[0])
+        manager.mark(messages[1])
+      end
+
+      it 'expect to remove non-marked' do
+        limiter.apply!(messages)
+        expect(messages).to eq([message3, message4])
+      end
+    end
+  end
 end

--- a/spec/lib/karafka/pro/processing/strategies_spec.rb
+++ b/spec/lib/karafka/pro/processing/strategies_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe_current do
         end
 
         it 'expect its #handle_before_enqueue to not fail without virtual_offset_manager' do
-          expect {  consumer.send(:handle_before_enqueue) }.not_to raise_error
+          expect { consumer.send(:handle_before_enqueue) }.not_to raise_error
         end
       end
     end

--- a/spec/lib/karafka/pro/processing/strategies_spec.rb
+++ b/spec/lib/karafka/pro/processing/strategies_spec.rb
@@ -2,7 +2,8 @@
 
 RSpec.describe_current do
   let(:message) { build(:messages_message) }
-  let(:coordinator) { build(:processing_coordinator_pro, seek_offset: 0) }
+  let(:coordinator) { build(:processing_coordinator_pro, seek_offset: 0, topic: topic) }
+  let(:topic) { build(:routing_topic) }
   let(:client) { instance_double(Karafka::Connection::Client, pause: true) }
   let(:consumer) do
     consumer = Karafka::BaseConsumer.new
@@ -18,6 +19,12 @@ RSpec.describe_current do
     .select { |strategy| strategy::FEATURES.include?(:virtual_partitions) }
     .each do |strategy|
       context "when having VP strategy: #{strategy}" do
+        let(:topic) do
+          topic = build(:routing_topic)
+          topic.virtual_partitions(partitioner: true)
+          topic
+        end
+
         it 'expect all of them to have #collapsed? method' do
           expect(strategy.method_defined?(:collapsed?)).to eq(true)
         end
@@ -67,7 +74,11 @@ RSpec.describe_current do
         it 'expect its #handle_before_enqueue to never register virtual offsets groups' do
           consumer.send(:handle_before_enqueue)
 
-          expect(coordinator.virtual_offset_manager.groups).to be_empty
+          expect(coordinator.virtual_offset_manager).to be_nil
+        end
+
+        it 'expect its #handle_before_enqueue to not fail without virtual_offset_manager' do
+          expect {  consumer.send(:handle_before_enqueue) }.not_to raise_error
         end
       end
     end
@@ -76,6 +87,12 @@ RSpec.describe_current do
     .select { |strategy| strategy::FEATURES.include?(:long_running_job) }
     .each do |strategy|
       context "when having an LRJ strategy: #{strategy}" do
+        let(:topic) do
+          topic = build(:routing_topic)
+          topic.virtual_partitions(partitioner: true) if strategy.to_s.include?('Vp')
+          topic
+        end
+
         before do
           consumer.singleton_class.include(strategy)
           allow(client).to receive(:pause)
@@ -93,6 +110,12 @@ RSpec.describe_current do
     .reject { |strategy| strategy::FEATURES.include?(:long_running_job) }
     .each do |strategy|
       context "when having a non LRJ strategy: #{strategy}" do
+        let(:topic) do
+          topic = build(:routing_topic)
+          topic.virtual_partitions(partitioner: true) if strategy.to_s.include?('Vp')
+          topic
+        end
+
         before do
           consumer.singleton_class.include(strategy)
           allow(client).to receive(:pause)

--- a/spec/lib/karafka/pro/processing/virtual_offset_manager_spec.rb
+++ b/spec/lib/karafka/pro/processing/virtual_offset_manager_spec.rb
@@ -166,19 +166,19 @@ RSpec.describe_current do
     it { expect(manager.marked).to eq([1, 3, 5, 7, 9, 11, 13]) }
   end
 
-  context 'when marking all' do
+  context 'when marking until' do
     let(:range) { (0..19).to_a }
 
     before do
       manager.register(range.select(&:odd?))
       manager.register(range.reject(&:odd?))
 
-      manager.mark_all
+      manager.mark_until(OpenStruct.new(offset: 10))
     end
 
     it { expect(manager.markable?).to eq(true) }
-    it { expect(manager.markable.offset).to eq(19) }
-    it { expect(manager.marked).to eq(range) }
+    it { expect(manager.markable.offset).to eq(10) }
+    it { expect(manager.marked).to eq((0..10).to_a) }
   end
 
   context 'when marking first one higher than first offset' do


### PR DESCRIPTION
This PR adds virtual offset filtering and management.

It removes the last issue with VPs, where on retry and collapse, we would have to restart all the processing. After this PR, only failed messages will be retried.

close https://github.com/karafka/karafka/issues/1397