### PR TITLE
Time based seek support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [Improvement] Provide time support for consumer `#seek`.
 - [Improvement] Remove no longer needed locks for client operations.
 - [Improvement] Raise `Karafka::Errors::TopicNotFoundError` when trying to iterate over non-existing topic.
+- [Improvement] Ensure that Kafka multi-command operations run under mutex together.
 - [Change] Require `waterdrop` `>= 2.6.2`
 - [Refactor] Clean-up iterator code.
 - [Fix] Rename `InvalidRealOffsetUsage` to `InvalidRealOffsetUsageError` to align with naming of other errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - [Fix] Fix unstable spec.
 - [Fix] Fix a case where automatic `#seek` would overwrite manual seek of a user when running LRJ.
 - [Fix] Make sure, that user direct `#seek` and `#pause` operations take precedence over system actions.
-- [Fix] Maure sure, that `#pause` and `#resume` with one underlying connection do not race-condition.
+- [Fix] Make sure, that `#pause` and `#resume` with one underlying connection do not race-condition.
 
 ## 2.1.5 (2023-06-19)
 - [Improvement] Drastically improve `#revoked?` response quality by checking the real time assignment lost state on librdkafka.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Karafka framework changelog
 
 ## 2.1.6 (Unreleased)
+- [Improvement] Provide time support for iterator
 - [Improvement] Provide time support for admin `#read_topic`
 - [Improvement] Provide time support for consumer `#seek`.
 - [Improvement] Remove no longer needed locks for client operations.
+- [Improvement] Raise `Karafka::Errors::TopicNotFoundError` when trying to iterate over non-existing topic.
 - [Change] Require `waterdrop` `>= 2.6.2`
+- [Refactor] Clean-up iterator code.
 - [Fix] Rename `InvalidRealOffsetUsage` to `InvalidRealOffsetUsageError` to align with naming of other errors.
 - [Fix] Fix unstable spec.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - [Refactor] Clean-up iterator code.
 - [Fix] Rename `InvalidRealOffsetUsage` to `InvalidRealOffsetUsageError` to align with naming of other errors.
 - [Fix] Fix unstable spec.
+- [Fix] Fix a case where automatic `#seek` would overwrite manual seek of a user when running LRJ.
+- [Fix] Make sure, that user direct `#seek` and `#pause` operations take precedence over system actions.
 
 ## 2.1.5 (2023-06-19)
 - [Improvement] Drastically improve `#revoked?` response quality by checking the real time assignment lost state on librdkafka.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Karafka framework changelog
 
 ## 2.1.6 (Unreleased)
+- [Improvement] Provide time support for admin `#read_topic`
+- [Improvement] Provide time support for consumer `#seek`.
 - [Improvement] Remove no longer needed locks for client operations.
 - [Change] Require `waterdrop` `>= 2.6.2`
+- [Fix] Rename `InvalidRealOffsetUsage` to `InvalidRealOffsetUsageError` to align with naming of other errors.
 - [Fix] Fix unstable spec.
 
 ## 2.1.5 (2023-06-19)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [Improvement] Ensure that Kafka multi-command operations run under mutex together.
 - [Change] Require `waterdrop` `>= 2.6.2`
 - [Refactor] Clean-up iterator code.
+- [Fix]  Improve performance in dev environment for a Rails app (juike)
 - [Fix] Rename `InvalidRealOffsetUsage` to `InvalidRealOffsetUsageError` to align with naming of other errors.
 - [Fix] Fix unstable spec.
 - [Fix] Fix a case where automatic `#seek` would overwrite manual seek of a user when running LRJ.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka framework changelog
 
 ## 2.1.6 (Unreleased)
+- [Improvement] Remove no longer needed locks for client operations.
 - [Change] Require `waterdrop` `>= 2.6.2`
 - [Fix] Fix unstable spec.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [Fix] Fix unstable spec.
 - [Fix] Fix a case where automatic `#seek` would overwrite manual seek of a user when running LRJ.
 - [Fix] Make sure, that user direct `#seek` and `#pause` operations take precedence over system actions.
+- [Fix] Maure sure, that `#pause` and `#resume` with one underlying connection do not race-condition.
 
 ## 2.1.5 (2023-06-19)
 - [Improvement] Drastically improve `#revoked?` response quality by checking the real time assignment lost state on librdkafka.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
     karafka-core (2.1.0)
       concurrent-ruby (>= 1.1)
       karafka-rdkafka (>= 0.13.0, < 0.14.0)
-    karafka-rdkafka (0.13.0)
+    karafka-rdkafka (0.13.1)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)

--- a/lib/karafka/admin.rb
+++ b/lib/karafka/admin.rb
@@ -18,6 +18,9 @@ module Karafka
     # retry after checking that the operation was finished or failed using external factor.
     MAX_WAIT_TIMEOUT = 1
 
+    # Max time for a TPL request. We increase it to compensate for remote clusters latency
+    TPL_REQUEST_TIMEOUT = 2_000
+
     # How many times should be try. 1 x 60 => 60 seconds wait in total
     MAX_ATTEMPTS = 60
 
@@ -34,7 +37,8 @@ module Karafka
       'enable.auto.commit': false
     }.freeze
 
-    private_constant :Topic, :CONFIG_DEFAULTS, :MAX_WAIT_TIMEOUT, :MAX_ATTEMPTS
+    private_constant :Topic, :CONFIG_DEFAULTS, :MAX_WAIT_TIMEOUT, :TPL_REQUEST_TIMEOUT,
+                     :MAX_ATTEMPTS
 
     class << self
       # Allows us to read messages from the topic
@@ -262,7 +266,7 @@ module Karafka
             name, partition => offset
           )
 
-          real_offsets = consumer.offsets_for_times(tpl, 2_000)
+          real_offsets = consumer.offsets_for_times(tpl, TPL_REQUEST_TIMEOUT)
           detected_offset = real_offsets.to_h.dig(name, partition)
 
           detected_offset&.offset || raise(Errors::InvalidTimeBasedOffsetError)

--- a/lib/karafka/admin.rb
+++ b/lib/karafka/admin.rb
@@ -42,8 +42,9 @@ module Karafka
       # @param name [String, Symbol] topic name
       # @param partition [Integer] partition
       # @param count [Integer] how many messages we want to get at most
-      # @param start_offset [Integer] offset from which we should start. If -1 is provided
-      #   (default) we will start from the latest offset
+      # @param start_offset [Integer, Time] offset from which we should start. If -1 is provided
+      #   (default) we will start from the latest offset. If time is provided, the appropriate
+      #   offset will be resolved.
       # @param settings [Hash] kafka extra settings (optional)
       #
       # @return [Array<Karafka::Messages::Message>] array with messages
@@ -53,6 +54,9 @@ module Karafka
         low_offset, high_offset = nil
 
         with_consumer(settings) do |consumer|
+          # Convert the time offset (if needed)
+          start_offset = resolve_offset(consumer, name.to_s, partition, start_offset)
+
           low_offset, high_offset = consumer.query_watermark_offsets(name, partition)
 
           # Select offset dynamically if -1 or less
@@ -242,6 +246,29 @@ module Karafka
         )
 
         ::Rdkafka::Config.new(config_hash)
+      end
+
+      # Resolves the offset if offset is in a time format. Otherwise returns the offset without
+      # resolving.
+      # @param consumer [::Rdkafka::Consumer]
+      # @param name [String, Symbol] expected topic name
+      # @param partition [Integer]
+      # @param offset [Integer, Time]
+      # @return [Integer] expected offset
+      def resolve_offset(consumer, name, partition, offset)
+        if offset.is_a?(Time)
+          tpl = ::Rdkafka::Consumer::TopicPartitionList.new
+          tpl.add_topic_and_partitions_with_offsets(
+            name, partition => offset
+          )
+
+          real_offsets = consumer.offsets_for_times(tpl, 2_000)
+          detected_offset = real_offsets.to_h.dig(name, partition)
+
+          detected_offset&.offset || raise(Errors::InvalidTimeBasedOffsetError)
+        else
+          offset
+        end
       end
     end
   end

