### PR TITLE
Support changing service_name in datadog integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.1.11 (2023-08-23)
 - [Enhancement] Expand the error handling for offset related queries with timeout error retries.
-- [Enhancement] Allow for connection proxy timeouts configuration
+- [Enhancement] Allow for connection proxy timeouts configuration.
 
 ## 2.1.10 (2023-08-21)
 - [Enhancement] Introduce `connection.client.rebalance_callback` event for instrumentation of rebalances.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Karafka framework changelog
 
-## 2.1.11 (Unreleased)
+## 2.1.11 (2023-08-23)
 - [Enhancement] Expand the error handling for offset related queries with timeout error retries.
 - [Enhancement] Allow for connection proxy timeouts configuration
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
     karafka-core (2.1.1)
       concurrent-ruby (>= 1.1)
       karafka-rdkafka (>= 0.13.1, < 0.14.0)
-    karafka-rdkafka (0.13.3)
+    karafka-rdkafka (0.13.4)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)

--- a/spec/integrations/instrumentation/error_callback_multiple_subscription_groups_spec.rb
+++ b/spec/integrations/instrumentation/error_callback_multiple_subscription_groups_spec.rb
@@ -44,7 +44,14 @@ unique = error_events
          .transform_values(&:count)
 
 assert_equal 2, error_events.keys.size
+
+
+g1 = error_events.values.first.map { |event| event.payload[:error] }
+g2 = error_events.values.last.map { |event| event.payload[:error] }
+
 # Each error published, should be published only once
-assert_equal [2], unique.values.uniq
+# If this would not be true, all would go everywhere
+assert (g1 & g2).empty?
+
 assert_equal 'error.occurred', error_events.values.first.first.id
 assert_equal 'librdkafka.error', error_events.values.first.first[:type]


### PR DESCRIPTION
By default datadog will use the service name such as `myservice` which will be the same for web and karafka processes. 

However, it is beneficial to separate those and have  `myservice-karafka` as a separate service name. This allows setting different default operation in Datadog UI and makes analyzing traces much easier.

In https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/ruby/ you can find examples how every integration supports setting service name.

Tested manually in Datadog as well.
![image](https://github.com/karafka/karafka/assets/65587/c61fcf47-6cca-4893-b6e1-ed685cf52c12)