### PR TITLE
Draft: add prometheus listener

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,11 +6,12 @@ plugin 'diffend'
 
 gemspec
 
-# Karafka gem does not require activejob nor karafka-web  to work
+# Karafka gem does not require activejob, prometheus_exporter nor karafka-web  to work
 # They are added here because they are part of the integration suite
 group :integrations do
   gem 'activejob'
   gem 'karafka-web'
+  gem 'prometheus_exporter'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,8 @@ GEM
       tilt (~> 2.0)
     mini_portile2 (2.8.2)
     minitest (5.18.0)
+    prometheus_exporter (2.0.8)
+      webrick
     rack (3.0.7)
     rake (13.0.6)
     roda (3.68.0)
@@ -75,9 +77,11 @@ GEM
     waterdrop (2.5.2)
       karafka-core (>= 2.0.12, < 3.0.0)
       zeitwerk (~> 2.3)
+    webrick (1.8.1)
     zeitwerk (2.6.8)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -86,6 +90,7 @@ DEPENDENCIES
   factory_bot
   karafka!
   karafka-web
+  prometheus_exporter
   rspec
   simplecov
 

--- a/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_collector.rb
+++ b/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_collector.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "yaml"
+# Note prometheus exporter does not load rails and dependencies
+# You must manually require anything you need outside of prometheus_exporter
+# This includes Rails helpers like deep_symbolize_keys, present? for a hash, etc
+module Karafka
+  module Instrumentation
+    module Vendors
+      module PrometheusExporter
+        # The metrics collector is responsible for collecting metrics from the event payload
+        # The collector is only run on the prometheus_exporter server and not in the karafka app
+        # Once tested ideally it is added directly to the prometheus_exporter repository as a standard collector
+        # Once added to prometheus_exporter, Karafka no longer needs to maintain this file
+        class MetricsCollector < ::PrometheusExporter::Server::TypeCollector
+          # @return [Hash] registry, hash of metric names to their config
+          attr_reader :registry
+
+          CONFIG = YAML.load_file(
+            File.join(__dir__, "metrics_collector", "config.yaml")
+          ).freeze
+
+          def initialize
+            @registry = {}
+          end
+
+          # @param [Hash] hash of metric names to values: {'consumer_lags_delta=' => [2, {label: 1 }] }
+          # @return [Hash] the same hash passed in
+          def collect(obj)
+            ensure_metrics!
+            observe_metrics!(obj)
+          end
+
+          # @return [Array<PrometheusExporter::Metric::Base>] Instantiated Prometheus metrics (gauges, counters, etc)
+          def metrics
+            @registry.values
+          end
+
+          def type
+            "kafka"
+          end
+
+          protected
+
+          # @param [Hash] hash of metric names to values: {'consumer_lags_delta' => [2, {label: 1 }] }
+          def observe_metrics!(obj)
+            if obj.nil? || obj.empty? || obj["payload"].nil? || obj["payload"].empty? # standard:disable Rails/Blank
+              return warn("No kafka metrics to observe")
+            end
+
+            obj["payload"].each do |metric_name, payload|
+              metric = registry[metric_name]
+              next observe_metric(metric, payload) if metric && !payload.empty?
+              warn "Undefined metric: '#{metric_name}', for metrics: #{registry.keys}"
+            rescue StandardError => e
+              warn "Uncaught exception: #{e.message}, processing metric: '#{metric_name}' with payload: #{payload}"
+            end
+          end
+
+          # @param [::PrometheusExporter::Metric::Base] metric
+          # @param [Array] payload, array of tuples: [value, {label: 1}] or [[value, {label: 1}], [value, {label: 2}]]
+          def observe_metric(metric, payload)
+            if !payload[0].is_a? Array
+              metric.observe(*payload)
+            else
+              payload.each do |tuple|
+                metric.observe(*tuple)
+              end
+            end
+          end
+
+          # @return [Hash] config, hash of metric names to their config
+          def ensure_metrics!
+            return CONFIG unless registry.empty?
+
+            CONFIG.each do |metric_name, config|
+              type, description, buckets, quantiles = config.values_at("type", "description", "buckets", "quantiles")
+              metric_klass = ::PrometheusExporter::Metric.const_get(type)
+              args = [metric_name, description, buckets || quantiles].compact
+
+              registry[metric_name] = metric_klass.new(*args)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_collector.rb
+++ b/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_collector.rb
@@ -44,7 +44,7 @@ module Karafka
 
           # @param [Hash] hash of metric names to values: {'consumer_lags_delta' => [2, {label: 1 }] }
           def observe_metrics!(obj)
-            if obj.nil? || obj.empty? || obj["payload"].nil? || obj["payload"].empty? # standard:disable Rails/Blank
+            if obj.nil? || obj.empty? || obj["payload"].nil? || obj["payload"].empty?
               return warn("No kafka metrics to observe")
             end
 

--- a/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_collector.rb
+++ b/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_collector.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "prometheus_exporter" # Added for specs
+require "prometheus_exporter/server" # Added for specs
 require "yaml"
 # Note prometheus exporter does not load rails and dependencies
 # You must manually require anything you need outside of prometheus_exporter
@@ -43,6 +45,7 @@ module Karafka
             registry.values
           end
 
+          # @return [String] karafka, the type of metrics collected
           def type
             "karafka"
           end

--- a/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_collector.rb
+++ b/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_collector.rb
@@ -14,72 +14,93 @@ module Karafka
         # Once added to prometheus_exporter, Karafka no longer needs to maintain this file
         class MetricsCollector < ::PrometheusExporter::Server::TypeCollector
           # @return [Hash] registry, hash of metric names to their config
-          attr_reader :registry
-
+          attr_reader :registry, :expireable_metrics, :persistent_metrics, :gauge_names
+          MAX_METRIC_AGE = 60
           CONFIG = YAML.load_file(
             File.join(__dir__, "metrics_collector", "config.yaml")
           ).freeze
 
           def initialize
+            @expireable_metrics = MetricsContainer.new(ttl: MAX_METRIC_AGE)
+            @persistent_metrics = []
+            @gauge_names = []
             @registry = {}
           end
 
           # @param [Hash] hash of metric names to values: {'consumer_lags_delta=' => [2, {label: 1 }] }
           # @return [Hash] the same hash passed in
           def collect(obj)
-            ensure_metrics!
-            observe_metrics!(obj)
+            ensure_metrics
+            collect_metrics(obj)
           end
 
           # @return [Array<PrometheusExporter::Metric::Base>] Instantiated Prometheus metrics (gauges, counters, etc)
           def metrics
-            @registry.values
+            reset_registry_gauges!
+            observe_metrics(expireable_metrics)
+            observe_metrics(persistent_metrics)
+            persistent_metrics.clear
+            registry.values
           end
 
           def type
-            "kafka"
+            "karafka"
           end
 
           protected
 
-          # @param [Hash] hash of metric names to values: {'consumer_lags_delta' => [2, {label: 1 }] }
-          def observe_metrics!(obj)
-            if obj.nil? || obj.empty? || obj["payload"].nil? || obj["payload"].empty?
-              return warn("No kafka metrics to observe")
-            end
+          def reset_registry_gauges!
+            gauge_names.each { |name| registry[name]&.reset! }
+          end
 
+          def observe_metrics(metric_container)
+            metric_container.each do |observed_metric|
+              name, payload = observed_metric.values_at("name", "payload")
+              metric = registry[name]
+              observe_metric(metric, payload)
+            end
+          end
+
+          def collect_metrics(obj)
             obj["payload"].each do |metric_name, payload|
-              metric = registry[metric_name]
-              next observe_metric(metric, payload) if metric && !payload.empty?
-              warn "Undefined metric: '#{metric_name}', for metrics: #{registry.keys}"
-            rescue StandardError => e
-              warn "Uncaught exception: #{e.message}, processing metric: '#{metric_name}' with payload: #{payload}"
+              name = namespaced_metric(metric_name)
+              container = gauge_names.include?(name) ? expireable_metrics : persistent_metrics
+              container << { "name" => metric_name, "payload" => payload }
             end
           end
 
           # @param [::PrometheusExporter::Metric::Base] metric
-          # @param [Array] payload, array of tuples: [value, {label: 1}] or [[value, {label: 1}], [value, {label: 2}]]
+          # @param [Array] payload, tuple or array of tuples [value, {label: 1}] or [[value, {label: 1}], [value, {label: 2}]]
           def observe_metric(metric, payload)
-            if !payload[0].is_a? Array
-              metric.observe(*payload)
-            else
-              payload.each do |tuple|
-                metric.observe(*tuple)
-              end
-            end
+            observe = ->(tuple) { metric.observe(*tuple) }
+            return observe.call(payload) unless payload[0].is_a? Array
+            payload.each(&observe)
           end
 
           # @return [Hash] config, hash of metric names to their config
-          def ensure_metrics!
-            return CONFIG unless registry.empty?
+          def ensure_metrics
+            return unless registry.empty?
 
             CONFIG.each do |metric_name, config|
               type, description, buckets, quantiles = config.values_at("type", "description", "buckets", "quantiles")
               metric_klass = ::PrometheusExporter::Metric.const_get(type)
-              args = [metric_name, description, buckets || quantiles].compact
+              name = namespaced_metric(metric_name)
+              args = [name, description]
 
-              registry[metric_name] = metric_klass.new(*args)
+              registry[name] = if buckets && type == "Histogram"
+                metric_klass.new(*args, buckets: buckets)
+              elsif quantiles && type == "Summary"
+                metric_klass.new(*args, quantiles: quantiles)
+              else
+                metric_klass.new(*args)
+              end
+
+              gauge_names << name if type == "Gauge"
             end
+          end
+
+          def namespaced_metric(metric_name)
+            "karafka_#{metric_name}"
           end
         end
       end

--- a/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_collector/config.yaml
+++ b/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_collector/config.yaml
@@ -20,7 +20,7 @@ listener_polling_time_seconds:
   scope: listener
   source: karafka
   conversion: milliseconds_to_seconds # karafka sends measurements in milliseconds
