### PR TITLE
cluster info based dynamic subscriptions

### DIFF
--- a/spec/integrations/consumption/from_never_existing_topic_spec.rb
+++ b/spec/integrations/consumption/from_never_existing_topic_spec.rb
@@ -7,8 +7,7 @@
 setup_karafka
 
 class Consumer < Karafka::BaseConsumer
-  def consume
-  end
+  def consume; end
 end
 
 draw_routes(create_topics: false) do

--- a/spec/integrations/consumption/from_never_existing_topic_spec.rb
+++ b/spec/integrations/consumption/from_never_existing_topic_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Karafka should work when subscribing to a topic that does not exist
+# This should operate even if topic is not created as it may be in the future.
+# Even if not created, we should still be able to operate, start and stop
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+  end
+end
+
+draw_routes(create_topics: false) do
+  topic DT.topic do
+    consumer Consumer
+  end
+end
+
+start_karafka_and_wait_until do
+  sleep(5)
+  true
+end

--- a/spec/integrations/consumption/from_non_existing_topic_spec.rb
+++ b/spec/integrations/consumption/from_non_existing_topic_spec.rb
@@ -14,7 +14,9 @@ class Consumer2 < Karafka::BaseConsumer
   def consume; end
 end
 
-draw_routes do
+Karafka::Admin.create_topic(DT.topics[1], 1, 1)
+
+draw_routes(create_topics: false) do
   topic DT.topic do
     consumer Consumer
   end

--- a/spec/integrations/consumption/with_cluster_info_based_routes_spec.rb
+++ b/spec/integrations/consumption/with_cluster_info_based_routes_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# We should be able to define settings and then use cluster info to get topics and subscribe
+# to them automatically also matching via regexp
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[message.topic] << message.offset
+    end
+  end
+end
+
+MATCH = SecureRandom.uuid
+
+t1 = "#{DT.topics[0]}-#{MATCH}"
+t2 = "#{DT.topics[1]}-#{MATCH}"
+
+Karafka::Admin.create_topic(t1, 1, 1)
+Karafka::Admin.create_topic(t2, 1, 1)
+
+draw_routes(create_topics: false) do
+  Karafka::Admin
+    .cluster_info
+    .topics
+    .map { |topic| topic[:topic_name] }
+    .select { |name| name =~ /#{MATCH}/ }
+    .each do |name|
+      topic name do
+        consumer Consumer
+      end
+    end
+end
+
+elements = DT.uuids(10)
+produce_many(t1, elements)
+produce_many(t2, elements)
+
+start_karafka_and_wait_until do
+  DT[t1].size >= 10 && DT[t2].size >= 10
+end
+
+assert_equal DT[t1], (0..9).to_a
+assert_equal DT[t2], (0..9).to_a

--- a/spec/integrations/routing/cluster_info_based_discovery_spec.rb
+++ b/spec/integrations/routing/cluster_info_based_discovery_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# We should be able to build topics based on cluster info
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[message.topic] << message.offset
+    end
+  end
+end
+
+MATCH = SecureRandom.uuid
+
+t1 = "#{DT.topics[0]}-#{MATCH}"
+t2 = "#{DT.topics[1]}-#{MATCH}"
+
+Karafka::Admin.create_topic(t1, 1, 1)
+Karafka::Admin.create_topic(t2, 1, 1)
+
+draw_routes(create_topics: false) do
+  Karafka::Admin
+    .cluster_info
+    .topics
+    .map { |topic| topic[:topic_name] }
+    .select { |name| name =~ /#{MATCH}/ }
+    .each do |name|
+      topic name do
+        consumer Consumer
+      end
+    end
+end
+
+subscribed_topics = Karafka::App.consumer_groups.first.topics.map(&:name).sort
+
+assert_equal [t1, t2].sort, subscribed_topics, subscribed_topics

--- a/spec/integrations/routing/runtime_routing_expansion_spec.rb
+++ b/spec/integrations/routing/runtime_routing_expansion_spec.rb
@@ -39,7 +39,7 @@ start_karafka_and_wait_until do
         consumer_group 'regular' do
           topic 'test-me' do
             consumer Consumer
-            max_wait_time -2
+            max_wait_time(-2)
           end
         end
       end

--- a/spec/integrations/routing/runtime_routing_expansion_spec.rb
+++ b/spec/integrations/routing/runtime_routing_expansion_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# When Karafka runs, we should be able to inject new routes and they should be picked
+# It does NOT mean they will be used (not yet) but it should mean, that valid once are accepted
+# and invalid are validated and an error is raised.
+#
+# This spec ensures, that dynamic routing expansions in runtime are subject to validation
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[0] << message.offset
+    end
+  end
+end
+
+draw_routes(Consumer)
+
+elements = DT.uuids(10)
+produce_many(DT.topic, elements)
+
+guarded = []
+
+start_karafka_and_wait_until do
+  if DT[0].size >= 10
+    # Should not crash
+    draw_routes do
+      consumer_group 'test2' do
+        topic 'test-me2' do
+          consumer Consumer
+        end
+      end
+    end
+
+    begin
+      draw_routes do
+        consumer_group 'regular' do
+          topic 'test-me' do
+            consumer Consumer
+            max_wait_time -2
+          end
+        end
+      end
+    rescue Karafka::Errors::InvalidConfigurationError
+      guarded << true
+    end
+
+    true
+  else
+    false
+  end
+end
+
+assert_equal [true], guarded
+assert Karafka::App.consumer_groups.map(&:name).include?('test2')


### PR DESCRIPTION
Some specs illustrating that while we do not support dynamic runtime subscriptions (yet), we do support subscriptions on process starts.