### PR TITLE
Unsubscribe long-living consumer client on close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2.1.10 (Unreleased)
 - [Enhancement] Introduce `connection.client.rebalance_callback` event for instrumentation of rebalances.
 - [Fix] Always try to unsubscribe short-lived consumers used throughout the system, especially in the admin APIs.
+- [Fix] Always unsubscribe long-lived consumers prior to shutdown.
+- [Fix] Add missing `connection.client.poll.error` error type reference.
 
 ## 2.1.9 (2023-08-06)
 - **[Feature]** Introduce ability to customize pause strategy on a per topic basis (Pro).

--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -380,6 +380,12 @@ module Karafka
           ::Karafka::Core::Instrumentation.statistics_callbacks.delete(@subscription_group.id)
           ::Karafka::Core::Instrumentation.error_callbacks.delete(@subscription_group.id)
 
+          # This should prevent from a race condition when we unsubscribe during brokers metadata
+          # states refreshes. With unsubscribed consumer there should be way less of potential
+          # refreshes running.
+          #
+          # @see https://github.com/appsignal/rdkafka-ruby/issues/273
+          @kafka.unsubscribe
           @kafka.close
           @buffer.clear
           # @note We do not clear rebalance manager here as we may still have revocation info

--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -385,12 +385,27 @@ module Karafka
           # refreshes running.
           #
           # @see https://github.com/appsignal/rdkafka-ruby/issues/273
-          @kafka.unsubscribe
+          unsubscribe
           @kafka.close
           @buffer.clear
           # @note We do not clear rebalance manager here as we may still have revocation info
           # here that we want to consider valid prior to running another reconnection
         end
+      end
+
+      # Unsubscribes from all the subscriptions
+      # @note This is a private API to be used only on shutdown
+      # @note We do not re-raise since this is supposed to be only used on close and can be safely
+      #   ignored. We do however want to instrument on it
+      def unsubscribe
+        @kafka.unsubscribe
+      rescue ::Rdkafka::RdkafkaError => e
+        Karafka.monitor.instrument(
+          'error.occurred',
+          caller: self,
+          error: e,
+          type: 'connection.client.unsubscribe.error'
+        )
       end
 
       # @param topic [String]

--- a/lib/karafka/instrumentation/logger_listener.rb
+++ b/lib/karafka/instrumentation/logger_listener.rb
@@ -280,6 +280,9 @@ module Karafka
         when 'connection.client.rebalance_callback.error'
           error "Rebalance callback error occurred: #{error}"
           error details
+        when 'connection.client.unsubscribe.error'
+          error "Client unsubscribe error occurred: #{error}"
+          error details
         else
           # This should never happen. Please contact the maintainers
           raise Errors::UnsupportedCaseError, event

--- a/lib/karafka/instrumentation/notifications.rb
+++ b/lib/karafka/instrumentation/notifications.rb
@@ -36,6 +36,8 @@ module Karafka
         connection.listener.fetch_loop.received
 
         connection.client.rebalance_callback
+        connection.client.poll.error
+        connection.client.unsubscribe.error
 
         consumer.consume
         consumer.consumed

--- a/spec/lib/karafka/instrumentation/logger_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/logger_listener_spec.rb
@@ -376,6 +376,13 @@ RSpec.describe_current do
       it { expect(Karafka.logger).to have_received(:error).with(message) }
     end
 
+    context 'when it is a connection.client.unsubscribe.error' do
+      let(:type) { 'connection.client.unsubscribe.error' }
+      let(:message) { "Client unsubscribe error occurred: #{error}" }
+
+      it { expect(Karafka.logger).to have_received(:error).with(message) }
+    end
+
     context 'when it is an unsupported error type' do
       subject(:error_trigger) { listener.on_error_occurred(event) }
 


### PR DESCRIPTION
Mitigates a case where a broker request for a subscription would start running the same moment we close the connection.