-  buckets: [0.25, 0.5, 1, 1.25, 1.5, 2, 2.5, 5.0, 10.0, 20.0, 60.0, 100.0]
+  buckets: [0.25, 0.5, 1, 1.25, 1.5, 2, 2.5, 5.0, 10.0, 20.0, 60.0, 100.0, 180.0, 300.0]
 listener_polling_messages:
   type: Histogram
   description: Number of messages fetched in a single polling cycle.
@@ -136,33 +136,33 @@ consumer_lags_delta:
   source: rd_kafka
   scope: topics
   key_location: [consumer_lag_stored_d]
-# Producer metrics
-producer_buffer_size:
-  type: Histogram
-  description: The number of messages waiting to be sent to the broker.
-  source: karafka
-  scope: producer
-  buckets: [0, 1, 5, 10, 25, 50, 100, 250, 500, 1_000]
-producer_error_total:
-  type: Counter
-  description: The total number of errors encountered while sending messages.
-  source: karafka
-  scope: producer
-producer_closed_total:
-  type: Counter
-  description: The total number of times the producer connection was closed.
-  source: karafka
-  scope: producer
-producer_messages_sent_total:
-  type: Counter
-  description: The total number of messages sent.
-  source: karafka
-  scope: producer
-producer_messages_acknowledged_total:
-  type: Counter
-  description: The total number of messages ack'd by the karafka before being sent to the broker.
-  source: karafka
-  scope: producer
+# Producer metrics TODO: Move to Waterdrop PR
+# producer_buffer_size:
+#   type: Histogram
+#   description: The number of messages waiting to be sent to the broker.
+#   source: karafka
+#   scope: producer
+#   buckets: [0, 1, 5, 10, 25, 50, 100, 250, 500, 1_000]
+# producer_error_total:
+#   type: Counter
+#   description: The total number of errors encountered while sending messages.
+#   source: karafka
+#   scope: producer
+# producer_closed_total:
+#   type: Counter
+#   description: The total number of times the producer connection was closed.
+#   source: karafka
+#   scope: producer
+# producer_messages_sent_total:
+#   type: Counter
+#   description: The total number of messages sent.
+#   source: karafka
+#   scope: producer
+# producer_messages_acknowledged_total:
+#   type: Counter
+#   description: The total number of messages ack'd by the karafka before being sent to the broker.
+#   source: karafka
+#   scope: producer
 request_retries_total:
   type: Counter
   description: librdkafka - brokers- the total number of request retries

--- a/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_collector/config.yaml
+++ b/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_collector/config.yaml
@@ -24,11 +24,6 @@ karafka_listener_polling_messages:
   description: Average number of messages fetched in a single polling cycle.
   scope: listener
   source: karafka
-karafka_listener_threads:
-  type: Gauge
-  description: Number of listener threads assigned to a Karafka server for polling messages.
-  scope: listener
-  source: karafka
 karafka_dead_letter_queue_total:
   type: Counter
   description: Number of messages that were sent to the dead letter queue.
@@ -205,12 +200,6 @@ karafka_deliver_errors_total:
   scope: brokers
   source: rd_kafka
   key_location: [txerrs_d]
-karafka_receive_errors_total:
-  type: Counter
-  description: From librdkafka - the total number of errors receiving messages.
-  scope: brokers
-  source: rd_kafka
-  key_location: [rxerrs_d]
 karafka_queue_latency_avg_seconds:
   type: Gauge
   description: From librdkafka - average elapsed time in seconds between the request to enqueue to the transmit queue and the request being written to TCP socket

--- a/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_collector/config.yaml
+++ b/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_collector/config.yaml
@@ -1,243 +1,223 @@
-karafka_worker_threads:
+worker_threads:
   type: Gauge
   description: Number of worker threads assigned to a Karafka server for processing messages. Is not the same as the number of threads in the thread pool.
   scope: worker
   source: karafka
-karafka_worker_threads_busy:
+worker_threads_busy:
   type: Gauge
   description: Number of worker threads that are currently busy processing messages.
   scope: worker
   source: karafka
-karafka_worker_enqueued_jobs:
+worker_enqueued_jobs:
   type: Summary
   description: Number of jobs waiting to be processed while workers are busy.
   scope: worker
   source: karafka
-karafka_listener_polling_time_seconds:
+listener_polling_time_seconds:
   type: Summary
   description: Time between two message polling cycles in a consumer. #  If a consumer is healthy it should be close or equal to the max_wait_time.
   scope: listener
   source: karafka
   conversion: milliseconds_to_seconds # karafka sends measurements in milliseconds
-karafka_listener_polling_messages:
+listener_polling_messages:
   type: Summary
   description: Average number of messages fetched in a single polling cycle.
   scope: listener
   source: karafka
-karafka_dead_letter_queue_total:
+dead_letter_queue_total:
   type: Counter
   description: Number of messages that were sent to the dead letter queue.
   scope: consumer
   source: karafka
-karafka_consumer_messages_total:
+consumer_messages_total:
   type: Counter
   description: Number of messages consumed by a consumer.
   scope: consumer
   source: karafka
-karafka_consumer_batches_total:
+consumer_batches_total:
   type: Counter
   description: Number of message batches consumed by a consumer.
   scope: consumer
   source: karafka
-karafka_consumer_offset:
+consumer_offset:
   type: Gauge
   description: Current offset of a consumer.
   scope: consumer
   source: karafka
-karafka_consumer_consumed_time_taken_seconds:
+consumer_consumed_time_taken_seconds:
   type: Summary
   description: Time taken to consume a batch of messages.
   scope: consumer
   source: karafka
   conversion: milliseconds_to_seconds # karafka sends measurements in milliseconds
-karafka_consumer_batch_size:
+consumer_batch_size:
   type: Summary
   description: Number of messages in a batch of messages when polled.
   scope: consumer
   source: karafka
-karafka_consumer_processing_lag_seconds:
+consumer_processing_lag_seconds:
   type: Summary
   description: Elapsed time between batch consumption job being scheduled and batch job completion
   scope: consumer
   source: karafka
   conversion: milliseconds_to_seconds # karafka sends measurements in milliseconds
-karafka_consumer_consumption_lag_seconds:
+consumer_consumption_lag_seconds:
   type: Summary
   description: Elapsed time between batch creation and batch consumption
   scope: consumer
   source: karafka
   conversion: milliseconds_to_seconds # karafka sends measurements in milliseconds
-karafka_consumer_revoked_total:
+consumer_revoked_total:
   type: Counter
   description: Amount of consumers that were revoked.
   scope: consumer
   source: karafka
-karafka_error_total:
+error_total:
   type: Counter
   description: Number of errors that occurred in karafka.
   scope: any
   source: karafka
-karafka_consumer_shutdown_total:
+consumer_shutdown_total:
   type: Counter
   description: Number of consumers that were shutdown.
   scope: consumer
   source: karafka
-karafka_app_stopped_total:
+app_stopped_total:
   type: Counter
   description: Number of times the app was stopped.
   scope: consumer
   source: karafka
-karafka_messages_consumed_total:
+
+messages_consumed_total:
   type: Counter
   description: From librdkafka - the total number of messages consumed.
   scope: root
   source: rd_kafka
   key_location: [rxmsgs_d]
-karafka_messages_consumed_bytes_total:
+messages_consumed_bytes_total:
   type: Counter
   description: From librdkafka - the total number of (message) bytes consumed.
   scope: root
   source: rd_kafka
   key_location: [rxmsg_bytes]
-karafka_consume_attempts_total:
+consume_attempts_total:
   type: Counter
   description: From librdkafka - the total number of consume attempts.
   scope: brokers
   source: rd_kafka
   key_location: [txretries_d]
-karafka_consume_errors_total:
+consume_errors_total:
   type: Counter
   description: From librdkafka - the total number of errors consuming messages.
   scope: brokers
   source: rd_kafka
   key_location: [txerrs_d]
-karafka_receive_errors_total:
+receive_errors_total:
   type: Counter
   description: From librdkafka - the total number of errors receiving messages.
   scope: brokers
   source: rd_kafka
   key_location: [rxerrs_d]
-karafka_connection_attempts_total:
+connection_attempts_total:
   type: Counter
   description: From librdkafka - the total number of connection attempts.
   scope: brokers
   source: rd_kafka
   key_location: [connects_d]
-karafka_connection_disconnects_total:
+connection_disconnects_total:
   type: Counter
   scope: brokers
   description: Number of disconnects (triggered by broker network load-balancer etc.).
   source: rd_kafka
   key_location: [disconnects_d]
-karafka_network_latency_avg_seconds:
-  type: Gauge
-  description: average network latency
-  scope: brokers
-  source: rd_kafka
-  key_location: [rtt, avg]
-  conversion: microseconds_to_seconds # librdkafka sends measurements in microseconds
-karafka_network_latency_p95_seconds:
-  type: Gauge
-  description: p95 network latency
-  scope: brokers
-  source: rd_kafka
-  key_location: [rtt, p95]
-  conversion: microseconds_to_seconds # librdkafka sends measurements in microseconds
-karafka_network_latency_p99_seconds:
-  type: Gauge
-  description: p99 network latency
-  scope: brokers
-  source: rd_kafka
-  key_location: [rtt, p99]
-  conversion: microseconds_to_seconds # librdkafka sends measurements in microseconds
-karafka_consumer_lags:
+consumer_lags:
   type: Gauge
   description: Difference between the last stable offset on the broker and the offset to be committed on the broker
   scope: topics
   source: rd_kafka
   key_location: [consumer_lag_stored]
-karafka_consumer_lags_delta:
+consumer_lags_delta:
   type: Gauge
   description: Difference of the previous consumer_lags and the current consumer_lags
   source: rd_kafka
   scope: topics
   key_location: [consumer_lag_stored_d]
 # Producer metrics
-karafka_producer_buffer_size:
+producer_buffer_size:
   type: Histogram
   description: The number of messages waiting to be sent to the broker.
   source: karafka
   scope: producer
