### PR TITLE
Customize retry and timeouts for proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.1.11 (Unreleased)
 - [Enhancement] Expand the error handling for offset related queries with timeout error retries.
+- [Enhancement] Allow for connection proxy timeouts configuration
 
 ## 2.1.10 (2023-08-21)
 - [Enhancement] Introduce `connection.client.rebalance_callback` event for instrumentation of rebalances.

--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -26,6 +26,12 @@ en:
       internal.process_format: needs to be present
       internal.routing.builder_format: needs to be present
       internal.routing.subscription_groups_builder_format: needs to be present
+      internal.connection.proxy.query_watermark_offsets.timeout_format: needs to be an integer bigger than 0
+      internal.connection.proxy.query_watermark_offsets.max_attempts_format: needs to be an integer bigger than 0
+      internal.connection.proxy.query_watermark_offsets.wait_time_format: needs to be an integer bigger than 0
+      internal.connection.proxy.offsets_for_times.timeout_format: needs to be an integer bigger than 0
+      internal.connection.proxy.offsets_for_times.max_attempts_format: needs to be an integer bigger than 0
+      internal.connection.proxy.offsets_for_times.wait_time_format: needs to be an integer bigger than 0
       key_must_be_a_symbol: All keys under the kafka settings scope need to be symbols
       max_timeout_vs_pause_max_timeout: pause_timeout must be less or equal to pause_max_timeout
       shutdown_timeout_vs_max_wait_time: shutdown_timeout must be more than max_wait_time

--- a/lib/karafka/connection/proxy.rb
+++ b/lib/karafka/connection/proxy.rb
@@ -10,26 +10,13 @@ module Karafka
     # do still want to be able to alter some functionalities. This wrapper helps us do it when
     # it would be needed
     class Proxy < SimpleDelegator
-      # Timeout on the watermark query
-      WATERMARK_REQUEST_TIMEOUT = 5_000
-
-      # Timeout on the TPL request query
-      TPL_REQUEST_TIMEOUT = 5_000
-
-      # How many attempts we want to take for something that would end up with all_brokers_down
-      OFFSETS_MAX_ATTEMPTS = 3
-
-      # How long should we wait in between all_brokers_down
-      OFFSETS_BACKOFF_TIME = 1
-
       # Errors on which we want to retry
       RETRYABLE_ERRORS = %i[
         all_brokers_down
         timed_out
       ].freeze
 
-      private_constant :WATERMARK_REQUEST_TIMEOUT, :OFFSETS_MAX_ATTEMPTS, :RETRYABLE_ERRORS,
-                       :OFFSETS_BACKOFF_TIME, :TPL_REQUEST_TIMEOUT
+      private_constant :RETRYABLE_ERRORS
 
       attr_accessor :wrapped
 
@@ -42,6 +29,7 @@ module Karafka
         # wrap an already wrapped object with another proxy level. Simplifies passing consumers
         # and makes it safe to wrap without type checking
         @wrapped = obj.is_a?(self.class) ? obj.wrapped : obj
+        @config = ::Karafka::App.config.internal.connection.proxy
       end
 
       # Proxies the `#query_watermark_offsets` with extra recovery from timeout problems.
@@ -52,12 +40,14 @@ module Karafka
       # @param partition [Partition]
       # @return [Array<Integer, Integer>] watermark offsets
       def query_watermark_offsets(topic, partition)
-        with_broker_errors_retry do
-          @wrapped.query_watermark_offsets(
-            topic,
-            partition,
-            WATERMARK_REQUEST_TIMEOUT
-          )
+        l_config = @config.query_watermark_offsets
+
+        with_broker_errors_retry(
+          # required to be in seconds, not ms
+          wait_time: l_config.wait_time / 1_000.to_f,
+          max_attempts: l_config.max_attempts
+        ) do
+          @wrapped.query_watermark_offsets(topic, partition, l_config.timeout)
         end
       end
 
@@ -67,8 +57,14 @@ module Karafka
       # @param tpl [Rdkafka::Consumer::TopicPartitionList] tpl to get time offsets
       # @return [Rdkafka::Consumer::TopicPartitionList] tpl with time offsets
       def offsets_for_times(tpl)
-        with_broker_errors_retry do
-          @wrapped.offsets_for_times(tpl, TPL_REQUEST_TIMEOUT)
+        l_config = @config.offsets_for_times
+
+        with_broker_errors_retry(
+          # required to be in seconds, not ms
+          wait_time: l_config.wait_time / 1_000.to_f,
+          max_attempts: l_config.max_attempts
+        ) do
+          @wrapped.offsets_for_times(tpl, l_config.timeout)
         end
       end
 
@@ -77,7 +73,7 @@ module Karafka
       # Runs expected block of code with few retries on all_brokers_down
       # librdkafka can return `all_brokers_down` for scenarios when broker is overloaded or not
       # reachable due to latency.
-      def with_broker_errors_retry
+      def with_broker_errors_retry(max_attempts:, wait_time: 1)
         attempt ||= 0
         attempt += 1
 
@@ -85,8 +81,8 @@ module Karafka
       rescue Rdkafka::RdkafkaError => e
         raise unless RETRYABLE_ERRORS.include?(e.code)
 
-        if attempt <= OFFSETS_MAX_ATTEMPTS
-          sleep(OFFSETS_BACKOFF_TIME)
+        if attempt <= max_attempts
+          sleep(wait_time)
 
           retry
         end

