### PR TITLE
stabilize spec

### DIFF
--- a/spec/integrations/pro/consumption/strategies/vp/with_pause_on_collapsed_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/with_pause_on_collapsed_spec.rb
@@ -5,6 +5,10 @@
 
 setup_karafka(allow_errors: true) do |config|
   config.concurrency = 10
+  # We need to have less than 5 messages polled at once because if we poll more, then in case
+  # all are fetched in one go (5) and error is raised, post collapse message recording will
+  # automatically stop processing too fast
+  config.max_messages = 3
 end
 
 class Consumer < Karafka::BaseConsumer


### PR DESCRIPTION
This PR tackles an edge case that rarely occurs where all messages were shipped in one go, so the karafka consumer stopped prior to pause restore causing the spec to fail.

ref https://github.com/karafka/karafka/actions/runs/5751096603/job/15589173788