-karafka_producer_error_total:
+producer_error_total:
   type: Counter
   description: The total number of errors encountered while sending messages.
   source: karafka
   scope: producer
-karafka_producer_closed_total:
+producer_closed_total:
   type: Counter
   description: The total number of times the producer connection was closed.
   source: karafka
   scope: producer
-karafka_producer_messages_sent_total:
+producer_messages_sent_total:
   type: Counter
   description: The total number of messages sent.
   source: karafka
   scope: producer
-karafka_producer_messages_acknowledged_total:
+producer_messages_acknowledged_total:
   type: Counter
   description: The total number of messages ack'd by the karafka before being sent to the broker.
   source: karafka
   scope: producer
-karafka_deliver_attempts_total:
+deliver_attempts_total:
   type: Counter
   description: From librdkafka - the total number of delivery attempts.
   scope: brokers
   source: rd_kafka
   key_location: [txretries_d]
-karafka_deliver_errors_total:
+deliver_errors_total:
   type: Counter
   description: From librdkafka - the total number of errors delivering messages.
   scope: brokers
   source: rd_kafka
   key_location: [txerrs_d]
-karafka_queue_latency_avg_seconds:
+queue_latency_avg_seconds:
   type: Gauge
   description: From librdkafka - average elapsed time in seconds between the request to enqueue to the transmit queue and the request being written to TCP socket
   scope: brokers
   source: rd_kafka
   key_location: [outbuf_latency, avg]
   conversion: microseconds_to_seconds # librdkafka sends measurements in microseconds
-karafka_queue_latency_p95_seconds:
+queue_latency_p95_seconds:
   type: Gauge
   description: From librdkafka - p95 elapsed time in seconds between the request to enqueue to the transmit queue and the request being written to TCP socket
   scope: brokers
   source: rd_kafka
   key_location: [outbuf_latency, p95]
   conversion: microseconds_to_seconds # librdkafka sends measurements in microseconds
-karafka_queue_latency_p99_seconds:
+queue_latency_p99_seconds:
   type: Gauge
   description: From librdkafka - p99 elapsed time in seconds between the request to enqueue to the transmit queue and the request being written to TCP socket
   scope: brokers
   source: rd_kafka
   key_location: [outbuf_latency, p99]
   conversion: microseconds_to_seconds # librdkafka sends measurements in microseconds
-karafka_producer_network_latency_avg_seconds:
+network_latency_avg_seconds:
   type: Gauge
-  description: From librdkafka - broker round-trip time
+  description: From librdkafka - broker round-trip time, per protocol request, between the request being written to the TCP socket and the time the response is received from the broker.
   scope: brokers
   source: rd_kafka
   key_location: [rtt, avg]
   conversion: microseconds_to_seconds # librdkafka sends measurements in microseconds
-karafka_producer_network_latency_p95_seconds:
+network_latency_p95_seconds:
   type: Gauge
-  description: From librdkafka - broker round-trip time
+  description: From librdkafka - broker round-trip time, per protocol request, between the request being written to the TCP socket and the time the response is received from the broker.
   scope: brokers
   source: rd_kafka
   key_location: [rtt, p95]
   conversion: microseconds_to_seconds # librdkafka sends measurements in microseconds
-karafka_producer_network_latency_p99_seconds:
+network_latency_p99_seconds:
   type: Gauge
-  description: From librdkafka - broker round-trip time
+  description: From librdkafka - broker round-trip time, per protocol request, between the request being written to the TCP socket and the time the response is received from the broker.
   scope: brokers
   source: rd_kafka
   key_location: [rtt, p99]

--- a/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_collector/config.yaml
+++ b/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_collector/config.yaml
@@ -9,21 +9,24 @@ worker_threads_busy:
   scope: worker
   source: karafka
 worker_enqueued_jobs:
-  type: Summary
+  type: Histogram
   description: Number of jobs waiting to be processed while workers are busy.
   scope: worker
   source: karafka
+  buckets: [0, 1, 5, 10, 25, 50, 100, 250, 500, 1_000]
 listener_polling_time_seconds:
-  type: Summary
+  type: Histogram
   description: Time between two message polling cycles in a consumer. #  If a consumer is healthy it should be close or equal to the max_wait_time.
   scope: listener
   source: karafka
   conversion: milliseconds_to_seconds # karafka sends measurements in milliseconds
+  buckets: [0.25, 0.5, 1, 1.25, 1.5, 2, 2.5, 5.0, 10.0, 20.0, 60.0, 100.0]
 listener_polling_messages:
-  type: Summary
-  description: Average number of messages fetched in a single polling cycle.
+  type: Histogram
+  description: Number of messages fetched in a single polling cycle.
   scope: listener
   source: karafka
+  buckets: [0, 1, 5, 10, 25, 50, 100, 250, 500, 1_000]
 dead_letter_queue_total:
   type: Counter
   description: Number of messages that were sent to the dead letter queue.
@@ -45,37 +48,41 @@ consumer_offset:
   scope: consumer
   source: karafka
 consumer_consumed_time_taken_seconds:
-  type: Summary
+  type: Histogram
   description: Time taken to consume a batch of messages.
   scope: consumer
   source: karafka
   conversion: milliseconds_to_seconds # karafka sends measurements in milliseconds
+  buckets: [0.5, 1, 2.5, 5.0, 10.0, 30.0, 60.0, 90.0, 120.0, 180.0, 240.0, 300.0]
 consumer_batch_size:
-  type: Summary
+  type: Histogram
   description: Number of messages in a batch of messages when polled.
   scope: consumer
   source: karafka
+  buckets: [0, 1, 5, 10, 25, 50, 100, 250, 500, 1_000]
 consumer_processing_lag_seconds:
-  type: Summary
+  type: Histogram
   description: Elapsed time between batch consumption job being scheduled and batch job completion
   scope: consumer
   source: karafka
   conversion: milliseconds_to_seconds # karafka sends measurements in milliseconds
+  buckets: [0.5, 1, 2.5, 5.0, 10.0, 30.0, 60.0, 90.0, 120.0, 180.0, 240.0, 300.0]
 consumer_consumption_lag_seconds:
-  type: Summary
+  type: Histogram
   description: Elapsed time between batch creation and batch consumption
   scope: consumer
   source: karafka
-  conversion: milliseconds_to_seconds # karafka sends measurements in milliseconds
+  conversion: milliseconds_to_seconds # karafka sends measurements in millisecond
+  buckets: [0.01, 0.025, 0.1, 0.25, 0.5, 1, 2.5, 5.0, 10.0, 30.0, 60.0]
 consumer_revoked_total:
   type: Counter
   description: Amount of consumers that were revoked.
   scope: consumer
   source: karafka
-error_total:
+consumer_error_total:
   type: Counter
-  description: Number of errors that occurred in karafka.
-  scope: any
+  description: Number of errors that occurred in a karafka consumer.
+  scope: consumer
   source: karafka
 consumer_shutdown_total:
   type: Counter
@@ -87,40 +94,27 @@ app_stopped_total:
   description: Number of times the app was stopped.
   scope: consumer
   source: karafka
-
 messages_consumed_total:
   type: Counter
-  description: From librdkafka - the total number of messages consumed.
+  description: librdkafka - the total number of messages consumed.
   scope: root
   source: rd_kafka
   key_location: [rxmsgs_d]
 messages_consumed_bytes_total:
   type: Counter
-  description: From librdkafka - the total number of (message) bytes consumed.
+  description: librdkafka - the total number of (message) bytes consumed.
   scope: root
   source: rd_kafka
   key_location: [rxmsg_bytes]
-consume_attempts_total:
-  type: Counter
-  description: From librdkafka - the total number of consume attempts.
-  scope: brokers
-  source: rd_kafka
-  key_location: [txretries_d]
 consume_errors_total:
   type: Counter
-  description: From librdkafka - the total number of errors consuming messages.
+  description: librdkafka - the total number of errors consuming messages.
   scope: brokers
   source: rd_kafka
   key_location: [txerrs_d]
-receive_errors_total:
-  type: Counter
-  description: From librdkafka - the total number of errors receiving messages.
-  scope: brokers
-  source: rd_kafka
-  key_location: [rxerrs_d]
 connection_attempts_total:
   type: Counter
-  description: From librdkafka - the total number of connection attempts.
+  description: librdkafka - the total number of connection attempts.
   scope: brokers
   source: rd_kafka
   key_location: [connects_d]
@@ -148,6 +142,7 @@ producer_buffer_size:
   description: The number of messages waiting to be sent to the broker.
   source: karafka
   scope: producer
+  buckets: [0, 1, 5, 10, 25, 50, 100, 250, 500, 1_000]
 producer_error_total:
   type: Counter
   description: The total number of errors encountered while sending messages.
@@ -168,56 +163,62 @@ producer_messages_acknowledged_total:
   description: The total number of messages ack'd by the karafka before being sent to the broker.
   source: karafka
   scope: producer
-deliver_attempts_total:
+request_retries_total:
   type: Counter
-  description: From librdkafka - the total number of delivery attempts.
+  description: librdkafka - brokers- the total number of request retries
   scope: brokers
   source: rd_kafka
   key_location: [txretries_d]
-deliver_errors_total:
+transmission_errors_total:
   type: Counter
-  description: From librdkafka - the total number of errors delivering messages.
+  description: librdkafka - brokers - the total number of transmission errors.
   scope: brokers
   source: rd_kafka
   key_location: [txerrs_d]
+receive_errors_total:
+  type: Counter
+  description: librdkafka - brokers - the total number of errors receiving messages.
+  scope: brokers
+  source: rd_kafka
+  key_location: [rxerrs_d]
 queue_latency_avg_seconds:
   type: Gauge
-  description: From librdkafka - average elapsed time in seconds between the request to enqueue to the transmit queue and the request being written to TCP socket
+  description: librdkafka - average elapsed time in seconds between the request to enqueue to the transmit queue and the request being written to TCP socket
   scope: brokers
   source: rd_kafka
   key_location: [outbuf_latency, avg]
   conversion: microseconds_to_seconds # librdkafka sends measurements in microseconds
 queue_latency_p95_seconds:
   type: Gauge