--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -206,8 +206,13 @@ module Karafka
     #
     # @param offset [Integer, Time] offset where we want to seek or time of the offset where we
     #   want to seek.
+    # @param manual_seek [Boolean] Flag to differentiate between user seek and system/strategy
+    #   based seek. User seek operations should take precedence over system actions, hence we need
+    #   to know who invoked it.
     # @note Please note, that if you are seeking to a time offset, getting the offset is blocking
-    def seek(offset)
+    def seek(offset, manual_seek = true)
+      coordinator.manual_seek if manual_seek
+
       client.seek(
         Karafka::Messages::Seek.new(
           topic.name,

--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -204,7 +204,9 @@ module Karafka
 
     # Seeks in the context of current topic and partition
     #
-    # @param offset [Integer] offset where we want to seek
+    # @param offset [Integer, Time] offset where we want to seek or time of the offset where we
+    #   want to seek.
+    # @note Please note, that if you are seeking to a time offset, getting the offset is blocking
     def seek(offset)
       client.seek(
         Karafka::Messages::Seek.new(

--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -20,11 +20,14 @@ module Karafka
       # How many times should we retry polling in case of a failure
       MAX_POLL_RETRIES = 20
 
+      # Max time for a TPL request. We increase it to compensate for remote clusters latency
+      TPL_REQUEST_TIMEOUT = 2_000
+
       # We want to make sure we never close several clients in the same moment to prevent
       # potential race conditions and other issues
       SHUTDOWN_MUTEX = Mutex.new
 
-      private_constant :MAX_POLL_RETRIES, :SHUTDOWN_MUTEX
+      private_constant :MAX_POLL_RETRIES, :SHUTDOWN_MUTEX, :TPL_REQUEST_TIMEOUT
 
       # Creates a new consumer instance.
       #
@@ -151,7 +154,7 @@ module Karafka
           # Now we can overwrite the seek message offset with our resolved offset and we can
           # then seek to the appropriate message
           # We set the timeout to 2_000 to make sure that remote clusters handle this well
-          real_offsets = @kafka.offsets_for_times(tpl, 2_000)
+          real_offsets = @kafka.offsets_for_times(tpl, TPL_REQUEST_TIMEOUT)
           detected_partition = real_offsets.to_h.dig(message.topic, message.partition)
 
           # There always needs to be an offset. In case we seek into the future, where there

--- a/lib/karafka/errors.rb
+++ b/lib/karafka/errors.rb
@@ -48,6 +48,9 @@ module Karafka
     StrategyNotFoundError = Class.new(BaseError)
 
     # This should never happen. Please open an issue if it does.
-    InvalidRealOffsetUsage = Class.new(BaseError)
+    InvalidRealOffsetUsageError = Class.new(BaseError)
+
+    # This should never happen. Please open an issue if it does.
+    InvalidTimeBasedOffsetError = Class.new(BaseError)
   end
 end

--- a/lib/karafka/messages/seek.rb
+++ b/lib/karafka/messages/seek.rb
@@ -4,6 +4,9 @@ module Karafka
   module Messages
     # "Fake" message that we use as an abstraction layer when seeking back.
     # This allows us to encapsulate a seek with a simple abstraction
+    #
+    # @note `#offset` can be either the offset value or the time of the offset
+    # (first equal or greater)
     Seek = Struct.new(:topic, :partition, :offset)
   end
 end

--- a/lib/karafka/pro/iterator.rb
+++ b/lib/karafka/pro/iterator.rb
@@ -50,7 +50,7 @@ module Karafka
         settings: { 'auto.offset.reset': 'beginning' },
         yield_nil: false
       )
-        @topics_with_partitions = expand_topics_with_partitions(topics)
+        @topics_with_partitions = Expander.new.call(topics)
 
         @routing_topics = @topics_with_partitions.map do |name, _|
           [name, ::Karafka::Routing::Router.find_or_initialize_by_name(name)]
@@ -71,7 +71,7 @@ module Karafka
       # only eat up resources.
       def each
         Admin.with_consumer(@settings) do |consumer|
-          tpl = tpl_with_expanded_offsets(consumer)
+          tpl = TplBuilder.new(consumer, @topics_with_partitions).call
           consumer.assign(tpl)
 
           # We need this for self-referenced APIs like pausing
@@ -131,43 +131,6 @@ module Karafka
 
       private
 
-      # Expands topics to which we want to subscribe with partitions information in case this
-      # info is not provided. For our convenience we want to support 5 formats of defining
-      # the subscribed topics:
-      #
-      # - 'topic1' - just a string with one topic name
-      # - ['topic1', 'topic2'] - just the names
-      # - { 'topic1' => -100 } - names with negative lookup offset
-      # - { 'topic1' => { 0 => 5 } } - names with exact partitions offsets
-      # - { 'topic1' => { 0 => -5 }, 'topic2' => { 1 => 5 } } - with per partition negative offsets
-      #
-      # @param topics [Array, Hash] topics definitions
-      # @return [Hash] hash with topics containing partitions definitions
-      def expand_topics_with_partitions(topics)
-        # Simplification for the single topic case
-        topics = [topics] if topics.is_a?(String)
-        # If we've got just array with topics, we need to convert that into a representation
-        # that we can expand with offsets
-        topics = topics.map { |name| [name, false] }.to_h if topics.is_a?(Array)
-
-        expanded = Hash.new { |h, k| h[k] = {} }
-
-        topics.map do |topic, details|
-          if details.is_a?(Hash)
-            details.each do |partition, offset|
-              expanded[topic][partition] = offset
-            end
-          else
-            partition_count(topic.to_s).times do |partition|
-              # If no offsets are provided, we just start from zero
-              expanded[topic][partition] = details || 0
-            end
-          end
-        end
-
-        expanded
-      end
-
       # @param timeout [Integer] timeout in ms
       # @return [Rdkafka::Consumer::Message, nil] message or nil if nothing to do
       def poll(timeout)
@@ -199,54 +162,6 @@ module Karafka
       # @return [Boolean]
       def done?
         @stopped_partitions >= @total_partitions
-      end
-
-      # Builds the tpl representing all the subscriptions we want to run
-      #
-      # Additionally for negative offsets, does the watermark calculation where to start
-      #
-      # @param consumer [Rdkafka::Consumer] consumer we need in case of negative offsets as
-      #   negative are going to be used to do "give me last X". We use the already initialized
-      #   consumer instance, not to start another one again.
-      # @return [Rdkafka::Consumer::TopicPartitionList]
-      def tpl_with_expanded_offsets(consumer)
-        tpl = Rdkafka::Consumer::TopicPartitionList.new
-
-        @topics_with_partitions.each do |name, partitions|
-          partitions_with_offsets = {}
-
-          # When no offsets defined, we just start from zero
-          if partitions.is_a?(Array) || partitions.is_a?(Range)
-            partitions_with_offsets = partitions.map { |partition| [partition, 0] }.to_h
-          else
-            # When offsets defined, we can either use them if positive or expand and move back
-            # in case of negative (-1000 means last 1000 messages, etc)
-            partitions.each do |partition, offset|
-              if offset.negative?
-                _, high_watermark_offset = consumer.query_watermark_offsets(name, partition)
-                # We add because this offset is negative
-                partitions_with_offsets[partition] = high_watermark_offset + offset
-              else
-                partitions_with_offsets[partition] = offset
-              end
-            end
-          end
-
-          tpl.add_topic_and_partitions_with_offsets(name, partitions_with_offsets)
-        end
-
-        tpl
-      end
-
-      # @param name [String] topic name
-      # @return [Integer] number of partitions of the topic we want to iterate over
-      def partition_count(name)
-        Admin
-          .cluster_info
-          .topics
-          .find { |topic| topic.fetch(:topic_name) == name }
-          .fetch(:partitions)
-          .count
       end
     end
   end

--- a/lib/karafka/pro/iterator/expander.rb
+++ b/lib/karafka/pro/iterator/expander.rb
@@ -37,19 +37,9 @@ module Karafka
         # @param topics [Array, Hash, String] topics definitions
         # @return [Hash] expanded and normalized requested topics and partitions data
         def call(topics)
-          # Simplification for the single topic case
-          topics = [topics] if topics.is_a?(String)
-
-          # If we've got just array with topics, we need to convert that into a representation
-          # that we can expand with offsets
-          topics = topics.map { |name| [name, false] }.to_h if topics.is_a?(Array)
-          # We remap by creating new hash, just in case the hash came as the argument for this
-          # expanded. We do not want to modify user provided hash
-          topics = topics.transform_keys(&:to_s)
-
           expanded = Hash.new { |h, k| h[k] = {} }
 
-          topics.map do |topic, details|
+          normalize_format(topics).map do |topic, details|
             if details.is_a?(Hash)
               details.each do |partition, offset|
                 expanded[topic][partition] = offset
@@ -66,6 +56,24 @@ module Karafka
         end
 
         private
+
+        # Input can be provided in multiple formats. Here we normalize it to one (hash).
+        #
+        # @param topics [Array, Hash, String] requested topics
+        # @return [Hash] normalized hash with topics data
+        def normalize_format(topics)
+          # Simplification for the single topic case
+          topics = [topics] if topics.is_a?(String)
+
+          # If we've got just array with topics, we need to convert that into a representation
+          # that we can expand with offsets
+          topics = topics.map { |name| [name, false] }.to_h if topics.is_a?(Array)
+          # We remap by creating new hash, just in case the hash came as the argument for this
+          # expanded. We do not want to modify user provided hash
+          topics = topics.transform_keys(&:to_s)
+
+          topics
+        end
 
         # List of topics with their partition information for expansion
         # We cache it so we do not have to run consecutive requests to obtain data about multiple

--- a/lib/karafka/pro/iterator/expander.rb
+++ b/lib/karafka/pro/iterator/expander.rb
@@ -70,9 +70,7 @@ module Karafka
           topics = topics.map { |name| [name, false] }.to_h if topics.is_a?(Array)
           # We remap by creating new hash, just in case the hash came as the argument for this
           # expanded. We do not want to modify user provided hash
-          topics = topics.transform_keys(&:to_s)
-
-          topics
+          topics.transform_keys(&:to_s)
         end
 
         # List of topics with their partition information for expansion

--- a/lib/karafka/pro/iterator/expander.rb
+++ b/lib/karafka/pro/iterator/expander.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    class Iterator
+      # There are various ways you can provide topics information for iterating.
+      #
+      # This mapper normalizes this data, resolves offsets and maps the time based offsets into
+      # appropriate once
+      #
+      # Following formats are accepted:
+      #
+      # - 'topic1' - just a string with one topic name
+      # - ['topic1', 'topic2'] - just the names
+      # - { 'topic1' => -100 } - names with negative lookup offset
+      # - { 'topic1' => { 0 => 5 } } - names with exact partitions offsets
+      # - { 'topic1' => { 0 => -5 }, 'topic2' => { 1 => 5 } } - with per partition negative offsets
+      # - { 'topic1' => 100 } - means we run all partitions from the offset 100
+      # - { 'topic1' => Time.now - 60 } - we run all partitions from the message from 60s ago
+      # - { 'topic1' => { 1 => Time.now - 60 } } - partition1 from message 60s ago
+      #
+      class Expander
+        # Expands topics to which we want to subscribe with partitions information in case this
+        # info is not provided.
+        #
+        # @param topics [Array, Hash, String] topics definitions
+        # @return [Hash] expanded and normalized requested topics and partitions data
+        def call(topics)
+          # Simplification for the single topic case
+          topics = [topics] if topics.is_a?(String)
+
+          # If we've got just array with topics, we need to convert that into a representation
+          # that we can expand with offsets
+          topics = topics.map { |name| [name, false] }.to_h if topics.is_a?(Array)
+          # We remap by creating new hash, just in case the hash came as the argument for this
+          # expanded. We do not want to modify user provided hash
+          topics = topics.transform_keys(&:to_s)
+
+          expanded = Hash.new { |h, k| h[k] = {} }
+
+          topics.map do |topic, details|
+            if details.is_a?(Hash)
+              details.each do |partition, offset|
+                expanded[topic][partition] = offset
+              end
+            else
+              partition_count(topic).times do |partition|
+                # If no offsets are provided, we just start from zero
+                expanded[topic][partition] = details || 0
+              end
+            end
+          end
+
+          expanded
+        end
+
+        private
+
+        # List of topics with their partition information for expansion
+        # We cache it so we do not have to run consecutive requests to obtain data about multiple
+        # topics
+        def topics
+          @topics ||= Admin.cluster_info.topics
+        end
+
+        # @param name [String] topic name
+        # @return [Integer] number of partitions of the topic we want to iterate over
+        def partition_count(name)
+          topics
+            .find { |topic| topic.fetch(:topic_name) == name }
+            .tap { |topic| topic || raise(Errors::TopicNotFoundError, name) }
+            .fetch(:partitions)
+            .count
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/iterator/tpl_builder.rb
+++ b/lib/karafka/pro/iterator/tpl_builder.rb
@@ -27,12 +27,15 @@ module Karafka
       # This builder resolves that and builds a tpl to which we can safely subscribe the way
       # we want it.
       class TplBuilder
+        # @param consumer [::Rdkafka::Consumer] consumer instance needed to talk with Kafka
+        # @param expanded_topics [Hash] hash with expanded and normalized topics data
         def initialize(consumer, expanded_topics)
           @consumer = consumer
           @expanded_topics = expanded_topics
           @mapped_topics = Hash.new { |h, k| h[k] = {} }
         end
 
+        # @return [Rdkafka::Consumer::TopicPartitionList] final tpl we can use to subscribe
         def call
           resolve_partitions_without_offsets
           resolve_partitions_with_exact_offsets

--- a/lib/karafka/pro/iterator/tpl_builder.rb
+++ b/lib/karafka/pro/iterator/tpl_builder.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    class Iterator
+      # Max time for a TPL request. We increase it to compensate for remote clusters latency
+      TPL_REQUEST_TIMEOUT = 2_000
+
+      private_constant :TPL_REQUEST_TIMEOUT
+
+      # Because we have various formats in which we can provide the offsets, before we can
+      # subscribe to them, there needs to be a bit of normalization.
+      #
+      # For some of the cases, we need to go to Kafka and get the real offsets or watermarks.
+      #
+      # This builder resolves that and builds a tpl to which we can safely subscribe the way
+      # we want it.
+      class TplBuilder
+        def initialize(consumer, expanded_topics)
+          @consumer = consumer
+          @expanded_topics = expanded_topics
+          @mapped_topics = Hash.new { |h, k| h[k] = {} }
+        end
+
+        def call
+          resolve_partitions_without_offsets
+          resolve_partitions_with_exact_offsets
+          resolve_partitions_with_negative_offsets
+          resolve_partitions_with_time_offsets
+
+          # Final tpl with all the data
+          tpl = Rdkafka::Consumer::TopicPartitionList.new
+
+          @mapped_topics.each do |name, partitions|
+            tpl.add_topic_and_partitions_with_offsets(name, partitions)
+          end
+
+          tpl
+        end
+
+        private
+
+        # First we expand on those partitions that do not have offsets defined.
+        # When we operate in case like this, we just start from beginning
+        def resolve_partitions_without_offsets
+          @expanded_topics.each do |name, partitions|
+            # We can here only about the case where we have partitions without offsets
+            next unless partitions.is_a?(Array) || partitions.is_a?(Range)
+
+            # When no offsets defined, we just start from zero
+            @mapped_topics[name] = partitions.map { |partition| [partition, 0] }.to_h
+          end
+        end
+
+        # If we get exact numeric offsets, we can just start from them without any extra work
+        def resolve_partitions_with_exact_offsets
+          @expanded_topics.each do |name, partitions|
+            next unless partitions.is_a?(Hash)
+
+            partitions.each do |partition, offset|
+              # Skip negative and time based offsets
+              next unless offset.is_a?(Integer) && offset >= 0
+
+              # Exact offsets can be used as they are
+              # No need for extra operations
+              @mapped_topics[name][partition] = offset
+            end
+          end
+        end
+
+        # If the offsets are negative, it means we want to fetch N last messages and we need to
+        # figure out the appropriate offsets
+        #
+        # We do it by getting the watermark offsets and just calculating it. This means that for
+        # heavily compacted topics, this may return less than the desired number but it is a
+        # limitation that is documented.
+        def resolve_partitions_with_negative_offsets
+          @expanded_topics.each do |name, partitions|
+            next unless partitions.is_a?(Hash)
+
+            partitions.each do |partition, offset|
+              # Care only about negative offsets (last n messages)
+              next unless offset.is_a?(Integer) && offset.negative?
+
+              _, high_watermark_offset = @consumer.query_watermark_offsets(name, partition)
+              # We add because this offset is negative
+              @mapped_topics[name][partition] = high_watermark_offset + offset
+            end
+          end
+        end
+
+        # For time based offsets we first need to aggregate them and request the proper offsets.
+        # We want to get all times in one go for all tpls defined with times, so we accumulate
+        # them here and we will make one sync request to kafka for all.
+        def resolve_partitions_with_time_offsets
+          time_tpl = Rdkafka::Consumer::TopicPartitionList.new
+
+          # First we need to collect the time based once
+          @expanded_topics.each do |name, partitions|
+            next unless partitions.is_a?(Hash)
+
+            time_based = {}
+
+            partitions.each do |partition, offset|
+              next unless offset.is_a?(Time)
+
+              time_based[partition] = offset
+            end
+
+            next if time_based.empty?
+
+            time_tpl.add_topic_and_partitions_with_offsets(name, time_based)
+          end
+
+          # If there were no time-based, no need to query Kafka
+          return if time_tpl.empty?
+
+          real_offsets = @consumer.offsets_for_times(time_tpl, TPL_REQUEST_TIMEOUT)
+
+          real_offsets.to_h.each do |name, results|
+            results.each do |result|
+              raise(Errors::InvalidTimeBasedOffsetError) unless result
+
+              @mapped_topics[name][result.partition] = result.offset
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/processing/coordinator.rb
+++ b/lib/karafka/pro/processing/coordinator.rb
@@ -49,9 +49,6 @@ module Karafka
         def start(messages)
           super
 
-          # When we start, there are no seeks, hence no user invoked seek as well
-          @manual_seek = false
-
           @collapser.refresh!(messages.first.offset)
 
           @filter.apply!(messages)
@@ -88,16 +85,6 @@ module Karafka
         # @return [Boolean] is the coordinated work finished or not
         def finished?
           @running_jobs.zero?
-        end
-
-        # Marks seek as manual for coordination purposes
-        def manual_seek
-          @manual_seek = true
-        end
-
-        # @return [Boolean] did a user invoke seek in the current operations scope
-        def manual_seek?
-          @manual_seek
         end
 
         # Runs synchronized code once for a collective of virtual partitions prior to work being

--- a/lib/karafka/pro/processing/coordinator.rb
+++ b/lib/karafka/pro/processing/coordinator.rb
@@ -49,6 +49,9 @@ module Karafka
         def start(messages)
           super
 
+          # When we start, there are no seeks, hence no user invoked seek as well
+          @manual_seek = false
+
           @collapser.refresh!(messages.first.offset)
 
           @filter.apply!(messages)
@@ -85,6 +88,16 @@ module Karafka
         # @return [Boolean] is the coordinated work finished or not
         def finished?
           @running_jobs.zero?
+        end
+
+        # Marks seek as manual for coordination purposes
+        def manual_seek
+          @manual_seek = true
+        end
+
+        # @return [Boolean] did a user invoke seek in the current operations scope
+        def manual_seek?
+          @manual_seek
         end
 
         # Runs synchronized code once for a collective of virtual partitions prior to work being

--- a/lib/karafka/pro/processing/filters_applier.rb
+++ b/lib/karafka/pro/processing/filters_applier.rb
@@ -81,6 +81,7 @@ module Karafka
         # The first message we do need to get next time we poll. We use the minimum not to jump
         # accidentally by over any.
         # @return [Karafka::Messages::Message, nil] cursor message or nil if none
+        # @note Cursor message can also return the offset in the time format
         def cursor
           return nil unless active?
 

--- a/lib/karafka/pro/processing/strategies/aj/dlq_ftr_lrj_mom.rb
+++ b/lib/karafka/pro/processing/strategies/aj/dlq_ftr_lrj_mom.rb
@@ -44,7 +44,9 @@ module Karafka
                   if coordinator.filtered? && !revoked?
                     handle_post_filtering
                   elsif !revoked?
-                    seek(coordinator.seek_offset)
+                    # no need to check for manual seek because AJ consumer is internal and
+                    # fully controlled by us
+                    seek(coordinator.seek_offset, false)
                     resume
                   else
                     resume

--- a/lib/karafka/pro/processing/strategies/aj/dlq_ftr_lrj_mom_vp.rb
+++ b/lib/karafka/pro/processing/strategies/aj/dlq_ftr_lrj_mom_vp.rb
@@ -50,7 +50,9 @@ module Karafka
                   if coordinator.filtered? && !revoked?
                     handle_post_filtering
                   elsif !revoked?
-                    seek(coordinator.seek_offset)
+                    # no need to check for manual seek because AJ consumer is internal and
+                    # fully controlled by us
+                    seek(coordinator.seek_offset, false)
                     resume
                   else
                     resume

--- a/lib/karafka/pro/processing/strategies/aj/dlq_lrj_mom.rb
+++ b/lib/karafka/pro/processing/strategies/aj/dlq_lrj_mom.rb
@@ -42,7 +42,9 @@ module Karafka
                 if coordinator.success?
                   coordinator.pause_tracker.reset
 
-                  seek(coordinator.seek_offset) unless revoked?
+                  # no need to check for manual seek because AJ consumer is internal and
+                  # fully controlled by us
+                  seek(coordinator.seek_offset, false) unless revoked?
 
                   resume
                 elsif coordinator.pause_tracker.attempt <= topic.dead_letter_queue.max_retries

--- a/lib/karafka/pro/processing/strategies/aj/dlq_lrj_mom_vp.rb
+++ b/lib/karafka/pro/processing/strategies/aj/dlq_lrj_mom_vp.rb
@@ -46,7 +46,9 @@ module Karafka
                   # Since we have VP here we do not commit intermediate offsets and need to commit
                   # them here. We do commit in collapsed mode but this is generalized.
                   mark_as_consumed(last_group_message) unless revoked?
-                  seek(coordinator.seek_offset) unless revoked?
+                  # no need to check for manual seek because AJ consumer is internal and
+                  # fully controlled by us
+                  seek(coordinator.seek_offset, false) unless revoked?
 
                   resume
                 elsif coordinator.pause_tracker.attempt <= topic.dead_letter_queue.max_retries

--- a/lib/karafka/pro/processing/strategies/aj/ftr_lrj_mom_vp.rb
+++ b/lib/karafka/pro/processing/strategies/aj/ftr_lrj_mom_vp.rb
@@ -46,7 +46,9 @@ module Karafka
                   if coordinator.filtered? && !revoked?
                     handle_post_filtering
                   elsif !revoked?
-                    seek(coordinator.seek_offset)
+                    # no need to check for manual seek because AJ consumer is internal and
+                    # fully controlled by us
+                    seek(coordinator.seek_offset, false)
                     resume
                   else
                     resume

--- a/lib/karafka/pro/processing/strategies/aj/lrj_mom_vp.rb
+++ b/lib/karafka/pro/processing/strategies/aj/lrj_mom_vp.rb
@@ -48,7 +48,10 @@ module Karafka
                   coordinator.pause_tracker.reset
 
                   mark_as_consumed(last_group_message) unless revoked?
-                  seek(coordinator.seek_offset) unless revoked?
+
+                  # no need to check for manual seek because AJ consumer is internal and
+                  # fully controlled by us
+                  seek(coordinator.seek_offset, false) unless revoked?
 
                   resume
                 else

--- a/lib/karafka/pro/processing/strategies/dlq/ftr_lrj.rb
+++ b/lib/karafka/pro/processing/strategies/dlq/ftr_lrj.rb
@@ -47,8 +47,8 @@ module Karafka
 
                   if coordinator.filtered? && !revoked?
                     handle_post_filtering
-                  elsif !revoked?
-                    seek(coordinator.seek_offset)
+                  elsif !revoked? && !coordinator.manual_seek?
+                    seek(coordinator.seek_offset, false)
                     resume
                   else
                     resume

--- a/lib/karafka/pro/processing/strategies/dlq/ftr_lrj_mom.rb
+++ b/lib/karafka/pro/processing/strategies/dlq/ftr_lrj_mom.rb
@@ -42,8 +42,8 @@ module Karafka
 
                   if coordinator.filtered? && !revoked?
                     handle_post_filtering
-                  elsif !revoked?
-                    seek(last_group_message.offset + 1)
+                  elsif !revoked? && !coordinator.manual_seek?
+                    seek(last_group_message.offset + 1, false)
                     resume
                   else
                     resume

--- a/lib/karafka/pro/processing/strategies/dlq/lrj.rb
+++ b/lib/karafka/pro/processing/strategies/dlq/lrj.rb
@@ -38,7 +38,8 @@ module Karafka
                   return if coordinator.manual_pause?
 
                   mark_as_consumed(last_group_message) unless revoked?
-                  seek(coordinator.seek_offset) unless revoked?
+                  # We should not overwrite user manual seel request with our seek
+                  seek(coordinator.seek_offset, false) unless revoked? || coordinator.manual_seek?
 
                   resume
                 elsif coordinator.pause_tracker.attempt <= topic.dead_letter_queue.max_retries

--- a/lib/karafka/pro/processing/strategies/dlq/lrj_mom.rb
+++ b/lib/karafka/pro/processing/strategies/dlq/lrj_mom.rb
@@ -37,7 +37,9 @@ module Karafka
 
                   return if coordinator.manual_pause?
 
-                  seek(last_group_message.offset + 1, false) unless revoked? || coordinator.manual_seek?
+                  unless revoked? || coordinator.manual_seek?
+                    seek(last_group_message.offset + 1, false)
+                  end
 
                   resume
                 elsif coordinator.pause_tracker.attempt <= topic.dead_letter_queue.max_retries

--- a/lib/karafka/pro/processing/strategies/dlq/lrj_mom.rb
+++ b/lib/karafka/pro/processing/strategies/dlq/lrj_mom.rb
@@ -37,7 +37,7 @@ module Karafka
 
                   return if coordinator.manual_pause?
 
-                  seek(last_group_message.offset + 1) unless revoked?
+                  seek(last_group_message.offset + 1, false) unless revoked? || coordinator.manual_seek?
 
                   resume
                 elsif coordinator.pause_tracker.attempt <= topic.dead_letter_queue.max_retries

--- a/lib/karafka/pro/processing/strategies/ftr/default.rb
+++ b/lib/karafka/pro/processing/strategies/ftr/default.rb
@@ -71,7 +71,8 @@ module Karafka
                 nil
               when :seek
                 # User direct actions take priority over automatic operations
-                return nil if coordinator.manual_seek?
+                # If we've already seeked we can just resume operations, nothing extra needed
+                return resume if coordinator.manual_seek?
 
                 throttle_message = filter.cursor
 

--- a/lib/karafka/pro/processing/strategies/ftr/default.rb
+++ b/lib/karafka/pro/processing/strategies/ftr/default.rb
@@ -70,6 +70,9 @@ module Karafka
               when :skip
                 nil
               when :seek
+                # User direct actions take priority over automatic operations
+                return nil if coordinator.manual_seek?
+
                 throttle_message = filter.cursor
 
                 Karafka.monitor.instrument(
@@ -77,11 +80,14 @@ module Karafka
                   caller: self,
                   message: throttle_message
                 ) do
-                  seek(throttle_message.offset)
+                  seek(throttle_message.offset, false)
                 end
 
                 resume
               when :pause
+                # User direct actions take priority over automatic operations
+                return nil if coordinator.manual_pause?
+
                 throttle_message = filter.cursor
 
                 Karafka.monitor.instrument(

--- a/lib/karafka/pro/processing/strategies/lrj/default.rb
+++ b/lib/karafka/pro/processing/strategies/lrj/default.rb
@@ -53,7 +53,7 @@ module Karafka
                   return if coordinator.manual_pause?
 
                   mark_as_consumed(last_group_message) unless revoked?
-                  seek(coordinator.seek_offset) unless revoked?
+                  seek(coordinator.seek_offset, false) unless revoked? || coordinator.manual_seek?
 
                   resume
                 else

--- a/lib/karafka/pro/processing/strategies/lrj/ftr.rb
+++ b/lib/karafka/pro/processing/strategies/lrj/ftr.rb
@@ -45,10 +45,10 @@ module Karafka
                   # If still not revoked and was throttled, we need to apply throttling logic
                   if coordinator.filtered? && !revoked?
                     handle_post_filtering
-                  elsif !revoked?
+                  elsif !revoked? && !coordinator.manual_seek?
                     # If not revoked and not throttled, we move to where we were suppose to and
                     # resume
-                    seek(coordinator.seek_offset)
+                    seek(coordinator.seek_offset, false)
                     resume
                   else
                     resume

--- a/lib/karafka/pro/processing/strategies/lrj/ftr_mom.rb
+++ b/lib/karafka/pro/processing/strategies/lrj/ftr_mom.rb
@@ -43,10 +43,10 @@ module Karafka
                   # If still not revoked and was throttled, we need to apply filtering logic
                   if coordinator.filtered? && !revoked?
                     handle_post_filtering
-                  elsif !revoked?
+                  elsif !revoked? && !coordinator.manual_seek?
                     # If not revoked and not throttled, we move to where we were suppose to and
                     # resume
-                    seek(last_group_message.offset + 1)
+                    seek(last_group_message.offset + 1, false)
                     resume
                   else
                     resume

--- a/lib/karafka/pro/processing/strategies/lrj/mom.rb
+++ b/lib/karafka/pro/processing/strategies/lrj/mom.rb
@@ -52,7 +52,9 @@ module Karafka
 
                   return if coordinator.manual_pause?
 
-                  seek(last_group_message.offset + 1, false) unless revoked? || coordinator.manual_seek?
+                  unless revoked? || coordinator.manual_seek?
+                    seek(last_group_message.offset + 1, false)
+                  end
 
                   resume
                 else

--- a/lib/karafka/pro/processing/strategies/lrj/mom.rb
+++ b/lib/karafka/pro/processing/strategies/lrj/mom.rb
@@ -52,7 +52,7 @@ module Karafka
 
                   return if coordinator.manual_pause?
 
-                  seek(last_group_message.offset + 1) unless revoked?
+                  seek(last_group_message.offset + 1, false) unless revoked? || coordinator.manual_seek?
 
                   resume
                 else

--- a/lib/karafka/pro/processing/virtual_offset_manager.rb
+++ b/lib/karafka/pro/processing/virtual_offset_manager.rb
@@ -118,7 +118,7 @@ module Karafka
 
         # @return [Messages::Seek] markable message for real offset marking
         def markable
-          raise Errors::InvalidRealOffsetUsage unless markable?
+          raise Errors::InvalidRealOffsetUsageError unless markable?
 
           Messages::Seek.new(
             @topic,

--- a/lib/karafka/processing/coordinator.rb
+++ b/lib/karafka/processing/coordinator.rb
@@ -42,6 +42,9 @@ module Karafka
         # When starting to run, no pause is expected and no manual pause as well
         @manual_pause = false
 
+        # No user invoked seeks on a new run
+        @manual_seek = false
+
         # We set it on the first encounter and never again, because then the offset setting
         # should be up to the consumers logic (our or the end user)
         # Seek offset needs to be always initialized as for case where manual offset management

--- a/lib/karafka/processing/coordinator.rb
+++ b/lib/karafka/processing/coordinator.rb
@@ -23,6 +23,7 @@ module Karafka
         @consumptions = {}
         @running_jobs = 0
         @manual_pause = false
+        @manual_seek = false
         @mutex = Mutex.new
         @marked = false
         @failure = false
@@ -146,6 +147,16 @@ module Karafka
       # @return [Boolean] are we in a pause that was initiated by the user
       def manual_pause?
         @pause_tracker.paused? && @manual_pause
+      end
+
+      # Marks seek as manual for coordination purposes
+      def manual_seek
+        @manual_seek = true
+      end
+
+      # @return [Boolean] did a user invoke seek in the current operations scope
+      def manual_seek?
+        @manual_seek
       end
 
       # Allows to run synchronized (locked) code that can operate in between virtual partitions

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_vp/time_limit_check_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_vp/time_limit_check_spec.rb
@@ -39,4 +39,6 @@ start_karafka_and_wait_until do
   sleep(15)
 end
 
-assert_equal elements[0..1], DT[0]
+# Since it runs with VPs, we need to sort to make sure it matches as the messages can
+# be distributed into independent VPs and run not in dispatch order
+assert_equal elements[0..1].sort, DT[0].sort

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj/with_manual_seek_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj/with_manual_seek_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Manual seek per user request should super-seed the automatic LRJ movement. Configured DLQ should
+# have nothing to do with this
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 10
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[0] << messages.first.offset
+
+    seek(0)
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    long_running_job true
+    dead_letter_queue topic: DT.topics[1]
+  end
+end
+
+produce_many(DT.topics[0], DT.uuids(10))
+
+start_karafka_and_wait_until do
+  DT[0].size >= 10
+end
+
+assert_equal [0], DT[0].uniq

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/with_manual_seek_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/with_manual_seek_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Manual seek per user request should super-seed the automatic LRJ movement
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 10
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[0] << messages.first.offset
+
+    seek(0)
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    long_running_job true
+    manual_offset_management
+    dead_letter_queue topic: DT.topics[1]
+  end
+end
+
+produce_many(DT.topics[0], DT.uuids(10))
+
+start_karafka_and_wait_until do
+  DT[0].size >= 10
+end
+
+assert_equal [0], DT[0].uniq

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/with_non_recoverable_slow_no_marking_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/with_non_recoverable_slow_no_marking_error_spec.rb
@@ -14,6 +14,8 @@ end
 
 class Consumer < Karafka::BaseConsumer
   def consume
+    seek(0) if messages.count < 2
+
     @sleep ||= 20
     @sleep -= 5
     @sleep = 1 if @sleep < 1

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/with_non_recoverable_slow_no_marking_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/with_non_recoverable_slow_no_marking_error_spec.rb
@@ -14,7 +14,7 @@ end
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    seek(0) if messages.count < 2
+    return seek(0) if messages.count < 2
 
     @sleep ||= 20
     @sleep -= 5

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/with_non_recoverable_slow_no_marking_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/with_non_recoverable_slow_no_marking_error_spec.rb
@@ -53,7 +53,7 @@ draw_routes do
   end
 end
 
-produce_many(DT.topics[0], DT.uuids(100))
+produce_many(DT.topics[0], DT.uuids(20))
 
 start_karafka_and_wait_until do
   DT.key?(1) && DT[0].uniq.size >= 3

--- a/spec/integrations/pro/consumption/strategies/ftr/with_manual_seek_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/with_manual_seek_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Manual seek per user request should super-seed the filters.
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 10
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[0] << messages.first.offset
+
+    seek(3)
+  end
+end
+
+class Filter
+  def apply!(messages)
+    @applied = true
+
+    messages
+  end
+
+  def action
+    :seek
+  end
+
+  def applied?
+    true
+  end
+
+  def timeout
+    0
+  end
+
+  def cursor
+    raise
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    filter(->(*) { Filter.new })
+  end
+end
+
+produce_many(DT.topics[0], DT.uuids(10))
+
+start_karafka_and_wait_until do
+  DT[0].size >= 10
+end
+
+assert_equal [0, 3], DT[0].uniq

--- a/spec/integrations/pro/consumption/strategies/lrj/default/with_manual_seek_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/default/with_manual_seek_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Manual seek per user request should super-seed the automatic LRJ movement.
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 10
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[0] << messages.first.offset
+
+    seek(0)
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    long_running_job true
+  end
+end
+
+produce_many(DT.topics[0], DT.uuids(10))
+
+start_karafka_and_wait_until do
+  DT[0].size >= 10
+end
+
+assert_equal [0], DT[0].uniq

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr/with_manual_seek_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr/with_manual_seek_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Manual seek per user request should super-seed the automatic LRJ movement.
+# Filter that would require seek, should use the user requested offset over its own
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 10
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[0] << messages.first.offset
+
+    seek(0)
+  end
+end
+
+class Filter
+  def apply!(messages)
+    @applied = true
+
+    messages
+  end
+
+  def action
+    :seek
+  end
+
+  def applied?
+    true
+  end
+
+  def timeout
+    0
+  end
+
+  def cursor
+    raise
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    long_running_job true
+    filter(->(*) { Filter.new })
+  end
+end
+
+produce_many(DT.topics[0], DT.uuids(10))
+
+start_karafka_and_wait_until do
+  DT[0].size >= 10
+end
+
+assert_equal [0], DT[0].uniq

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/with_manual_seek_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/with_manual_seek_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Manual seek per user request should super-seed the automatic LRJ movement.
+# Filter that would require seek, should use the user requested offset over its own
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 10
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[0] << messages.first.offset
+
+    seek(0)
+  end
+end
+
+class Filter
+  def apply!(messages)
+    @applied = true
+
+    messages
+  end
+
+  def action
+    :seek
+  end
+
+  def applied?
+    true
+  end
+
+  def timeout
+    0
+  end
+
+  def cursor
+    raise
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    long_running_job true
+    manual_offset_management true
+    filter(->(*) { Filter.new })
+  end
+end
+
+produce_many(DT.topics[0], DT.uuids(10))
+
+start_karafka_and_wait_until do
+  DT[0].size >= 10
+end
+
+assert_equal [0], DT[0].uniq

--- a/spec/integrations/pro/consumption/strategies/lrj/mom/with_manual_seek_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/mom/with_manual_seek_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Manual seek per user request should super-seed the automatic LRJ movement.
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 10
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[0] << messages.first.offset
+
+    seek(3)
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    long_running_job true
+    manual_offset_management true
+  end
+end
+
+produce_many(DT.topics[0], DT.uuids(10))
+
+start_karafka_and_wait_until do
+  DT[0].size >= 10
+end
+
+assert_equal [0, 3], DT[0].uniq

--- a/spec/integrations/pro/iterator/future_time_lookup_spec.rb
+++ b/spec/integrations/pro/iterator/future_time_lookup_spec.rb
@@ -16,8 +16,5 @@ iterator = Karafka::Pro::Iterator.new(
   { DT.topic => { 0 => Time.now + 60 } }
 )
 
-iterator.each do |message|
-  raise
-end
-
 # No checks needed as in case we would get something older, it will raise
+iterator.each { raise }

--- a/spec/integrations/pro/iterator/future_time_lookup_spec.rb
+++ b/spec/integrations/pro/iterator/future_time_lookup_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# When we want to get something from the future and there is nothing, we should just stop
+
+setup_karafka
+
+draw_routes do
+  topic DT.topic do
+    active false
+  end
+end
+
+produce(DT.topic, '1')
+
+iterator = Karafka::Pro::Iterator.new(
+  { DT.topic => { 0 => Time.now + 60 } }
+)
+
+iterator.each do |message|
+  raise
+end
+
+# No checks needed as in case we would get something older, it will raise

--- a/spec/integrations/pro/iterator/with_many_partitions_from_different_times_spec.rb
+++ b/spec/integrations/pro/iterator/with_many_partitions_from_different_times_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# When iterating over different topics/partitions with different times, each should start from
+# the expected one.
+
+setup_karafka
+
+draw_routes do
+  topic DT.topic do
+    config(partitions: 5)
+    active false
+  end
+end
+
+start_times = {}
+
+10.times do |index|
+  start_times[index] = Time.now
+
+  5.times do |partition_nr|
+    produce(DT.topic, DT.uuid, partition: partition_nr)
+  end
+
+  sleep(0.5)
+end
+
+partitioned_data = Hash.new { |h, v| h[v] = [] }
+
+partitions = start_times.map { |partition, time| [partition, time] }.first(5).to_h
+
+iterator = Karafka::Pro::Iterator.new({ DT.topic => partitions })
+
+iterator.each do |message|
+  partitioned_data[message.partition] << message.offset
+end
+
+partitioned_data.each do |partition, data|
+  assert_equal (partition..9).to_a, data
+end

--- a/spec/integrations/pro/iterator/with_many_partitions_from_same_time.rb
+++ b/spec/integrations/pro/iterator/with_many_partitions_from_same_time.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# When iterating over the topic from the same time on all partitions, we should start from the
+# expected on all and finish accordingly
+
+setup_karafka
+
+draw_routes do
+  topic DT.topic do
+    config(partitions: 5)
+    active false
+  end
+end
+
+partitioned_elements = {}
+
+start_time = nil
+
+10.times.with_index do |partition, index|
+  start_time = Time.now if index == 5
+
+  5.times do |partition|
+    produce(DT.topic, DT.uuid, partition: partition)
+  end
+
+  sleep(0.5)
+end
+
+partitioned_data = Hash.new { |h, v| h[v] = [] }
+
+iterator = Karafka::Pro::Iterator.new({DT.topic => start_time})
+
+iterator.each do |message, internal_iterator|
+  partitioned_data[message.partition] << message.offset
+end
+
+partitioned_data.each do |_, data|
+  assert_equal (5..9).to_a, data
+end

--- a/spec/integrations/pro/iterator/with_many_partitions_from_same_time_spec.rb
+++ b/spec/integrations/pro/iterator/with_many_partitions_from_same_time_spec.rb
@@ -12,15 +12,13 @@ draw_routes do
   end
 end
 
-partitioned_elements = {}
-
 start_time = nil
 
-10.times.with_index do |partition, index|
+10.times do |index|
   start_time = Time.now if index == 5
 
-  5.times do |partition|
-    produce(DT.topic, DT.uuid, partition: partition)
+  5.times do |partition_nr|
+    produce(DT.topic, DT.uuid, partition: partition_nr)
   end
 
   sleep(0.5)
@@ -28,9 +26,9 @@ end
 
 partitioned_data = Hash.new { |h, v| h[v] = [] }
 
-iterator = Karafka::Pro::Iterator.new({DT.topic => start_time})
+iterator = Karafka::Pro::Iterator.new({ DT.topic => start_time })
 
-iterator.each do |message, internal_iterator|
+iterator.each do |message|
   partitioned_data[message.partition] << message.offset
 end
 

--- a/spec/integrations/pro/iterator/with_many_partitions_from_the_same_offset_spec.rb
+++ b/spec/integrations/pro/iterator/with_many_partitions_from_the_same_offset_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# When iterating over the topic from the same offset on all partitions, we should start from the
+# expected on all and finish accordingly
+
+setup_karafka
+
+draw_routes do
+  topic DT.topic do
+    config(partitions: 10)
+    active false
+  end
+end
+
+partitioned_elements = {}
+
+10.times do |partition|
+  elements = DT.uuids(20).map { |data| { value: data }.to_json }
+  produce_many(DT.topic, elements, partition: partition)
+  partitioned_elements[partition] = elements
+end
+
+partitioned_data = Hash.new { |h, v| h[v] = [] }
+
+iterator = Karafka::Pro::Iterator.new({DT.topic => 10})
+
+iterator.each do |message, internal_iterator|
+  partitioned_data[message.partition] << message.offset
+end
+
+partitioned_data.each do |_, data|
+  assert_equal (10..19).to_a, data
+end

--- a/spec/integrations/pro/iterator/with_many_partitions_from_the_same_offset_spec.rb
+++ b/spec/integrations/pro/iterator/with_many_partitions_from_the_same_offset_spec.rb
@@ -22,9 +22,9 @@ end
 
 partitioned_data = Hash.new { |h, v| h[v] = [] }
 
-iterator = Karafka::Pro::Iterator.new({DT.topic => 10})
+iterator = Karafka::Pro::Iterator.new({ DT.topic => 10 })
 
-iterator.each do |message, internal_iterator|
+iterator.each do |message|
   partitioned_data[message.partition] << message.offset
 end
 

--- a/spec/integrations/pro/rebalancing/saturated_execution_skip_spec.rb
+++ b/spec/integrations/pro/rebalancing/saturated_execution_skip_spec.rb
@@ -18,7 +18,7 @@ class Consumer < Karafka::BaseConsumer
 
     DT[:executed] << messages.metadata.partition
 
-    sleep(11)
+    sleep(15)
   end
 
   def revoked

--- a/spec/integrations/seek/seek_to_non_existing_future_spec.rb
+++ b/spec/integrations/seek/seek_to_non_existing_future_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# When we seek to a future where there are no offsets, we should seek to the first not yet
+# produced message and get it
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    seek(Time.now + 120)
+
+    DT[:offsets] << messages.first.offset
+
+    # seek is async, so if we would produce too fast, we would actually skip this
+    # message is it would not be considered latest
+    sleep(2)
+
+    produce(DT.topic, DT.uuids(1).first)
+  end
+end
+
+draw_routes(Consumer)
+
+# We start with one so we have a way to seek
+produce(DT.topic, DT.uuids(1).first)
+
+start_karafka_and_wait_until do
+  DT[:offsets].size >= 5
+end
+
+assert_equal (0..4).to_a, DT[:offsets][0..4]

--- a/spec/integrations/seek/seek_to_time_before_start_spec.rb
+++ b/spec/integrations/seek/seek_to_time_before_start_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# If we seek to a long ago, before even topic was created, we should start from beginning
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    if @after_seek
+      # Process data only after the offset seek has been sent
+      messages.each do |message|
+        DT[message.metadata.partition] << message.raw_payload
+      end
+    else
+      seek(Time.now - 60 * 5)
+      @after_seek = true
+    end
+  end
+end
+
+draw_routes(Consumer)
+
+elements = DT.uuids(20)
+produce_many(DT.topic, elements)
+
+start_karafka_and_wait_until do
+  DT[0].size >= 10
+end
+
+assert_equal elements, DT[0]

--- a/spec/integrations/seek/seek_with_time_spec.rb
+++ b/spec/integrations/seek/seek_with_time_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Karafka should be able to easily consume from a given offset based on the time of the event and
+# not the offset numeric value.
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    if @after_seek
+      # Process data only after the offset seek has been sent
+      messages.each do |message|
+        DT[message.metadata.partition] << message.raw_payload
+      end
+    else
+      seek(DT[:starting_time])
+      @after_seek = true
+    end
+  end
+end
+
+draw_routes(Consumer)
+
+expected = []
+
+DT.uuids(12).each_with_index do |uuid, index|
+  DT[:starting_time] = Time.now if index == 10
+
+  expected << uuid if DT.key?(:starting_time)
+
+  produce(DT.topic, uuid)
+
+  # Sleep between messages so we can go to a proper time
+  sleep(0.5)
+end
+
+start_karafka_and_wait_until do
+  DT[0].size >= 2
+end
+
+assert_equal expected, DT[0]

--- a/spec/lib/karafka/errors_spec.rb
+++ b/spec/lib/karafka/errors_spec.rb
@@ -43,8 +43,14 @@ RSpec.describe_current do
     specify { expect(error).to be < described_class::BaseError }
   end
 
-  describe 'InvalidRealOffsetUsage' do
-    subject(:error) { described_class::InvalidRealOffsetUsage }
+  describe 'InvalidRealOffsetUsageError' do
+    subject(:error) { described_class::InvalidRealOffsetUsageError }
+
+    specify { expect(error).to be < described_class::BaseError }
+  end
+
+  describe 'InvalidTimeBasedOffsetError' do
+    subject(:error) { described_class::InvalidTimeBasedOffsetError }
 
     specify { expect(error).to be < described_class::BaseError }
   end

--- a/spec/lib/karafka/pro/iterator/expander_spec.rb
+++ b/spec/lib/karafka/pro/iterator/expander_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:expand) { described_class.new.call(topics) }
+
+  context 'when trying to expand on a non-existing topic' do
+    let(:topics) { 'topic' }
+
+    it { expect { expand }.to raise_error(Karafka::Errors::TopicNotFoundError) }
+  end
+
+  context 'when expanding on a full name' do
+    let(:topics) { SecureRandom.uuid }
+
+    before { Karafka::Admin.create_topic(topics, 2, 1) }
+
+    it { expect(expand).to eq({ topics => { 0 => 0, 1 => 0 } }) }
+  end
+
+  context 'when expanding on full names' do
+    let(:topics) { [SecureRandom.uuid, SecureRandom.uuid] }
+
+    before { topics.each { |topic| Karafka::Admin.create_topic(topic, 2, 1) } }
+
+    it 'expect to expand them all' do
+      expect(expand).to eq(
+        {
+          topics[0] => { 0 => 0, 1 => 0 },
+          topics[1] => { 0 => 0, 1 => 0 }
+        }
+      )
+    end
+  end
+
+  context 'when expanding on a full topic with given offset' do
+    let(:topics) { { SecureRandom.uuid => 100 } }
+
+    before { Karafka::Admin.create_topic(topics.keys.first, 2, 1) }
+
+    it { expect(expand).to eq({ topics.keys.first => { 0 => 100, 1 => 100 } }) }
+  end
+
+  # The negative offset lookup is left for integrations due to its nature
+
+  context 'when expanding on partitions with exact offsets' do
+    let(:topics) { { 'topic1' => { 0 => 5, 5 => 10 } } }
+
+    it { expect(expand).to eq('topic1' => topics['topic1']) }
+  end
+
+  context 'when expanding on a full topic with a time' do
+    let(:time) { Time.now }
+    let(:topics) { { SecureRandom.uuid => time } }
+
+    before { Karafka::Admin.create_topic(topics.keys.first, 2, 1) }
+
+    it { expect(expand).to eq({ topics.keys.first => { 0 => time, 1 => time } }) }
+  end
+
+  context 'when expanding on partitions with times' do
+    let(:time1) { Time.now }
+    let(:time2) { Time.now + 60 }
+    let(:topics) { { 'topic1' => { 0 => time1, 5 => time2 } } }
+
+    it { expect(expand).to eq('topic1' => topics['topic1']) }
+  end
+end

--- a/spec/lib/karafka/pro/iterator/tpl_builder_spec.rb
+++ b/spec/lib/karafka/pro/iterator/tpl_builder_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  pending
+end

--- a/spec/lib/karafka/pro/processing/virtual_offset_manager_spec.rb
+++ b/spec/lib/karafka/pro/processing/virtual_offset_manager_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe_current do
     before { manager.register(range) }
 
     it { expect(manager.markable?).to eq(false) }
-    it { expect { manager.markable }.to raise_error(Karafka::Errors::InvalidRealOffsetUsage) }
+    it { expect { manager.markable }.to raise_error(Karafka::Errors::InvalidRealOffsetUsageError) }
     it { expect(manager.marked).to eq([]) }
   end
 
@@ -133,7 +133,7 @@ RSpec.describe_current do
     end
 
     it { expect(manager.markable?).to eq(false) }
-    it { expect { manager.markable }.to raise_error(Karafka::Errors::InvalidRealOffsetUsage) }
+    it { expect { manager.markable }.to raise_error(Karafka::Errors::InvalidRealOffsetUsageError) }
     it { expect(manager.marked).to eq([1, 3, 5, 7, 9]) }
   end
 
@@ -162,7 +162,7 @@ RSpec.describe_current do
     end
 
     it { expect(manager.markable?).to eq(false) }
-    it { expect { manager.markable }.to raise_error(Karafka::Errors::InvalidRealOffsetUsage) }
+    it { expect { manager.markable }.to raise_error(Karafka::Errors::InvalidRealOffsetUsageError) }
     it { expect(manager.marked).to eq([1, 3, 5, 7, 9, 11, 13]) }
   end
 
@@ -203,7 +203,7 @@ RSpec.describe_current do
     end
 
     it { expect(manager.markable?).to eq(false) }
-    it { expect { manager.markable }.to raise_error(Karafka::Errors::InvalidRealOffsetUsage) }
+    it { expect { manager.markable }.to raise_error(Karafka::Errors::InvalidRealOffsetUsageError) }
     it { expect(manager.marked).to eq([7, 8, 9, 10]) }
   end
 end

--- a/spec/lib/karafka/processing/coordinator_spec.rb
+++ b/spec/lib/karafka/processing/coordinator_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe_current do
     it { expect(coordinator.success?).to eq(true) }
     it { expect(coordinator.revoked?).to eq(false) }
     it { expect(coordinator.manual_pause?).to eq(false) }
+    it { expect(coordinator.manual_seek?).to eq(false) }
 
     context 'when previous coordinator usage had a manual pause' do
       before do
@@ -29,6 +30,17 @@ RSpec.describe_current do
       it { expect(coordinator.success?).to eq(true) }
       it { expect(coordinator.revoked?).to eq(false) }
       it { expect(coordinator.manual_pause?).to eq(false) }
+    end
+
+    context 'when previous coordinator usage had a manual seek' do
+      before do
+        coordinator.manual_seek
+        coordinator.start([message])
+      end
+
+      it { expect(coordinator.success?).to eq(true) }
+      it { expect(coordinator.revoked?).to eq(false) }
+      it { expect(coordinator.manual_seek?).to eq(false) }
     end
   end
 
@@ -149,6 +161,18 @@ RSpec.describe_current do
       end
 
       it { expect(coordinator.manual_pause?).to eq(true) }
+    end
+  end
+
+  describe '#manual_seek and manual_seek?' do
+    context 'when there is no seek' do
+      it { expect(coordinator.manual_seek?).to eq(false) }
+    end
+
+    context 'when there is a manual seek' do
+      before { coordinator.manual_seek }
+
+      it { expect(coordinator.manual_seek?).to eq(true) }
     end
   end
 end

--- a/spec/support/data_collector.rb
+++ b/spec/support/data_collector.rb
@@ -63,7 +63,12 @@ class DataCollector
     # @param amount [Integer] number of uuids we want to get
     # @return [Array<String>] array with uuids
     def uuids(amount)
-      Array.new(amount) { SecureRandom.uuid }
+      Array.new(amount) { uuid }
+    end
+
+    # @return [String] single uuid
+    def uuid
+      SecureRandom.uuid
     end
 
     # Removes all the data from the collector


### PR DESCRIPTION
- [x] consumer seek support
- [x] admin `read_topic` time based offset support
- [x] iterator API time based support

additionally fixes a bug where a user triggered `#seek` under LRJ would be super-seeded by automatic action.

close https://github.com/karafka/karafka/issues/1429
