### PR TITLE
1596 - do not crash on non-regexp patterns prior to contracts validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka framework changelog
 
+## 2.2.1 (Unreleased)
+- [Fix] Fix insufficient validation of named patterns
+
 ## 2.2.0 (2023-09-01)
 - **[Feature]** Introduce dynamic topic subscriptions based on patterns [Pro].
 - [Enhancement] Allow for `Karafka::Admin` setup reconfiguration via `config.admin` scope.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Karafka framework changelog
 
-## 2.2.1 (Unreleased)
+## 2.2.1 (2023-09-01)
 - [Fix] Fix insufficient validation of named patterns
+- [Maintenance] Rely on `2.2.x` `karafka-core`.
 
 ## 2.2.0 (2023-09-01)
 - **[Feature]** Introduce dynamic topic subscriptions based on patterns [Pro].

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka (2.2.0)
+    karafka (2.2.1)
       karafka-core (>= 2.1.1, < 2.2.0)
       thor (>= 0.20)
       waterdrop (>= 2.6.6, < 3.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     karafka (2.2.1)
-      karafka-core (>= 2.1.1, < 2.2.0)
+      karafka-core (>= 2.2.0, < 2.3.0)
       thor (>= 0.20)
       waterdrop (>= 2.6.6, < 3.0.0)
       zeitwerk (~> 2.3)
@@ -30,7 +30,7 @@ GEM
       activesupport (>= 5.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    karafka-core (2.1.1)
+    karafka-core (2.2.0)
       concurrent-ruby (>= 1.1)
       karafka-rdkafka (>= 0.13.1, < 0.14.0)
     karafka-rdkafka (0.13.4)

--- a/karafka.gemspec
+++ b/karafka.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
     without having to focus on things that are not your business domain.
   DESC
 
-  spec.add_dependency 'karafka-core', '>= 2.1.1', '< 2.2.0'
+  spec.add_dependency 'karafka-core', '>= 2.2.0', '< 2.3.0'
   spec.add_dependency 'thor', '>= 0.20'
   spec.add_dependency 'waterdrop', '>= 2.6.6', '< 3.0.0'
   spec.add_dependency 'zeitwerk', '~> 2.3'

--- a/lib/karafka/pro/routing/features/patterns/pattern.rb
+++ b/lib/karafka/pro/routing/features/patterns/pattern.rb
@@ -53,7 +53,7 @@ module Karafka
               # topic but this minimizes simple mistakes
               #
               # This sub-part of sh1 should be unique enough and short-enough to use it here
-              digest = Digest::SHA1.hexdigest(regexp.source)[8..16]
+              digest = Digest::SHA1.hexdigest(safe_regexp.source)[8..16]
               @name = name ? name.to_s : "karafka-pattern-#{digest}"
               @config = config
             end
@@ -62,7 +62,7 @@ module Karafka
             #   librdkafka expectations. We use it as a subscription name for initial patterns
             #   subscription start.
             def regexp_string
-              "^#{regexp.source}"
+              "^#{safe_regexp.source}"
             end
 
             # @return [Hash] hash representation of this routing pattern
@@ -72,6 +72,20 @@ module Karafka
                 name: name,
                 regexp_string: regexp_string
               }.freeze
+            end
+
+            private
+
+            # Since pattern building happens before validations and we rely internally on the fact
+            # that regexp is provided and nothing else, we here "sanitize" the regexp for our
+            # internal usage. Karafka will not run anyhow because our post-routing contracts will
+            # prevent it from running but internally in this component we need to ensure, that
+            # prior to the validations we operate on a regexp
+            #
+            # @return [Regexp] returns a regexp always even if what we've received was not a regexp
+            def safe_regexp
+              # This regexp will never match anything
+              regexp.is_a?(Regexp) ? regexp : /$a/
             end
           end
         end

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '2.2.0'
+  VERSION = '2.2.1'
 end

--- a/spec/integrations/pro/routing/patterns/anonymous_with_invalid_regexp_spec.rb
+++ b/spec/integrations/pro/routing/patterns/anonymous_with_invalid_regexp_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# When we have anonymous pattern with a non-regexp value, it should validate and fail
+
+setup_karafka
+
+guarded = []
+
+begin
+  draw_routes(create_topics: false) do
+    pattern('not-a-regexp') do
+      consumer Class.new
+    end
+  end
+rescue Karafka::Errors::InvalidConfigurationError
+  guarded << 1
+end
+
+assert_equal [1], guarded

--- a/spec/integrations/pro/routing/patterns/named_with_invalid_regexp_spec.rb
+++ b/spec/integrations/pro/routing/patterns/named_with_invalid_regexp_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# When we have a valid name but provide regexp that is not a regexp, we should fail
+
+setup_karafka
+
+guarded = []
+
+begin
+  draw_routes(create_topics: false) do
+    pattern('super-name1', 'not-a-regexp') do
+      consumer Class.new
+    end
+  end
+rescue Karafka::Errors::InvalidConfigurationError
+  guarded << 1
+end
+
+assert_equal [1], guarded


### PR DESCRIPTION
close https://github.com/karafka/karafka/issues/1596

also updates dep on karafka-core to 2.2.0