-  description: From librdkafka - p95 elapsed time in seconds between the request to enqueue to the transmit queue and the request being written to TCP socket
+  description: librdkafka - p95 elapsed time in seconds between the request to enqueue to the transmit queue and the request being written to TCP socket
   scope: brokers
   source: rd_kafka
   key_location: [outbuf_latency, p95]
   conversion: microseconds_to_seconds # librdkafka sends measurements in microseconds
 queue_latency_p99_seconds:
   type: Gauge
-  description: From librdkafka - p99 elapsed time in seconds between the request to enqueue to the transmit queue and the request being written to TCP socket
+  description: librdkafka - p99 elapsed time in seconds between the request to enqueue to the transmit queue and the request being written to TCP socket
   scope: brokers
   source: rd_kafka
   key_location: [outbuf_latency, p99]
   conversion: microseconds_to_seconds # librdkafka sends measurements in microseconds
 network_latency_avg_seconds:
   type: Gauge
-  description: From librdkafka - broker round-trip time, per protocol request, between the request being written to the TCP socket and the time the response is received from the broker.
+  description: librdkafka - broker round-trip time, per protocol request, between the request being written to the TCP socket and the time the response is received from the broker.
   scope: brokers
   source: rd_kafka
   key_location: [rtt, avg]
   conversion: microseconds_to_seconds # librdkafka sends measurements in microseconds
 network_latency_p95_seconds:
   type: Gauge
-  description: From librdkafka - broker round-trip time, per protocol request, between the request being written to the TCP socket and the time the response is received from the broker.
+  description: librdkafka - broker round-trip time, per protocol request, between the request being written to the TCP socket and the time the response is received from the broker.
   scope: brokers
   source: rd_kafka
   key_location: [rtt, p95]
   conversion: microseconds_to_seconds # librdkafka sends measurements in microseconds
 network_latency_p99_seconds:
   type: Gauge
-  description: From librdkafka - broker round-trip time, per protocol request, between the request being written to the TCP socket and the time the response is received from the broker.
+  description: librdkafka - broker round-trip time, per protocol request, between the request being written to the TCP socket and the time the response is received from the broker.
   scope: brokers
   source: rd_kafka
   key_location: [rtt, p99]

--- a/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_collector/config.yaml
+++ b/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_collector/config.yaml
@@ -1,0 +1,255 @@
+karafka_worker_threads:
+  type: Gauge
+  description: Number of worker threads assigned to a Karafka server for processing messages. Is not the same as the number of threads in the thread pool.
+  scope: worker
+  source: karafka
+karafka_worker_threads_busy:
+  type: Gauge
+  description: Number of worker threads that are currently busy processing messages.
+  scope: worker
+  source: karafka
+karafka_worker_enqueued_jobs:
+  type: Summary
+  description: Number of jobs waiting to be processed while workers are busy.
+  scope: worker
+  source: karafka
+karafka_listener_polling_time_seconds:
+  type: Summary
+  description: Time between two message polling cycles in a consumer. #  If a consumer is healthy it should be close or equal to the max_wait_time.
+  scope: listener
+  source: karafka
+  conversion: milliseconds_to_seconds # karafka sends measurements in milliseconds
+karafka_listener_polling_messages:
+  type: Summary
+  description: Average number of messages fetched in a single polling cycle.
+  scope: listener
+  source: karafka
+karafka_listener_threads:
+  type: Gauge
+  description: Number of listener threads assigned to a Karafka server for polling messages.
+  scope: listener
+  source: karafka
+karafka_dead_letter_queue_total:
+  type: Counter
+  description: Number of messages that were sent to the dead letter queue.
+  scope: consumer
+  source: karafka
+karafka_consumer_messages_total:
+  type: Counter
+  description: Number of messages consumed by a consumer.
+  scope: consumer
+  source: karafka
+karafka_consumer_batches_total:
+  type: Counter
+  description: Number of message batches consumed by a consumer.
+  scope: consumer
+  source: karafka
+karafka_consumer_offset:
+  type: Gauge
+  description: Current offset of a consumer.
+  scope: consumer
+  source: karafka
+karafka_consumer_consumed_time_taken_seconds:
+  type: Summary
+  description: Time taken to consume a batch of messages.
+  scope: consumer
+  source: karafka
+  conversion: milliseconds_to_seconds # karafka sends measurements in milliseconds
+karafka_consumer_batch_size:
+  type: Summary
+  description: Number of messages in a batch of messages when polled.
+  scope: consumer
+  source: karafka
+karafka_consumer_processing_lag_seconds:
+  type: Summary
+  description: Elapsed time between batch consumption job being scheduled and batch job completion
+  scope: consumer
+  source: karafka
+  conversion: milliseconds_to_seconds # karafka sends measurements in milliseconds
+karafka_consumer_consumption_lag_seconds:
+  type: Summary
+  description: Elapsed time between batch creation and batch consumption
+  scope: consumer
+  source: karafka
+  conversion: milliseconds_to_seconds # karafka sends measurements in milliseconds
+karafka_consumer_revoked_total:
+  type: Counter
+  description: Amount of consumers that were revoked.
+  scope: consumer
+  source: karafka
+karafka_error_total:
+  type: Counter
+  description: Number of errors that occurred in karafka.
+  scope: any
+  source: karafka
+karafka_consumer_shutdown_total:
+  type: Counter
+  description: Number of consumers that were shutdown.
+  scope: consumer
+  source: karafka
+karafka_app_stopped_total:
+  type: Counter
+  description: Number of times the app was stopped.
+  scope: consumer
+  source: karafka
+karafka_messages_consumed_total:
+  type: Counter
+  description: From librdkafka - the total number of messages consumed.
+  scope: root
+  source: rd_kafka
+  key_location: [rxmsgs_d]
+karafka_messages_consumed_bytes_total:
+  type: Counter
+  description: From librdkafka - the total number of (message) bytes consumed.
+  scope: root
+  source: rd_kafka
+  key_location: [rxmsg_bytes]
+karafka_consume_attempts_total:
+  type: Counter
+  description: From librdkafka - the total number of consume attempts.
+  scope: brokers
+  source: rd_kafka
+  key_location: [txretries_d]
+karafka_consume_errors_total:
+  type: Counter
+  description: From librdkafka - the total number of errors consuming messages.
+  scope: brokers
+  source: rd_kafka
+  key_location: [txerrs_d]
+karafka_receive_errors_total:
+  type: Counter
+  description: From librdkafka - the total number of errors receiving messages.
+  scope: brokers
+  source: rd_kafka
+  key_location: [rxerrs_d]
+karafka_connection_attempts_total:
+  type: Counter
+  description: From librdkafka - the total number of connection attempts.
+  scope: brokers
+  source: rd_kafka
+  key_location: [connects_d]
+karafka_connection_disconnects_total:
+  type: Counter
+  scope: brokers
+  description: Number of disconnects (triggered by broker network load-balancer etc.).
+  source: rd_kafka
+  key_location: [disconnects_d]
+karafka_network_latency_avg_seconds:
+  type: Gauge
+  description: average network latency
+  scope: brokers
+  source: rd_kafka
+  key_location: [rtt, avg]
+  conversion: microseconds_to_seconds # librdkafka sends measurements in microseconds
+karafka_network_latency_p95_seconds:
+  type: Gauge
+  description: p95 network latency
+  scope: brokers
+  source: rd_kafka
+  key_location: [rtt, p95]
+  conversion: microseconds_to_seconds # librdkafka sends measurements in microseconds
+karafka_network_latency_p99_seconds:
+  type: Gauge
+  description: p99 network latency
+  scope: brokers
+  source: rd_kafka
+  key_location: [rtt, p99]
+  conversion: microseconds_to_seconds # librdkafka sends measurements in microseconds
+karafka_consumer_lags:
+  type: Gauge
+  description: Difference between the last stable offset on the broker and the offset to be committed on the broker
+  scope: topics
+  source: rd_kafka
+  key_location: [consumer_lag_stored]
+karafka_consumer_lags_delta:
+  type: Gauge
+  description: Difference of the previous consumer_lags and the current consumer_lags
+  source: rd_kafka
+  scope: topics
+  key_location: [consumer_lag_stored_d]
+# Producer metrics
+karafka_producer_buffer_size:
+  type: Histogram
+  description: The number of messages waiting to be sent to the broker.
+  source: karafka
+  scope: producer
+karafka_producer_error_total:
+  type: Counter
+  description: The total number of errors encountered while sending messages.
+  source: karafka
+  scope: producer
+karafka_producer_closed_total:
+  type: Counter
+  description: The total number of times the producer connection was closed.
+  source: karafka
+  scope: producer
+karafka_producer_messages_sent_total:
+  type: Counter
+  description: The total number of messages sent.
+  source: karafka
+  scope: producer
+karafka_producer_messages_acknowledged_total:
+  type: Counter
+  description: The total number of messages ack'd by the karafka before being sent to the broker.
+  source: karafka
+  scope: producer
+karafka_deliver_attempts_total:
+  type: Counter
+  description: From librdkafka - the total number of delivery attempts.
+  scope: brokers
+  source: rd_kafka
+  key_location: [txretries_d]
+karafka_deliver_errors_total:
+  type: Counter
+  description: From librdkafka - the total number of errors delivering messages.
+  scope: brokers
+  source: rd_kafka
+  key_location: [txerrs_d]
+karafka_receive_errors_total:
+  type: Counter
+  description: From librdkafka - the total number of errors receiving messages.
+  scope: brokers
+  source: rd_kafka
+  key_location: [rxerrs_d]
+karafka_queue_latency_avg_seconds:
+  type: Gauge
+  description: From librdkafka - average elapsed time in seconds between the request to enqueue to the transmit queue and the request being written to TCP socket
+  scope: brokers
+  source: rd_kafka
+  key_location: [outbuf_latency, avg]
+  conversion: microseconds_to_seconds # librdkafka sends measurements in microseconds
+karafka_queue_latency_p95_seconds:
+  type: Gauge
+  description: From librdkafka - p95 elapsed time in seconds between the request to enqueue to the transmit queue and the request being written to TCP socket
+  scope: brokers
+  source: rd_kafka
+  key_location: [outbuf_latency, p95]
+  conversion: microseconds_to_seconds # librdkafka sends measurements in microseconds
+karafka_queue_latency_p99_seconds:
+  type: Gauge
+  description: From librdkafka - p99 elapsed time in seconds between the request to enqueue to the transmit queue and the request being written to TCP socket
+  scope: brokers
+  source: rd_kafka
+  key_location: [outbuf_latency, p99]
+  conversion: microseconds_to_seconds # librdkafka sends measurements in microseconds
+karafka_producer_network_latency_avg_seconds:
+  type: Gauge
+  description: From librdkafka - broker round-trip time
+  scope: brokers
+  source: rd_kafka
+  key_location: [rtt, avg]
+  conversion: microseconds_to_seconds # librdkafka sends measurements in microseconds
+karafka_producer_network_latency_p95_seconds:
+  type: Gauge
+  description: From librdkafka - broker round-trip time
+  scope: brokers
+  source: rd_kafka
+  key_location: [rtt, p95]
+  conversion: microseconds_to_seconds # librdkafka sends measurements in microseconds
+karafka_producer_network_latency_p99_seconds:
+  type: Gauge
+  description: From librdkafka - broker round-trip time
+  scope: brokers
+  source: rd_kafka
+  key_location: [rtt, p99]
+  conversion: microseconds_to_seconds # librdkafka sends measurements in microseconds

