### PR TITLE
Fix `#retrying?` helper, enable phantom test

### DIFF
--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -225,7 +225,7 @@ module Karafka
     #   different flow after there is an error, for example for resources cleanup, small manual
     #   backoff or different instrumentation tracking.
     def retrying?
-      coordinator.pause_tracker.attempt.positive?
+      coordinator.pause_tracker.attempt > 1
     end
 
     # Pauses the processing from the last offset to retry on given message


### PR DESCRIPTION
Currently, `BaseConsumer#retrying?` never evaluates to false since `coordinator.pause_tracker.attempt` starts with 0 and gets incremented even during initial consumption [here](https://github.com/karafka/karafka/blob/625e33267cc21d675d30d5c219df128244233d33/lib/karafka/connection/listener.rb#L277), if I understand correctly.

The only spec that I could find that tests this helper is being silently ignored since its name does not end with `_spec`. If it were to run, it would result in a false positive since it does not assert that an error has happened.

Moreover, dangling descendant of `Exception` is never used in this test, and raising it would also not work, since as far I understand, Karafka recreates the listener when it encounters something that is not a descendant of `StandardError`. `#retrying?` in this case would correctly evaluate to `false`, since pause tracker would be reset as well, resulting in an infinite consumption cycle.