### PR TITLE
Change to kraft and validate cache state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka framework changelog
 
 ## 2.2.5 (Unreleased)
+- [Enhancement] Ensure, that when topic related operations end, the result is usable. There were few cases where admin operations on topics would finish successfully but internal Kafka caches would not report changes for a short period of time.
 - [Enhancement] Stabilize cooperative-sticky early shutdown procedure.
 - [Maintenance] Align connection clearing API with Rails 7.1 deprecation warning.
 - [Maintenance] Make `#subscription_group` reference consistent in the Routing and Instrumentation.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,23 @@
 version: '2'
 
 services:
-  zookeeper:
-    container_name: karafka_zookeeper
-    image: confluentinc/cp-zookeeper:7.5.0
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-
   kafka:
-    container_name: karafka_kafka
+    container_name: kafka
     image: confluentinc/cp-kafka:7.5.0
-    depends_on:
-      - zookeeper
+
     ports:
       - 9092:9092
+
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:29092,PLAINTEXT_HOST://localhost:9092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      CLUSTER_ID: adqr22r231e223131231ww
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://127.0.0.1:9092
+      KAFKA_BROKER_ID: 1
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@127.0.0.1:9093
+      ALLOW_PLAINTEXT_LISTENER: 'yes'
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'

--- a/lib/karafka/admin.rb
+++ b/lib/karafka/admin.rb
@@ -216,7 +216,11 @@ module Karafka
         attempt += 1
 
         handler.call
-      rescue Rdkafka::AbstractHandle::WaitTimeoutError
+
+        # If breaker does not operate, it means that the requested change was applied but is still
+        # not visible and we need to wait
+        raise(Errors::ResultNotVisibleError) unless breaker.call
+      rescue Rdkafka::AbstractHandle::WaitTimeoutError, Errors::ResultNotVisibleError
         return if breaker.call
 
         retry if attempt <= app_config.admin.max_attempts

--- a/lib/karafka/errors.rb
+++ b/lib/karafka/errors.rb
@@ -55,5 +55,10 @@ module Karafka
 
     # This should never happen. Please open an issue if it does.
     InvalidTimeBasedOffsetError = Class.new(BaseError)
+
+    # For internal usage only
+    # Raised when we run operations that require certain result but despite successfully finishing
+    # it is not yet available due to some synchronization mechanisms and caches
+    ResultNotVisibleError = Class.new(BaseError)
   end
 end


### PR DESCRIPTION
This PR changes two things:
- KRaft for docker
- Ensure that the result of topic related admin operations is visible from the broker perspective before finishing

close https://github.com/karafka/karafka/issues/1633