--- a/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_listener.rb
+++ b/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_listener.rb
@@ -22,7 +22,9 @@ module Karafka
 
           # Prometheus Exporter client that we should use to publish the metrics
           # Usually you'll want ::PrometheusExporter::Client.default
-          setting :client
+          setting :client, default: ::PrometheusExporter::Client.default
+
+          setting :logger, default: Karafka.logger
 
           # Default labels we want to publish (for example hostname)
           # Format as followed (example for hostname): `{ host: Socket.gethostname }`
@@ -160,10 +162,7 @@ module Karafka
 
           # @param [Hash] metrics to send to the prometheus exporter server
           def observe(metrics)
-            client.send_json({
-              type: "karafka",
-              payload: metrics
-            })
+            client.send_json(type: "karafka", payload: metrics)
           end
 
           # Builds basic per consumer labels for publication

--- a/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_listener.rb
+++ b/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_listener.rb
@@ -96,7 +96,7 @@ module Karafka
             messages = consumer.messages
             metadata = messages.metadata
             time_taken = event[:time] / 1000.0 # convert to seconds to adhere to prometheus standards
-            proccess_lag = metadata.processing_lag / 1000.0
+            processing_lag = metadata.processing_lag / 1000.0
             consumption_lag = metadata.consumption_lag / 1000.0
 
             labels = default_labels.merge(consumer_labels(consumer))

--- a/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_listener.rb
+++ b/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_listener.rb
@@ -75,7 +75,7 @@ module Karafka
           #
           # @param event [Karafka::Core::Monitoring::Event]
           def on_connection_listener_fetch_loop_received(event)
-            time_taken = event[:time] / 1000 # convert to seconds to adhere to prometheus standards
+            time_taken = event[:time] / 1_000.0 # convert to seconds to adhere to prometheus standards
             message_count = event[:messages_buffer].size
 
             consumer_group_id = event[:subscription_group].consumer_group_id
@@ -95,9 +95,9 @@ module Karafka
             consumer = event.payload[:caller]
             messages = consumer.messages
             metadata = messages.metadata
-            time_taken = event[:time] / 1000 # convert to seconds to adhere to prometheus standards
-            proccess_lag = metadata.processing_lag / 1000
-            consumption_lag = metadata.consumption_lag / 1000
+            time_taken = event[:time] / 1000.0 # convert to seconds to adhere to prometheus standards
+            proccess_lag = metadata.processing_lag / 1000.0
+            consumption_lag = metadata.consumption_lag / 1000.0
 
             labels = default_labels.merge(consumer_labels(consumer))
 

--- a/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_listener.rb
+++ b/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_listener.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+module Karafka
+  module Instrumentation
+    # Namespace for vendor specific instrumentation
+    module Vendors
+      # Prometheus Exporter specific instrumentation
+      module PrometheusExporter
+        # Listener that can be used to subscribe to Karafka to send stats
+        # to a Prometheus Exporter server
+        #
+        # @note You need to run the `prometheus_exporter` server and pass the karafka collector
+        # `prometheus_exporter -a path/to/prometheus_exporter/metrics_collector.rb`
+        class MetricsListener
+          include ::Karafka::Core::Configurable
+          extend Forwardable
+
+          def_delegators :config, :client, :metric_config, :namespace, :default_labels
+
+          # Value object for storing a single rdkafka metric publishing details
+          RdKafkaMetric = Struct.new(:type, :scope, :name, :key_location)
+
+          # Namespace under which the DD metrics should be published
+          setting :namespace, default: 'karafka'
+
+          # Prometheus Exporter client that we should use to publish the metrics
+          # Usually you'll want ::PrometheusExporter::Client.default
+          setting :client
+
+          # Default labels we want to publish (for example hostname)
+          # Format as followed (example for hostname): `{ host: Socket.gethostname }`
+          setting :default_labels, default: {}
+
+          # All the rdkafka metrics we want to publish
+          #
+          # By default we publish quite a lot so this can be tuned
+          setting :metric_config, default: ::Karafka::Instrumentation::Vendors::PrometheusExporter::MetricsCollector::CONFIG
+
+          configure
+
+          # @param block [Proc] configuration block
+          def initialize(&block)
+            configure
+            setup(&block) if block
+          end
+
+          # @param block [Proc] configuration block
+          # @note We define this alias to be consistent with `WaterDrop#setup`
+          def setup(&block)
+            configure(&block)
+          end
+
+          # Hooks up to WaterDrop instrumentation for emitted statistics
+          #
+          # @param event [Karafka::Core::Monitoring::Event]
+          def on_statistics_emitted(event)
+            metrics = OnStatisticsEmitted.call(listener: self, event: event).metrics
+            observe(metrics)
+          end
+
+          # Increases the errors count by 1
+          #
+          # @param event [Karafka::Core::Monitoring::Event]
+          def on_error_occurred(event)
+            labels = default_labels.merge(type: event[:type])
+
+            if event.payload[:caller].respond_to?(:messages)
+              labels = labels.merge(consumer_labels(event.payload[:caller]))
+            end
+
+            observe(karafka_error_total: [1, labels])
+          end
+
+          # Reports how many messages we've polled and how much time did we spend on it
+          #
+          # @param event [Karafka::Core::Monitoring::Event]
+          def on_connection_listener_fetch_loop_received(event)
+            time_taken = event[:time] / 1000 # convert to seconds to adhere to prometheus standards
+            message_count = event[:messages_buffer].size
+
+            consumer_group_id = event[:subscription_group].consumer_group_id
+
+            labels = default_labels.merge(consumer_group: consumer_group_id)
+
+            observe(
+              karafka_listener_polling_time_seconds: [time_taken, labels],
+              karafka_listener_polling_messages: [message_count, labels]
+            )
+          end
+
+          # Here we report majority of things related to processing as we have access to the
+          # consumer
+          # @param event [Karafka::Core::Monitoring::Event]
+          def on_consumer_consumed(event)
+            consumer = event.payload[:caller]
+            messages = consumer.messages
+            metadata = messages.metadata
+            time_taken = event[:time] / 1000 # convert to seconds to adhere to prometheus standards
+
+            labels = default_labels.merge(consumer_labels(consumer))
+
+            observe(
+              karafka_consumer_messages_total: [messages.count, labels],
+              karafka_consumer_batches_total: [1, labels],
+              karafka_consumer_offset: [metadata.last_offset, labels],
+              karafka_consumer_consumed_time_taken_seconds: [time_taken, labels],
+              karafka_consumer_batch_size: [messages.count, labels],
+              karafka_consumer_processing_lag_seconds: [metadata.processing_lag, labels],
+              karafka_consumer_consumption_lag_seconds: [metadata.consumption_lag, labels]
+            )
+          end
+
+          # @param event [Karafka::Core::Monitoring::Event]
+          def on_consumer_revoked(event)
+            labels = default_labels.merge(consumer_labels(event.payload[:caller]))
+
+            observe(karafka_consumer_revoked_total: [1, labels])
+          end
+
+          # @param event [Karafka::Core::Monitoring::Event]
+          def on_consumer_shutdown(event)
+            labels = default_labels.merge(consumer_labels(event.payload[:caller]))
+
+            observe(karafka_consumer_shutdown_total: [1, labels])
+          end
+
+          # Worker related metrics
+          # @param event [Karafka::Core::Monitoring::Event]
+          def on_worker_process(event)
+            jobs_queue_stats = event[:jobs_queue].statistics
+
+            observe(
+              karafka_worker_threads: [Karafka::App.config.concurrency, default_labels],
+              karafka_worker_threads_busy: [jobs_queue_stats[:busy], default_labels],
+              karafka_worker_enqueued_jobs: [jobs_queue_stats[:enqueued], default_labels]
+            )
+          end
+
+          # We report this metric before and after processing for higher accuracy
+          # Without this, the utilization would not be fully reflected
+          # @param event [Karafka::Core::Monitoring::Event]
+          def on_worker_processed(event)
+            jobs_queue_stats = event[:jobs_queue].statistics
+            count = jobs_queue_stats[:busy] || 0
+            observe(karafka_worker_threads_busy: [count, default_labels])
+          end
+
+          private
+
+          # @param [Hash] metrics to send to the prometheus exporter server
+          def observe(metrics)
+            client.send_json({
+              type: "kafka",
+              payload: metrics
+            })
+          end
+
+          # Builds basic per consumer labels for publication
+          #
+          # @param consumer [Karafka::BaseConsumer]
+          # @return [Hash]
+          def consumer_labels(consumer)
+            messages = consumer.messages
+            metadata = messages.metadata
+            consumer_group_id = consumer.topic.consumer_group.id
+
+            {
+              topic: metadata.topic,
+              partition: metadata.partition,
+              consumer_group: consumer_group_id
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_listener.rb
+++ b/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_listener.rb
@@ -65,7 +65,7 @@ module Karafka
               labels = labels.merge(consumer_labels(event.payload[:caller]))
             end
 
-            observe(error_total: [1, labels])
+            observe(consumer_error_total: [1, labels])
           end
 
           # Reports how many messages we've polled and how much time did we spend on it

--- a/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_listener.rb
+++ b/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_listener.rb
@@ -96,6 +96,8 @@ module Karafka
             messages = consumer.messages
             metadata = messages.metadata
             time_taken = event[:time] / 1000 # convert to seconds to adhere to prometheus standards
+            proccess_lag = metadata.processing_lag / 1000
+            consumption_lag = metadata.consumption_lag / 1000
 
             labels = default_labels.merge(consumer_labels(consumer))
 
@@ -105,8 +107,8 @@ module Karafka
               karafka_consumer_offset: [metadata.last_offset, labels],
               karafka_consumer_consumed_time_taken_seconds: [time_taken, labels],
               karafka_consumer_batch_size: [messages.count, labels],
-              karafka_consumer_processing_lag_seconds: [metadata.processing_lag, labels],
-              karafka_consumer_consumption_lag_seconds: [metadata.consumption_lag, labels]
+              karafka_consumer_processing_lag_seconds: [processing_lag, labels],
+              karafka_consumer_consumption_lag_seconds: [consumption_lag, labels]
             )
           end
 