--- a/lib/karafka/connection/proxy.rb
+++ b/lib/karafka/connection/proxy.rb
@@ -73,6 +73,10 @@ module Karafka
       # Runs expected block of code with few retries on all_brokers_down
       # librdkafka can return `all_brokers_down` for scenarios when broker is overloaded or not
       # reachable due to latency.
+      # @param max_attempts [Integer] how many attempts (not retries) should we take before failing
+      #   completely.
+      # @param wait_time [Integer, Float] how many seconds should we wait. It uses `#sleep` of Ruby
+      #   so it needs time in seconds.
       def with_broker_errors_retry(max_attempts:, wait_time: 1)
         attempt ||= 0
         attempt += 1

--- a/lib/karafka/contracts/config.rb
+++ b/lib/karafka/contracts/config.rb
@@ -39,6 +39,22 @@ module Karafka
         required(:status) { |val| !val.nil? }
         required(:process) { |val| !val.nil? }
 
+        nested(:connection) do
+          nested(:proxy) do
+            nested(:query_watermark_offsets) do
+              required(:timeout) { |val| val.is_a?(Integer) && val.positive? }
+              required(:max_attempts) { |val| val.is_a?(Integer) && val.positive? }
+              required(:wait_time) { |val| val.is_a?(Integer) && val.positive? }
+            end
+
+            nested(:offsets_for_times) do
+              required(:timeout) { |val| val.is_a?(Integer) && val.positive? }
+              required(:max_attempts) { |val| val.is_a?(Integer) && val.positive? }
+              required(:wait_time) { |val| val.is_a?(Integer) && val.positive? }
+            end
+          end
+        end
+
         nested(:routing) do
           required(:builder) { |val| !val.nil? }
           required(:subscription_groups_builder) { |val| !val.nil? }

--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -126,6 +126,32 @@ module Karafka
           setting :activity_manager, default: Routing::ActivityManager.new
         end
 
+        # Namespace for internal connection related settings
+        setting :connection do
+          # Settings that are altered by our client proxy layer
+          setting :proxy do
+            # Watermark offsets request settings
+            setting :query_watermark_offsets do
+              # timeout for this request. For busy or remote clusters, this should be high enough
+              setting :timeout, default: 5_000
+              # How many times should we try to run this call before raising an error
+              setting :max_attempts, default: 3
+              # How long should we wait before next attempt in case of a failure
+              setting :wait_time, default: 1_000
+            end
+
+            # Offsets for times request settings
+            setting :offsets_for_times do
+              # timeout for this request. For busy or remote clusters, this should be high enough
+              setting :timeout, default: 5_000
+              # How many times should we try to run this call before raising an error
+              setting :max_attempts, default: 3
+              # How long should we wait before next attempt in case of a failure
+              setting :wait_time, default: 1_000
+            end
+          end
+        end
+
         setting :processing do
           # option scheduler [Object] scheduler we will be using
           setting :scheduler, default: Processing::Scheduler.new

--- a/spec/lib/karafka/contracts/config_spec.rb
+++ b/spec/lib/karafka/contracts/config_spec.rb
@@ -21,6 +21,20 @@ RSpec.describe_current do
       internal: {
         status: Karafka::Status.new,
         process: Karafka::Process.new,
+        connection: {
+          proxy: {
+            query_watermark_offsets: {
+              timeout: 100,
+              max_attempts: 5,
+              wait_time: 1_000
+            },
+            offsets_for_times: {
+              timeout: 100,
+              max_attempts: 5,
+              wait_time: 1_000
+            }
+          }
+        },
         routing: {
           builder: Karafka::Routing::Builder.new,
           subscription_groups_builder: Karafka::Routing::SubscriptionGroupsBuilder.new
@@ -266,6 +280,53 @@ RSpec.describe_current do
       before { config.delete(:internal) }
 
       it { expect(contract.call(config)).not_to be_success }
+    end
+
+    context 'when connection is missing' do
+      before { config[:internal].delete(:connection) }
+
+      it { expect(contract.call(config)).not_to be_success }
+    end
+
+    context 'when proxy is missing' do
+      before { config[:internal][:connection].delete(:proxy) }
+
+      it { expect(contract.call(config)).not_to be_success }
+    end
+
+    %i[
+      query_watermark_offsets
+      offsets_for_times
+    ].each do |scope|
+      context "when proxy #{scope} is missing" do
+        before { config[:internal][:connection][:proxy].delete(scope) }
+
+        it { expect(contract.call(config)).not_to be_success }
+      end
+
+      %i[
+        timeout
+        max_attempts
+        wait_time
+      ].each do |field|
+        context "when proxy #{scope} #{field} is 0" do
+          before { config[:internal][:connection][:proxy][scope][field] = 0 }
+
+          it { expect(contract.call(config)).not_to be_success }
+        end
+
+        context "when proxy #{scope} #{field} is not an integer" do
+          before { config[:internal][:connection][:proxy][scope][field] = 100.2 }
+
+          it { expect(contract.call(config)).not_to be_success }
+        end
+
+        context "when proxy #{scope} #{field} is a string" do
+          before { config[:internal][:connection][:proxy][scope][field] = 'test' }
+
+          it { expect(contract.call(config)).not_to be_success }
+        end
+      end
     end
 
     context 'when routing builder is missing' do


### PR DESCRIPTION
This PR extracts the constant timeouts and makes them customizable. It is part of mitigation of issues with certain kafka commands that tend to fail on a first try. There are few librdkafka issues where the solution (or a mitigation) is to retry. Alongside of that fixes in rdkafka-ruby are in place.

close https://github.com/karafka/karafka/issues/1552