### PR TITLE
Optimize revocation switch change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - [Improvement] Expose `#commit_offsets` and `#commit_offsets!` methods in the consumer to provide ability to commit offsets directly to Kafka without having to mark new messages as consumed.
 - [Improvement] No longer skip offset commit when no messages marked as consumed as `librdkafka` has fixed the crashes there.
 - [Improvement] Remove no longer needed patches.
+- [Improvement] Ensure, that the coordinator revocation status is switched upon revocation detection when using `#revoked?`
+- [Improvement] Add benchmarks for marking as consumed (sync and async).
 - [Change] Require `karafka-core` `>= 2.1.0`
 - [Change] Require `waterdrop` `>= 2.6.1`
 

--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -221,7 +221,12 @@ module Karafka
     #   even before we poll but it gets reset when polling happens, hence we also need to switch
     #   the coordinator state after the revocation (but prior to running more jobs)
     def revoked?
-      client.assignment_lost? || coordinator.revoked?
+      return true if coordinator.revoked?
+      return false unless client.assignment_lost?
+
+      coordinator.revoke
+
+      true
     end
 
     # @return [Boolean] are we retrying processing after an error. This can be used to provide a

--- a/spec/benchmarks/offset_management/async.rb
+++ b/spec/benchmarks/offset_management/async.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# A simple case where we mark each message as consumed and move forward. We are interested here
+# only in how long per message it takes to mark it as consumed in an async mode
+
+setup_karafka { |config| config.concurrency = 1 }
+
+MAX_MESSAGES = 100_000
+
+$times = []
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    @count ||= 0
+    @count += messages.size
+
+    messages.each do |message|
+      start = Time.now
+      mark_as_consumed(message)
+      stop = Time.now
+
+      $times << stop - start
+    end
+
+    return if @count < MAX_MESSAGES
+    return if $stop
+
+    Thread.new { Karafka::Server.stop }
+  end
+end
+
+draw_routes('benchmarks_00_01')
+
+Tracker.run(messages_count: MAX_MESSAGES) do
+  Karafka::App.config.internal.status.reset!
+  Karafka::Server.run
+
+  $times.sum
+end
+
+# Time taken: 0.482942255
+# Messages per second: 207064.0929938922

--- a/spec/benchmarks/offset_management/revoked_checks.rb
+++ b/spec/benchmarks/offset_management/revoked_checks.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+setup_karafka { |config| config.concurrency = 1 }
+
+MAX_MESSAGES = 100_000
+
+$times = []
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    @count ||= 0
+    @count += messages.size
+
+    messages.each do
+      start = Time.now
+      revoked?
+      stop = Time.now
+
+      $times << stop - start
+    end
+
+    return if @count < MAX_MESSAGES
+    return if $stop
+
+    Thread.new { Karafka::Server.stop }
+  end
+end
+
+draw_routes('benchmarks_00_01')
+
+Tracker.run(messages_count: MAX_MESSAGES) do
+  Karafka::App.config.internal.status.reset!
+  Karafka::Server.run
+
+  $times.sum
+end
+
+# Time taken: 0.094014255
+# Messages per second: 1063668.4830401517

--- a/spec/benchmarks/offset_management/sync.rb
+++ b/spec/benchmarks/offset_management/sync.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# A simple case where we mark each message as consumed and move forward. We are interested here
+# only in how long per message it takes to mark it as consumed in the sync mode
+
+# Round-trips to Kafka are expensive and in general not recommended per message.
+
+setup_karafka { |config| config.concurrency = 1 }
+
+MAX_MESSAGES = 100_000
+
+$times = []
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    @count ||= 0
+    @count += messages.size
+
+    messages.each do |message|
+      start = Time.now
+      mark_as_consumed!(message)
+      stop = Time.now
+
+      $times << stop - start
+    end
+
+    return if @count < MAX_MESSAGES
+    return if $stop
+
+    Thread.new { Karafka::Server.stop }
+  end
+end
+
+draw_routes('benchmarks_00_01')
+
+Tracker.run(messages_count: MAX_MESSAGES) do
+  Karafka::App.config.internal.status.reset!
+  Karafka::Server.run
+
+  $times.sum
+end
+
+# Time taken: 16.43162835
+# Messages per second: 6085.824111278661

--- a/spec/benchmarks_helper.rb
+++ b/spec/benchmarks_helper.rb
@@ -95,7 +95,7 @@ class Tracker
     # @param messages_count [Integer, nil] how many messages did we process overall or nil if
     #   the benchmark is not per message data related
     # @param block [Proc] code we want to run in iterations
-    def run(messages_count: nil, iterations: 10, &block)
+    def run(messages_count: nil, iterations: 1, &block)
       instance = new(iterations: iterations, messages_count: messages_count)
 
       instance.iterate { block.call }

--- a/spec/integrations/offset_management/commit_offset_after_exceeding_max_poll_spec.rb
+++ b/spec/integrations/offset_management/commit_offset_after_exceeding_max_poll_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# When we exceed max poll interval but did not poll yet, the async offset commit may return true
-# while the sync should give us accurate representation of the ownership.
+# When we exceed max poll interval but did not poll yet, the async and sync offset commits should
+# give us accurate representation of the ownership because of lost assignment check.
 
 setup_karafka(allow_errors: true) do |config|
   config.kafka[:'max.poll.interval.ms'] = 10_000
@@ -33,4 +33,4 @@ start_karafka_and_wait_until do
   DT.key?(:done)
 end
 
-assert_equal DT[:results], [true, false]
+assert_equal DT[:results], [false, false]


### PR DESCRIPTION
A small change to optimize how the coordinator discovers the revocation state when using `#revoked?`

this PR also adds some new benchmarks

close https://github.com/karafka/karafka/issues/1492