--- a/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_listener/on_statistics_emitted.rb
+++ b/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_listener/on_statistics_emitted.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module Karafka
+  module Instrumentation
+    module Vendors
+      module PrometheusExporter
+        class MetricsListener
+          # Interfaces with a Karafka::Core::Monitoring::Event#on_statistics_emitted to extract librdkafka metrics
+          # This listener needs additional setup to be fired.
+          # #on_statistics_emitted is called by both consumers and producers
+          # Karafka on its own only reports librdkafka metrics if the appropriate config (statistics emitted interval) is set in karafka.rb
+          # A Full list of librdkafka metrics can be found at: https://github.com/edenhill/librdkafka/blob/master/STATISTICS.md
+          class OnStatisticsEmitted
+            attr_reader :statistics, :labels, :event
+
+            def self.call(**args)
+              new(**args).call
+            end
+
+            # @param listener [Karafka::Instrumentation::Vendors::PrometheusExporter::MetricsListener]
+            # @param event [Karafka::Core::Monitoring::Event]
+            def initialize(listener:, event:)
+              @event = event
+              @statistics = event[:statistics]
+              @labels = listener.default_labels.merge(source_labels)
+            end
+
+            # Extract & observe metric from Karafka::Core::Monitoring::Event
+            # @return [self]
+            def call
+              extract_metrics!
+              self
+            end
+
+            def metrics
+              @metrics ||= Hash.new { |hash, key| hash[key] = [] }
+            end
+
+            private
+
+            def extract_metrics!
+              metric_config.each do |name, metric|
+                scope, source = metric.values_at("scope", "source")
+                next unless source == "rd_kafka"
+                extract_metric(name, scope)
+              end
+            end
+
+            # Producer and consumer_group ids are not in every event
+            # If present this extracts them from the event payload
+            # we can then add them to the labels
+            # @return [Hash]
+            def source_labels
+              event.payload.slice(:producer_id, :consumer_group_id)
+            end
+
+            # Reports a given metric statistics to Prometheus
+            # @param [String] metric_name
+            # @param [String] scope
+            def extract_metric(name, scope)
+              case scope
+              when "root" then extract_root(name)
+              when "brokers" then extract_brokers(name)
+              when "topics" then extract_topics(name)
+              else raise ArgumentError, metric_scope
+              end
+            end
+
+            def extract_root(metric_name)
+              metric = metric_config[metric_name]
+              value = parse_value(statistics, metric)
+              metrics[metric_name] << [value, labels]
+            end
+
+            def extract_brokers(metric_name)
+              statistics.fetch("brokers").each_value do |broker_statistics|
+                # Skip bootstrap nodes
+                # Bootstrap nodes have nodeid -1,
+                # other nodes have positive node ids
+                next if broker_statistics["nodeid"] == -1
+
+                metric = metric_config[metric_name]
+                value = parse_value(broker_statistics, metric)
+                broker, name = broker_statistics.values_at("nodename", "name")
+                broker_labels = labels.merge(broker: broker, name: name)
+                metrics[metric_name] << [value, broker_labels]
+              end
+            end
+
+            def extract_topics(metric_name)
+              statistics.fetch("topics").each do |topic_name, topic_values|
+                topic_values["partitions"].each do |partition_name, partition_statistics|
+                  # Skip until lag info is available
+                  next if partition_name == "-1" || partition_statistics["consumer_lag"] == -1
+
+                  metric = metric_config[metric_name]
+                  value = parse_value(partition_statistics, metric)
+                  topic_labels = labels.merge(topic: topic_name, partition: partition_name)
+                  metrics[metric_name] << [value, topic_labels]
+                end
+              end
+            end
+
+            def metric_config
+              MetricsCollector::CONFIG
+            end
+
+            def parse_value(statistics, metric)
+              value = statistics.dig(*metric["key_location"])
+              return value unless metric["conversion"]
+              converter.fetch(metric["conversion"]).call(value)
+            end
+
+            def converter
+              {
+               "microseconds_to_seconds" => ->(value) { value / 1_000_000.0 },
+               "milliseconds_to_seconds" => ->(value) { value / 1_000.0 },
+              }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_listener/on_statistics_emitted.rb
+++ b/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_listener/on_statistics_emitted.rb
@@ -28,7 +28,7 @@ module Karafka
             # Extract & observe metric from Karafka::Core::Monitoring::Event
             # @return [self]
             def call
-              extract_metrics!
+              extract_metrics
               self
             end
 
@@ -38,7 +38,7 @@ module Karafka
 
             private
 
-            def extract_metrics!
+            def extract_metrics
               metric_config.each do |name, metric|
                 scope, source = metric.values_at("scope", "source")
                 next unless source == "rd_kafka"

--- a/spec/integrations/instrumentation/vendors/prometheus_exporter/metrics_flow_spec.rb
+++ b/spec/integrations/instrumentation/vendors/prometheus_exporter/metrics_flow_spec.rb
@@ -59,6 +59,7 @@ end
   karafka_consumer_messages_total
   karafka_consumer_batches_total
   karafka_consumer_shutdown_total
+  karafka_consumer_revoked_total
 ].each do |count_key|
   assert_equal true, prom_dummy.collector.registry.key?(count_key), "#{count_key} missing"
 end

--- a/spec/integrations/instrumentation/vendors/prometheus_exporter/metrics_flow_spec.rb
+++ b/spec/integrations/instrumentation/vendors/prometheus_exporter/metrics_flow_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+# Here we subscribe to our listener and make sure nothing breaks during the notifications
+# We use a dummy client that will intercept calls that should go to DataDog and check basic
+# metrics presence
+
+require 'prometheus_exporter'
+require 'prometheus_exporter/client'
+require 'prometheus_exporter/server'
+require 'karafka/instrumentation/vendors/prometheus_exporter/metrics_listener/on_statistics_emitted'
+require 'karafka/instrumentation/vendors/prometheus_exporter/metrics_collector'
+require 'karafka/instrumentation/vendors/prometheus_exporter/metrics_listener'
+require Karafka.gem_root.join('spec/support/vendors/prometheus_exporter/dummy_client')
+
+# We allow errors to raise one to make sure things are published as expected
+setup_karafka(allow_errors: true)
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    unless @raised
+      @raised = true
+      raise StandardError
+    end
+
+    messages.each do |message|
+      DT[message.metadata.partition] << message.raw_payload
+    end
+  end
+end
+
+prom_dummy = Vendors::PrometheusExporter::DummyClient.new
+
+listener = ::Karafka::Instrumentation::Vendors::PrometheusExporter::MetricsListener.new do |config|
+  config.client = prom_dummy
+  # Publish host as a tag alongside the rest of tags
+  config.default_labels = { host: Socket.gethostname }
+end
+
+Karafka.monitor.subscribe(listener)
+
+draw_routes(Consumer)
+
+produce_many(DT.topic, DT.uuids(100))
+
+start_karafka_and_wait_until do
+  # This sleeps make karafka run a bit longer for more metrics to kick in
+  DT[0].size >= 100 && sleep(5)
+end
+
+%w[
+  karafka_messages_consumed_total
+  karafka_messages_consumed_bytes_total
+  karafka_consume_attempts_total
+  karafka_consume_errors_total
+  karafka_receive_errors_total
+  karafka_connection_attempts_total
+  karafka_connection_disconnects_total
+  karafka_error_total
+  karafka_consumer_messages_total
+  karafka_consumer_batches_total
+  karafka_consumer_shutdown_total
+].each do |count_key|
+  assert_equal true, prom_dummy.collector.registry.key?(count_key), "#{count_key} missing"
+end
+
+error_tracks = prom_dummy.collector.registry['karafka_error_total']
+
+# Expect to have one error report from te consumption
+assert_equal 1, error_tracks.data.size
+assert_equal true, error_tracks.data.all? do |(label, _value)|
+  %w[host type topic partition consumer_group].all? { |key| label.key?(key) }
+end
+assert_equal true, error_tracks.data.keys.any? { |labels| labels["type"] == "consumer.consume.error" }
+
+%w[
+  karafka_network_latency_avg_seconds
+  karafka_network_latency_p95_seconds
+  karafka_network_latency_p99_seconds
+  karafka_worker_threads
+  karafka_consumer_offset
+  karafka_consumer_lags
+  karafka_consumer_lags_delta
+].each do |gauge_key|
+  assert_equal true, prom_dummy.collector.registry.key?(gauge_key), "#{gauge_key} missing"
+end
+
+%w[
+  karafka_worker_threads
+  karafka_worker_enqueued_jobs
+  karafka_consumer_consumed_time_taken_seconds
+  karafka_consumer_batch_size
+  karafka_consumer_processing_lag_seconds
+  karafka_consumer_consumption_lag_seconds
+].each do |hist_key|
+  assert_equal true, prom_dummy.collector.registry.key?(hist_key), "#{hist_key} missing"
+end

