### PR TITLE
Support changing service_name in datadog integration (#1576)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka framework changelog
 
+## 2.1.13 (Unreleased)
+- [Enhancement] Support changing `service_name` in DataDog integration.
+
 ## 2.1.12 (2023-08-25)
 - [Fix] Fix a case where DLQ + VP without intermediate marking would mark earlier message then the last one.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka (2.1.12)
+    karafka (2.1.13)
       karafka-core (>= 2.1.1, < 2.2.0)
       thor (>= 0.20)
       waterdrop (>= 2.6.6, < 3.0.0)

--- a/lib/karafka/instrumentation/vendors/datadog/logger_listener.rb
+++ b/lib/karafka/instrumentation/vendors/datadog/logger_listener.rb
@@ -17,7 +17,8 @@ module Karafka
           # `Datadog::Tracing` client that we should use to trace stuff
           setting :client
 
-          setting :service_name
+          # @see https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/ruby
+          setting :service_name, default: nil
 
           configure
 

--- a/lib/karafka/instrumentation/vendors/datadog/logger_listener.rb
+++ b/lib/karafka/instrumentation/vendors/datadog/logger_listener.rb
@@ -12,10 +12,12 @@ module Karafka
           include ::Karafka::Core::Configurable
           extend Forwardable
 
-          def_delegators :config, :client
+          def_delegators :config, :client, :service_name
 
           # `Datadog::Tracing` client that we should use to trace stuff
           setting :client
+
+          setting :service_name
 
           configure
 
@@ -44,7 +46,7 @@ module Karafka
           #
           # @param event [Karafka::Core::Monitoring::Event] event details including payload
           def on_worker_process(event)
-            current_span = client.trace('karafka.consumer')
+            current_span = client.trace('karafka.consumer', service: service_name)
             push_tags
 
             job = event[:job]

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '2.1.12'
+  VERSION = '2.1.13'
 end

--- a/spec/integrations/instrumentation/vendors/datadog/logger_flow_spec.rb
+++ b/spec/integrations/instrumentation/vendors/datadog/logger_flow_spec.rb
@@ -35,7 +35,7 @@ client = Vendors::Datadog::LoggerDummyClient.new
 
 listener = ::Karafka::Instrumentation::Vendors::Datadog::LoggerListener.new do |config|
   config.client = client
-  config.service_name = "myservice-karafka"
+  config.service_name = 'myservice-karafka'
 end
 
 Karafka.monitor.subscribe(listener)

--- a/spec/integrations/instrumentation/vendors/datadog/logger_flow_spec.rb
+++ b/spec/integrations/instrumentation/vendors/datadog/logger_flow_spec.rb
@@ -35,6 +35,7 @@ client = Vendors::Datadog::LoggerDummyClient.new
 
 listener = ::Karafka::Instrumentation::Vendors::Datadog::LoggerListener.new do |config|
   config.client = client
+  config.service_name = "myservice-karafka"
 end
 
 Karafka.monitor.subscribe(listener)
@@ -48,7 +49,7 @@ start_karafka_and_wait_until do
   DT[0].size >= 100 && sleep(5)
 end
 
-assert client.buffer.include?('karafka.consumer'), client.buffer
+assert client.buffer.include?(['karafka.consumer', 'myservice-karafka']), client.buffer
 assert client.buffer.include?('Consumer#consume'), client.buffer
 assert client.errors.any? { |error| error.is_a?(StandardError) }, client.errors
 assert client.errors.all? { |error| error.is_a?(StandardError) }, client.errors

--- a/spec/support/vendors/datadog/logger_dummy_client.rb
+++ b/spec/support/vendors/datadog/logger_dummy_client.rb
@@ -13,8 +13,9 @@ module Vendors
 
       # Store key trace
       # @param key [Object] key we want to start tracing
-      def trace(key)
-        @buffer << key
+      # @param service [String] Datadog service name
+      def trace(key, service: nil)
+        @buffer << [key, service]
         self
       end
 


### PR DESCRIPTION
* Support changing service_name in datadog integration

By default datadog will use the service name such as my-app which will be the same for web and karafka processes. 

However, it is beneficial to separate those and have  my-app-karafka as a separate service name. This allows setting different default operation in Datadog UI and makes analyzing traces much easier.

In https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/ruby/  you can find examples how every integration supports setting service name.



* delegate service_name to config



* Fix integration tests for datadog service name

---------