### PR TITLE
use nil? instead of present? on DataDog::Tracing::SpanOperation

### DIFF
--- a/lib/karafka/instrumentation/vendors/datadog/logger_listener.rb
+++ b/lib/karafka/instrumentation/vendors/datadog/logger_listener.rb
@@ -76,7 +76,7 @@ module Karafka
             info "[#{job.id}] #{job_type} job for #{consumer} on #{topic} finished in #{time}ms"
 
             current_span = client.active_span
-            current_span.finish if current_span.present?
+            current_span.finish unless current_span.nil?
 
             pop_tags
           end

--- a/lib/karafka/instrumentation/vendors/datadog/logger_listener.rb
+++ b/lib/karafka/instrumentation/vendors/datadog/logger_listener.rb
@@ -75,8 +75,7 @@ module Karafka
 
             info "[#{job.id}] #{job_type} job for #{consumer} on #{topic} finished in #{time}ms"
 
-            current_span = client.active_span
-            current_span.finish unless current_span.nil?
+            client.active_span&.finish
 
             pop_tags
           end

--- a/spec/support/vendors/datadog/logger_dummy_client.rb
+++ b/spec/support/vendors/datadog/logger_dummy_client.rb
@@ -47,11 +47,6 @@ module Vendors
         self
       end
 
-      # @return [Boolean]
-      def present?
-        true
-      end
-
       # API compatibility hook
       def finish
         self


### PR DESCRIPTION
I have the following configuration that leverages a simple consumer from the example documents.

```
class KarafkaApp < Karafka::App
  setup do |config|
    config.kafka = { 'bootstrap.servers': '127.0.0.1:9092' }
    config.client_id = 'example_app'

    require 'karafka/instrumentation/vendors/datadog/logger_listener'
    trace_listener = ::Karafka::Instrumentation::Vendors::Datadog::LoggerListener.new do |config|
      config.client = Datadog::Tracing
    end
    config.monitor.subscribe(trace_listener)
  end
```

This is the contents of my Gemfile
```
ruby '3.2.2'

gem 'ddtrace', '~> 1.0'
gem "karafka", ">= 2.2.0"
```

Running this consumer will yield the following FATAL error, causing the work process to fail.

>F, [2023-09-19T15:17:17.008201 #77740] FATAL -- : Worker processing failed due to an error: undefined method 'present?' for #<Datadog::Tracing::SpanOperation:0x0000000107a8bb98 @name="karafka.consumer", @service="karafka", @type=nil, @resource="ExampleConsumer#consume", ...`

Looking at [DataDog::Tracing::SpanOperation](https://github.com/DataDog/dd-trace-rb/blob/cb5fe8a5e2ea0560748f05e4f47ba2b8b8384e33/lib/datadog/tracing/span_operation.rb) shows that there is in fact no method named `present?`.

I'm not sure if this is the right [active_span](https://github.com/DataDog/dd-trace-rb/blob/ee1cb80ad50ec420e83ce8c7a34b924bf925ac5b/lib/datadog/tracing/tracer.rb#L218), but it looks like ddtrace will return nil in the case of there being no active trace.