--- a/spec/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_collector_spec.rb
+++ b/spec/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_collector_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe_current do
 
   let(:payload) { {"payload" => {"app_stopped_total" => [1, {}]}} }
 
+  before do
+    # Stub out the clock to allow time travel and test metric expiration
+    allow(Process).to receive(:clock_gettime).and_return(0)
+  end
+
   it "initiliazes with an empty registry" do
     expect(collector.registry).to eql({})
   end
@@ -26,4 +31,100 @@ RSpec.describe_current do
     expect(collector.type).to eql("karafka")
   end
 
+  context "when collecting persistent metrics" do
+    let(:labels) do
+      {
+        "host"=>"88a375b114dd",
+        "app"=>"karafka",
+        "consumer_group"=>"dummy_app"
+      }
+    end
+    let(:payload) do
+      {
+        "type"=>"karafka",
+        "payload"=> {
+          "listener_polling_time_seconds"=> [1.01, labels],
+          "listener_polling_messages"=> [0, labels]
+        }
+      }
+    end
+
+    before do
+      collector.collect(payload)
+      polling_time_metric = collector.registry["karafka_listener_polling_time_seconds"]
+      polling_msg_metric = collector.registry["karafka_listener_polling_messages"]
+      allow(polling_time_metric).to receive(:observe).and_call_original
+      allow(polling_msg_metric).to receive(:observe).and_call_original
+    end
+
+    it "resets persistent_metrics after observation" do
+      expect(collector.persistent_metrics).to be_present
+      collector.metrics
+      expect(collector.persistent_metrics).to be_empty
+    end
+
+    it "observes persistent metrics" do
+      polling_metric = collector.registry["karafka_listener_polling_time_seconds"]
+      polling_msg_metric = collector.registry["karafka_listener_polling_messages"]
+      expect(polling_metric).to receive(:observe).with(1.01, hash_including(labels))
+      expect(polling_msg_metric).to receive(:observe).with(0, hash_including(labels))
+      collector.metrics
+    end
+  end
+
+  context "when collecting expiring metrics" do
+    let(:labels) do
+      {
+        "host"=>"88a375b114dd",
+        "app"=>"karafka",
+        "producer_id"=>"0f10416fee3e",
+        "broker"=>"karafka:9092",
+        "name"=>"karafka:9092/1002"
+      }
+    end
+    let(:payload) do
+      {
+        "type"=>"karafka",
+        "payload"=> {
+          "queue_latency_avg_seconds"=> [[0.0, labels]],
+          "queue_latency_p95_seconds"=> [[0.0, labels]]
+        }
+      }
+    end
+
+    before do
+      collector.collect(payload)
+      latency_avg_metric = collector.registry["karafka_queue_latency_avg_seconds"]
+      latency_p95_metric = collector.registry["karafka_queue_latency_p95_seconds"]
+      allow(latency_avg_metric).to receive(:observe).and_call_original
+      allow(latency_p95_metric).to receive(:observe).and_call_original
+    end
+
+    it "does not reset expireable_metrics after observation" do
+      expect(collector.expireable_metrics.data).to be_present
+      collector.metrics
+      expect(collector.expireable_metrics.data).to be_present
+    end
+
+    it "observes expireable metrics" do
+      latency_avg_metric = collector.registry["karafka_queue_latency_avg_seconds"]
+      latency_p95_metric = collector.registry["karafka_queue_latency_p95_seconds"]
+      expect(latency_avg_metric).to receive(:observe).with(0.0, hash_including(labels))
+      expect(latency_p95_metric).to receive(:observe).with(0.0, hash_including(labels))
+      collector.metrics
+    end
+
+    context "when a metric expires" do
+      before do
+        allow(Process).to receive(:clock_gettime).and_return(described_class::MAX_METRIC_AGE + 1)
+      end
+      it "is no longer observed" do
+        latency_avg_metric = collector.registry["karafka_queue_latency_avg_seconds"]
+        latency_p95_metric = collector.registry["karafka_queue_latency_p95_seconds"]
+        collector.metrics
+        expect(collector.expireable_metrics.data).to be_empty
+        expect(collector.registry["karafka_queue_latency_p95_seconds"].data).to be_empty
+      end
+    end
+  end
 end

--- a/spec/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_collector_spec.rb
+++ b/spec/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_collector_spec.rb
@@ -1,0 +1,29 @@
+
+require "karafka/instrumentation/vendors/prometheus_exporter/metrics_listener"
+require 'prometheus_exporter'
+require 'prometheus_exporter/server'
+# These are integration tests, not unit tests.
+# Collectors live on the prometheus server, not the karafka server.
+RSpec.describe_current do
+  subject(:collector) { described_class.new }
+
+  let(:payload) { {"payload" => {"app_stopped_total" => [1, {}]}} }
+
+  it "initiliazes with an empty registry" do
+    expect(collector.registry).to eql({})
+  end
+
+  it "ensures metrics are registered when collected" do
+    collector.collect(payload)
+    described_class::CONFIG.each do |metric_name, config|
+      metric_klass = PrometheusExporter::Metric.const_get(config["type"])
+      name = collector.send(:namespace, metric_name)
+      expect(collector.registry[name]).to be_an_instance_of(metric_klass)
+    end
+  end
+
+  it "expects a type of karafka" do
+    expect(collector.type).to eql("karafka")
+  end
+
+end

