### PR TITLE
Disable auto-topic-create for admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.1.10 (Unreleased)
 - [Enhancement] Introduce `connection.client.rebalance_callback` event for instrumentation of rebalances.
 - [Refactor] Introduce low level commands proxy to handle deviation in how we want to run certain commands and how rdkafka-ruby runs that by design.
+- [Fix] Disable `allow.auto.create.topics` for admin by default to prevent accidental topics creation on topics metadata lookups.
 - [Fix] Improve the `query_watermark_offsets` operations by increasing too low timeout.
 - [Fix] Increase `TplBuilder` timeouts to compensate for remote clusters.
 - [Fix] Always try to unsubscribe short-lived consumers used throughout the system, especially in the admin APIs.

--- a/lib/karafka/admin.rb
+++ b/lib/karafka/admin.rb
@@ -26,7 +26,9 @@ module Karafka
       'fetch.message.max.bytes': 5 * 1_048_576,
       # Do not commit offset automatically, this prevents offset tracking for operations involving
       # a consumer instance
-      'enable.auto.commit': false
+      'enable.auto.commit': false,
+      # Make sure that topic metadata lookups do not create topics accidentally
+      'allow.auto.create.topics': false
     }.freeze
 
     private_constant :CONFIG_DEFAULTS, :MAX_WAIT_TIMEOUT, :MAX_ATTEMPTS


### PR DESCRIPTION
From librdkafka:

> We do recommend that you set allow.auto.create.topics=false to avoid topic metadata lookups to unexpectedly have the broker create topics.

I never encountered that but better safe than sorry ;)
