### PR TITLE
spec for revoked paused usage

### DIFF
--- a/spec/integrations/pausing/manual_pause_on_a_revoked_partition_spec.rb
+++ b/spec/integrations/pausing/manual_pause_on_a_revoked_partition_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# When we pause a lost partition, it should not have any impact on us getting the data after
+# we get it back (if we get it back)
+
+setup_karafka(allow_errors: true) do |config|
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+  config.concurrency = 1
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    if DT.key?(:paused)
+      DT[:again] = true
+    else
+      sleep(15)
+      pause(messages.last.offset, 100_000_000)
+      DT[:paused] = true
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+  end
+end
+
+produce_many(DT.topic, DT.uuids(1))
+
+start_karafka_and_wait_until do
+  DT.key?(:again)
+end


### PR DESCRIPTION
A simple spec that checks that revoked pause does not affect reassigned consumption.