### PR TITLE
Negative offset iterator lookup fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Karafka framework changelog
 
+## 2.1.7 (Unreleased)
+- [Fix] Fix a case where Iterator with per partition offsets with negative lookups would go below the number of available messages.
+- [Fix] Remove unused constant from Admin module.
+
 ## 2.1.6 (2023-06-29)
 - [Improvement] Provide time support for iterator
 - [Improvement] Provide time support for admin `#read_topic`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka (2.1.6)
+    karafka (2.1.7)
       karafka-core (>= 2.1.1, < 2.2.0)
       thor (>= 0.20)
       waterdrop (>= 2.6.2, < 3.0.0)

--- a/lib/karafka/admin.rb
+++ b/lib/karafka/admin.rb
@@ -9,11 +9,6 @@ module Karafka
   # @note It always uses the primary defined cluster and does not support multi-cluster work.
   #   If you need this, just replace the cluster info for the time you use this
   module Admin
-    # A fake admin topic representation that we use for messages fetched using this API
-    # We cannot use the topics directly because we may want to request data from topics that we
-    # do not have in the routing
-    Topic = Struct.new(:name, :deserializer)
-
     # We wait only for this amount of time before raising error as we intercept this error and
     # retry after checking that the operation was finished or failed using external factor.
     MAX_WAIT_TIMEOUT = 1
@@ -37,7 +32,7 @@ module Karafka
       'enable.auto.commit': false
     }.freeze
 
-    private_constant :Topic, :CONFIG_DEFAULTS, :MAX_WAIT_TIMEOUT, :TPL_REQUEST_TIMEOUT,
+    private_constant :CONFIG_DEFAULTS, :MAX_WAIT_TIMEOUT, :TPL_REQUEST_TIMEOUT,
                      :MAX_ATTEMPTS
 
     class << self

--- a/lib/karafka/pro/iterator/tpl_builder.rb
+++ b/lib/karafka/pro/iterator/tpl_builder.rb
@@ -96,9 +96,10 @@ module Karafka
               # Care only about negative offsets (last n messages)
               next unless offset.is_a?(Integer) && offset.negative?
 
-              _, high_watermark_offset = @consumer.query_watermark_offsets(name, partition)
+              low_offset, high_offset = @consumer.query_watermark_offsets(name, partition)
+
               # We add because this offset is negative
-              @mapped_topics[name][partition] = high_watermark_offset + offset
+              @mapped_topics[name][partition] = [high_offset + offset, low_offset].max
             end
           end
         end

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '2.1.6'
+  VERSION = '2.1.7'
 end

--- a/spec/integrations/pro/iterator/with_negative_bigger_than_available_data_spec.rb
+++ b/spec/integrations/pro/iterator/with_negative_bigger_than_available_data_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# When we request more data with negative lookup than there is in the partition, we should pick
+# as much as there is and no more.
+
+setup_karafka
+
+draw_routes do
+  topic DT.topic do
+    active false
+  end
+end
+
+2.times { produce(DT.topic, '1') }
+
+iterator = Karafka::Pro::Iterator.new(
+  { DT.topic => { 0 => -100 } }
+)
+
+data = []
+
+iterator.each { |message| data << message.offset }
+
+assert_equal [0, 1], data


### PR DESCRIPTION
This PR fixes an issue where upon negative offset selection (backwards lookup) we would compute an offset below the low watermark.