### PR TITLE
Fix consumption_lag and processing_lag references from workless flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka framework changelog
 
+## 2.1.4 (2023-06-06)
+- [Fix] `processing_lag` and `consumption_lag` on empty batch fail on shutdown usage (#1475)
+
 ## 2.1.3 (2023-05-29)
 - [Maintenance] Add linter to ensure, that all integration specs end with `_spec.rb`.
 - [Fix] Fix `#retrying?` helper result value (Aerdayne).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka (2.1.3)
+    karafka (2.1.4)
       karafka-core (>= 2.0.13, < 3.0.0)
       thor (>= 0.20)
       waterdrop (>= 2.5.3, < 3.0.0)

--- a/lib/karafka/messages/batch_metadata.rb
+++ b/lib/karafka/messages/batch_metadata.rb
@@ -20,14 +20,21 @@ module Karafka
     ) do
       # This lag describes how long did it take for a message to be consumed from the moment it was
       # created
+      #
+      #
+      # @return [Integer] number of milliseconds
+      # @note In case of usage in workless flows, this value will be set to -1
       def consumption_lag
-        time_distance_in_ms(processed_at, created_at)
+        processed_at ? time_distance_in_ms(processed_at, created_at) : -1
       end
 
       # This lag describes how long did a batch have to wait before it was picked up by one of the
       # workers
+      #
+      # @return [Integer] number of milliseconds
+      # @note In case of usage in workless flows, this value will be set to -1
       def processing_lag
-        time_distance_in_ms(processed_at, scheduled_at)
+        processed_at ? time_distance_in_ms(processed_at, scheduled_at) : -1
       end
 
       private

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '2.1.3'
+  VERSION = '2.1.4'
 end

--- a/spec/integrations/pro/consumption/strategies/ftr/with_delayed_shutdown_metadata_lags_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/with_delayed_shutdown_metadata_lags_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# We should be able to reference both `#processing_lag` and `consumption_lag` even when we
+# had delay and no data would be consumed prior.
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def shutdown
+    messages.metadata.processing_lag
+    messages.metadata.consumption_lag
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    delay_by(100_000)
+  end
+end
+
+produce_many(DT.topic, DT.uuids(1))
+
+start_karafka_and_wait_until do
+  sleep(5)
+end

--- a/spec/lib/karafka/messages/batch_metadata_spec.rb
+++ b/spec/lib/karafka/messages/batch_metadata_spec.rb
@@ -59,6 +59,12 @@ RSpec.describe_current do
     it 'expect to calculate it as a distance in between message creation time and processing' do
       expect(metadata.consumption_lag).to eq(((processed_at - created_at) * 1_000).round)
     end
+
+    context 'when processed_at is not set' do
+      let(:processed_at) { nil }
+
+      it { expect(metadata.consumption_lag).to eq(-1) }
+    end
   end
 
   describe '#processing_lag' do
@@ -72,6 +78,12 @@ RSpec.describe_current do
 
     it 'expect to calculate it as a distance in between message schedule time and processing' do
       expect(metadata.processing_lag).to eq(((processed_at - scheduled_at) * 1_000).round)
+    end
+
+    context 'when processed_at is not set' do
+      let(:processed_at) { nil }
+
+      it { expect(metadata.processing_lag).to eq(-1) }
     end
   end
 end


### PR DESCRIPTION
Workless flows jobs tracking in Web-UI fails because of this. We use -1 similar to how we report "not available" offsets as those flows are mostly used for internal operations. While we may skip reporting them in web when no data, it is still worth fixing.

close https://github.com/karafka/karafka/issues/1475