--- a/spec/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_listener_spec.rb
@@ -1,0 +1,267 @@
+# frozen_string_literal: true
+
+require "karafka/instrumentation/vendors/prometheus_exporter/metrics_listener"
+require 'prometheus_exporter'
+require 'prometheus_exporter/server'
+
+RSpec.describe_current do
+  subject(:listener) { described_class.new }
+
+  let(:event) { Karafka::Core::Monitoring::Event.new(rand.to_s, payload) }
+  let(:time) { rand }
+  let(:topic) { build(:routing_topic, name: topic_name) }
+  let(:topic_name) { rand.to_s }
+
+  before do
+    allow(listener.client).to receive(:send_json)
+    trigger
+  end
+
+  shared_examples 'a metrics listener' do
+    let(:metric_payload) { { type: "karafka", payload: metrics } }
+
+    it 'sends metrics to the prometheus exporter server' do
+      expect(listener.client).to have_received(:send_json).with(metric_payload)
+    end
+  end
+
+  describe '#on_connection_listener_fetch_loop_received' do
+    subject(:trigger) { listener.on_connection_listener_fetch_loop_received(event) }
+    let(:connection_listener) { instance_double(Karafka::Connection::Listener, id: 'id') }
+    let(:subscription_group) { instance_double(Karafka::Routing::SubscriptionGroup, consumer_group_id: rand(10)) }
+
+    context 'when there are no messages polled' do
+      let(:payload) do
+        {
+          caller: connection_listener,
+          subscription_group: subscription_group,
+          messages_buffer: [{},{}],
+          time: 2
+        }
+      end
+      let(:metrics) do
+        labels = {consumer_group: event.payload[:subscription_group].consumer_group_id}
+        {
+          listener_polling_messages: [
+            event.payload[:messages_buffer].size,
+            labels
+          ],
+          listener_polling_time_seconds: [
+            event.payload[:time] / 1_000.0, # expect seconds not ms
+            labels
+          ]
+        }
+      end
+
+      it_behaves_like 'a metrics listener'
+    end
+  end
+
+  describe '#on_worker_process' do
+    subject(:trigger) { listener.on_worker_process(event) }
+    let(:stats) { { busy: 1, enqueued: 1 } }
+    let(:jobs_queue) { instance_double(Karafka::Processing::JobsQueue, statistics: stats) }
+    let(:payload) { { jobs_queue: jobs_queue } }
+    let(:metrics) do
+      {
+        worker_threads: [Karafka::App.config.concurrency, {}],
+        worker_threads_busy: [stats[:busy], {}],
+        worker_enqueued_jobs: [stats[:enqueued], {}]
+      }
+    end
+
+    it_behaves_like 'a metrics listener'
+  end
+
+  describe '#on_worker_processed' do
+    subject(:trigger) { listener.on_worker_processed(event) }
+    let(:stats) { { busy: 1, enqueued: 1 } }
+    let(:jobs_queue) { instance_double(Karafka::Processing::JobsQueue, statistics: stats) }
+    let(:payload) { { jobs_queue: jobs_queue } }
+    let(:metrics) do
+      {
+        worker_threads_busy: [stats[:busy], {}],
+      }
+    end
+
+    it_behaves_like 'a metrics listener'
+  end
+
+  describe '#on_app_stopped' do
+    subject(:trigger) { listener.on_app_stopped(event) }
+
+    let(:payload) { {} }
+    let(:metrics) {  {app_stopped_total: [1, {}]} }
+
+    it_behaves_like 'a metrics listener'
+  end
+
+  describe '#on_dead_letter_queue_dispatched' do
+    subject(:trigger) { listener.on_dead_letter_queue_dispatched(event) }
+
+    let(:topic) { build(:routing_topic, name: 'test') }
+    let(:coordinator) { create(:processing_coordinator, topic: topic) }
+    let(:consumer) do
+      instance = Class.new(Karafka::BaseConsumer).new
+      instance.coordinator = coordinator
+      instance.messages = messages
+      topic.dead_letter_queue(topic: 'dlq')
+      instance
+    end
+    let(:messages) do
+      instance_double(
+        Karafka::Messages::Messages,
+        metadata: Karafka::Messages::BatchMetadata.new(
+          topic: topic.name,
+          partition: 0,
+          processed_at: Time.now
+        )
+      )
+    end
+    let(:payload) { { caller: consumer, messages: messages } }
+    let(:labels) do
+      {
+        dead_letter_queue_topic: event[:caller].topic.dead_letter_queue.topic,
+        consumer_group: consumer.topic.consumer_group.id,
+        partition: event[:caller].messages.metadata.partition,
+        topic: event[:caller].topic.name,
+      }
+    end
+    let(:metrics) { { dead_letter_queue_total: [1, labels] } }
+
+    it_behaves_like 'a metrics listener'
+  end
+
+  describe '#on_error_occurred' do
+    subject(:trigger) { listener.on_error_occurred(event) }
+
+    let(:error) { StandardError.new }
+    let(:payload) { { caller: caller, error: error, type: type } }
+    let(:metrics) { { consumer_error_total: [1, { type: type }]} }
+
+    context 'when a consumer with messages errors' do
+      let(:type) { 'consumer.consume.error' }
+      let(:coordinator) { create(:processing_coordinator, topic: topic) }
+      let(:caller) do
+        instance = Class.new(Karafka::BaseConsumer).new
+        instance.coordinator = coordinator
+        instance.messages = messages
+        topic.dead_letter_queue(topic: 'dlq')
+        instance
+      end
+      let(:messages) do
+        instance_double(
+          Karafka::Messages::Messages,
+          metadata: Karafka::Messages::BatchMetadata.new(
+            topic: topic.name,
+            partition: 0,
+            processed_at: Time.now
+          )
+        )
+      end
+      let(:labels) do
+        {
+          consumer_group: caller.topic.consumer_group.id,
+          partition: event[:caller].messages.metadata.partition,
+          topic: event[:caller].topic.name,
+          type: type
+        }
+      end
+      let(:metrics) { { consumer_error_total: [1, labels]} }
+
+
+      it_behaves_like 'a metrics listener'
+    end
+
+    context 'when it is a connection.listener.fetch_loop.error' do
+      let(:type) { 'connection.listener.fetch_loop.error' }
+
+      it_behaves_like 'a metrics listener'
+    end
+
+    context 'when it is a consumer.consume.error' do
+      let(:type) { 'consumer.consume.error' }
+
+      it_behaves_like 'a metrics listener'
+    end
+
+    context 'when it is a consumer.revoked.error' do
+      let(:type) { 'consumer.revoked.error' }
+
+      it_behaves_like 'a metrics listener'
+    end
+
+    context 'when it is a consumer.before_enqueue.error' do
+      let(:type) { 'consumer.before_enqueue.error' }
+
+      it_behaves_like 'a metrics listener'
+    end
+
+    context 'when it is a consumer.before_consume.error' do
+      let(:type) { 'consumer.before_consume.error' }
+
+      it_behaves_like 'a metrics listener'
+    end
+
+    context 'when it is a consumer.after_consume.error' do
+      let(:type) { 'consumer.after_consume.error' }
+
+      it_behaves_like 'a metrics listener'
+    end
+
+    context 'when it is a consumer.idle.error' do
+      let(:type) { 'consumer.idle.error' }
+
+      it_behaves_like 'a metrics listener'
+    end
+
+    context 'when it is a consumer.shutdown.error' do
+      let(:type) { 'consumer.shutdown.error' }
+
+      it_behaves_like 'a metrics listener'
+    end
+
+    context 'when it is a runner.call.error' do
+      let(:type) { 'runner.call.error' }
+
+      it_behaves_like 'a metrics listener'
+    end
+
+    context 'when it is an app.stopping.error' do
+      let(:type) { 'app.stopping.error' }
+      let(:payload) { { type: type, error: Karafka::Errors::ForcefulShutdownError.new } }
+
+      it_behaves_like 'a metrics listener'
+    end
+
+    context 'when it is a worker.process.error' do
+      let(:type) { 'worker.process.error' }
+
+      it_behaves_like 'a metrics listener'
+    end
+
+    context 'when it is a librdkafka.error' do
+      let(:type) { 'librdkafka.error' }
+
+      it_behaves_like 'a metrics listener'
+    end
+
+    context 'when it is a connection.client.poll.error' do
+      let(:type) { 'connection.client.poll.error' }
+
+      it_behaves_like 'a metrics listener'
+    end
+
+    context 'when it is a statistics.emitted.error' do
+      let(:type) { 'statistics.emitted.error' }
+
+      it_behaves_like 'a metrics listener'
+    end
+
+    context 'when it is an unsupported error type' do
+      let(:type) { 'unsupported.error' }
+
+      it_behaves_like 'a metrics listener'
+    end
+  end
+end

--- a/spec/prometheus_exporther_helper.rb
+++ b/spec/prometheus_exporther_helper.rb
@@ -1,0 +1,1 @@
+require 'prometheus_exporter'

--- a/spec/support/vendors/prometheus_exporter/dummy_client.rb
+++ b/spec/support/vendors/prometheus_exporter/dummy_client.rb
@@ -18,6 +18,7 @@ module Vendors
 
       def send_json(obj)
         @collector.collect(JSON.parse(obj.to_json)) # Fake the JSON serialization
+        @collector.metrics # Fake a hit to the metrics endpoint
       end
     end
   end

--- a/spec/support/vendors/prometheus_exporter/dummy_client.rb
+++ b/spec/support/vendors/prometheus_exporter/dummy_client.rb
@@ -4,10 +4,10 @@ require 'karafka/instrumentation/vendors/prometheus_exporter/metrics_collector'
 
 # Vendors specific support components
 module Vendors
-  # Namespace for DD specific support classes
+  # Namespace for Prometheus Exporter specific support classes
   module PrometheusExporter
-    # Dummy statsd client that accumulates metrics that are added instead of sending them
-    # This allows us not to be dependent on the statsd gem but also be able to test out the
+    # Dummy prometheus client that accumulates metrics that are added instead of sending them
+    # This allows us not to be dependent on the prometheus exporter gem but also be able to test out the
     # integration
     class DummyClient
       attr_reader :collector

--- a/spec/support/vendors/prometheus_exporter/dummy_client.rb
+++ b/spec/support/vendors/prometheus_exporter/dummy_client.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'karafka/instrumentation/vendors/prometheus_exporter/metrics_collector'
+
+# Vendors specific support components
+module Vendors
+  # Namespace for DD specific support classes
+  module PrometheusExporter
+    # Dummy statsd client that accumulates metrics that are added instead of sending them
+    # This allows us not to be dependent on the statsd gem but also be able to test out the
+    # integration
+    class DummyClient
+      attr_reader :collector
+
+      def initialize(prom_collector = nil)
+        @collector = prom_collector || ::Karafka::Instrumentation::Vendors::PrometheusExporter::MetricsCollector.new
+      end
+
+      def send_json(obj)
+        @collector.collect(JSON.parse(obj.to_json)) # Fake the JSON serialization
+      end
+    end
+  end
+end


### PR DESCRIPTION
**STATUS: WIP**

Adding a prometheus exporter listener to karafka

Prometheus Exporter - https://github.com/discourse/prometheus_exporter

Since the Collector is not in prometheus exporter the server would need to be started like so: 

```
BUNDLE_PATH="/usr/local/bin/bundle"
COLLECTOR_PATH="lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_collector.rb"
KARAFKA_PATH=$($BUNDLE_PATH info --path karafka)/$(COLLECTOR_PATH) 
$BUNDLE_PATH exec prometheus_exporter --bind 0.0.0.0 --verbose --histogram --type-collector $KOURIER_PATH
```

In K8s the prometheus exporter will need to live within the karafka server pod as a sidecar like so: 


```yaml
kind: Deployment
apiVersion: apps/v1
metadata:
  name: myapp-karafka
spec:
  revisionHistoryLimit: 5
  replicas: 1
  selector:
    matchLabels:
      service: myapp
      app: karafka
  strategy:
    type: Recreate
  template:
    metadata:
      labels:
        service: myapp
        app: karafka
    spec:
      volumes: []
      containers:
      - name: prometheus-exporter
        command:
        - "/bin/bash"
        - "-c"
        - |
          BUNDLE_PATH="/usr/local/bin/bundle"
          KOURIER_PATH=$($BUNDLE_PATH info --path kourier)/lib/karafka/instrumentation/vendors/prometheus_exporter/metrics_collector.rb
          $BUNDLE_PATH exec prometheus_exporter --bind 0.0.0.0 --verbose --histogram --type-collector $KOURIER_PATH
        image: my-ecr:latest
        imagePullPolicy: Always
        ports:
        - containerPort: 9394
          protocol: TCP
        resources:
          limits:
            cpu: 100m
            memory: 512Mi
          requests:
            cpu: 20m
            memory: 384Mi
      - name: karafka
        image: my-ecr:latest
        resources:
          requests:
            cpu: "1"
            memory: 1Gi
          limits:
            cpu: "1"
            memory: 2Gi
        lifecycle:
          preStop:
            exec:
              command:
              - "/bin/bash"
              - "-c"
              - "pkill -TSTP -f karafka; sleep 60;"
        command:
        - "/bin/bash"
        - "-c"
        - |
          until curl -s http://localhost:9394/ping > /dev/null; do echo waiting for prometheus-server; sleep 1; done;
          RAILS_ENV=production /usr/local/bin/bundle exec karafka server --exclude-consumer-groups karafka_web
        ports:
        - containerPort: 3000
          protocol: TCP
        livenessProbe:
          failureThreshold: 12 # 12 * 10s = 2 minutes of extra processing time after a missed poll interval
          initialDelaySeconds: 30
          httpGet:
            path: /
            port: 3000
            scheme: HTTP
        env: []
        imagePullPolicy: Always
        volumeMounts: []
      terminationGracePeriodSeconds: 300
```

Still needed:

- [ ] Refactoring the messy bits
- [ ] Testing metric conversions
- [ ] Testing that all metrics are reported accurately 
- [ ] Example rails app w/ prometheus exporter in examples repo
- [ ] Add params, return types, fix wrong types
- [ ] Better error handling