### PR TITLE
Split integrations into OSS and Pro and retry Docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,9 +119,6 @@ jobs:
           - '3.1'
           - '3.0'
           - '2.7'
-        include:
-          - ruby: '3.2'
-            coverage: 'true'
     steps:
       - uses: actions/checkout@v4
       - name: Install package dependencies
@@ -165,7 +162,6 @@ jobs:
           KARAFKA_PRO_PASSWORD: ${{ secrets.KARAFKA_PRO_PASSWORD }}
           KARAFKA_PRO_VERSION: ${{ secrets.KARAFKA_PRO_VERSION }}
           KARAFKA_PRO_LICENSE_CHECKSUM: ${{ secrets.KARAFKA_PRO_LICENSE_CHECKSUM }}
-          GITHUB_COVERAGE: ${{matrix.coverage}}
         run: bin/integrations --exclude '/pro'
 
   integrations_pro:
@@ -180,16 +176,10 @@ jobs:
           - '3.1'
           - '3.0'
           - '2.7'
-        include:
-          - ruby: '3.2'
-            coverage: 'true'
     steps:
       - uses: actions/checkout@v4
       - name: Install package dependencies
         run: "[ -e $APT_DEPS ] || sudo apt-get install -y --no-install-recommends $APT_DEPS"
-
-      - name: Remove libzstd-dev to check no supported compressions
-        run: sudo apt-get -y remove libzstd-dev
 
       - name: Start Kafka with docker-compose
         run: |
@@ -198,10 +188,6 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          # Do not use cache here as we run bundle install also later in some of the integration
-          # tests and we need to be able to run it without cache
-          #
-          # We also want to check that librdkafka is compiling as expected on all versions of Ruby
           ruby-version: ${{matrix.ruby}}
 
       - name: Install latest Bundler
@@ -226,6 +212,5 @@ jobs:
           KARAFKA_PRO_PASSWORD: ${{ secrets.KARAFKA_PRO_PASSWORD }}
           KARAFKA_PRO_VERSION: ${{ secrets.KARAFKA_PRO_VERSION }}
           KARAFKA_PRO_LICENSE_CHECKSUM: ${{ secrets.KARAFKA_PRO_LICENSE_CHECKSUM }}
-          GITHUB_COVERAGE: ${{matrix.coverage}}
 
         run: bin/integrations '/pro'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
           GITHUB_COVERAGE: ${{matrix.coverage}}
         run: bin/rspecs
 
-  integrations:
+  integrations_oss:
     timeout-minutes: 45
     runs-on: ubuntu-latest
     needs: diffend
@@ -156,7 +156,7 @@ jobs:
         run: |
           bundle exec bin/wait_for_kafka
 
-      - name: Run integration tests
+      - name: Run OSS integration tests
         env:
           KARAFKA_PRO_LICENSE_TOKEN: ${{ secrets.KARAFKA_PRO_LICENSE_TOKEN }}
           KARAFKA_PRO_USERNAME: ${{ secrets.KARAFKA_PRO_USERNAME }}
@@ -164,4 +164,66 @@ jobs:
           KARAFKA_PRO_VERSION: ${{ secrets.KARAFKA_PRO_VERSION }}
           KARAFKA_PRO_LICENSE_CHECKSUM: ${{ secrets.KARAFKA_PRO_LICENSE_CHECKSUM }}
           GITHUB_COVERAGE: ${{matrix.coverage}}
-        run: bin/integrations
+        run: bin/integrations --exclude '/pro'
+
+  integrations_pro:
+    timeout-minutes: 45
+    runs-on: ubuntu-latest
+    needs: diffend
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '3.2'
+          - '3.1'
+          - '3.0'
+          - '2.7'
+        include:
+          - ruby: '3.2'
+            coverage: 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install package dependencies
+        run: "[ -e $APT_DEPS ] || sudo apt-get install -y --no-install-recommends $APT_DEPS"
+
+      - name: Remove libzstd-dev to check no supported compressions
+        run: sudo apt-get -y remove libzstd-dev
+
+      - name: Start Kafka with docker-compose
+        run: |
+          docker-compose up -d
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          # Do not use cache here as we run bundle install also later in some of the integration
+          # tests and we need to be able to run it without cache
+          #
+          # We also want to check that librdkafka is compiling as expected on all versions of Ruby
+          ruby-version: ${{matrix.ruby}}
+
+      - name: Install latest Bundler
+        run: |
+          gem install bundler --no-document
+          gem update --system --no-document
+          bundle config set without 'tools benchmarks docs'
+
+      - name: Bundle install
+        run: |
+          bundle config set without development
+          bundle install
+
+      - name: Wait for Kafka
+        run: |
+          bundle exec bin/wait_for_kafka
+
+      - name: Run Pro integration tests
+        env:
+          KARAFKA_PRO_LICENSE_TOKEN: ${{ secrets.KARAFKA_PRO_LICENSE_TOKEN }}
+          KARAFKA_PRO_USERNAME: ${{ secrets.KARAFKA_PRO_USERNAME }}
+          KARAFKA_PRO_PASSWORD: ${{ secrets.KARAFKA_PRO_PASSWORD }}
+          KARAFKA_PRO_VERSION: ${{ secrets.KARAFKA_PRO_VERSION }}
+          KARAFKA_PRO_LICENSE_CHECKSUM: ${{ secrets.KARAFKA_PRO_LICENSE_CHECKSUM }}
+          GITHUB_COVERAGE: ${{matrix.coverage}}
+
+        run: bin/integrations '/pro'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,10 @@ jobs:
       - name: Run Coditsu
         run: \curl -sSL https://api.coditsu.io/run/ci | bash
 
+  # We do not split RSpec specs to OSS and Pro like integrations because they do not overload
+  # Kafka heavily, compute total coverage for specs and are fast enough
   specs:
-    timeout-minutes: 30
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     needs: diffend
     strategy:
@@ -88,7 +90,7 @@ jobs:
 
       - name: Start Kafka with docker-compose
         run: |
-          docker-compose up -d
+          docker-compose up -d || (sleep 5 && docker-compose up -d)
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -106,7 +108,7 @@ jobs:
         run: bin/rspecs
 
   integrations_oss:
-    timeout-minutes: 45
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     needs: diffend
     strategy:
@@ -130,7 +132,7 @@ jobs:
 
       - name: Start Kafka with docker-compose
         run: |
-          docker-compose up -d
+          docker-compose up -d || (sleep 5 && docker-compose up -d)
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -167,7 +169,7 @@ jobs:
         run: bin/integrations --exclude '/pro'
 
   integrations_pro:
-    timeout-minutes: 45
+    timeout-minutes: 40
     runs-on: ubuntu-latest
     needs: diffend
     strategy:
@@ -191,7 +193,7 @@ jobs:
 
       - name: Start Kafka with docker-compose
         run: |
-          docker-compose up -d
+          docker-compose up -d || (sleep 5 && docker-compose up -d)
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,12 +156,6 @@ jobs:
           bundle exec bin/wait_for_kafka
 
       - name: Run OSS integration tests
-        env:
-          KARAFKA_PRO_LICENSE_TOKEN: ${{ secrets.KARAFKA_PRO_LICENSE_TOKEN }}
-          KARAFKA_PRO_USERNAME: ${{ secrets.KARAFKA_PRO_USERNAME }}
-          KARAFKA_PRO_PASSWORD: ${{ secrets.KARAFKA_PRO_PASSWORD }}
-          KARAFKA_PRO_VERSION: ${{ secrets.KARAFKA_PRO_VERSION }}
-          KARAFKA_PRO_LICENSE_CHECKSUM: ${{ secrets.KARAFKA_PRO_LICENSE_CHECKSUM }}
         run: bin/integrations --exclude '/pro'
 
   integrations_pro:

--- a/bin/integrations
+++ b/bin/integrations
@@ -218,12 +218,25 @@ end
 # Load all the specs
 specs = Dir[ROOT_PATH.join('spec/integrations/**/*_spec.rb')]
 
+FILTER_TYPE = ARGV[0] == '--exclude' ? 'exclude' : 'include'
+
+# Remove the exclude flag
+ARGV.shift if FILTER_TYPE == '--exclude'
+
 # If filters is provided, apply
 # Allows to provide several filters one after another and applies all of them
 ARGV.each do |filter|
-  specs.delete_if { |name| !name.include?(filter) }
+  specs.delete_if do |name|
+    case FILTER_TYPE
+    when 'include'
+      !name.include?(filter)
+    when 'exclude'
+      name.include?(filter)
+    else
+      raise 'Invalid filter type'
+    end
+  end
 end
-
 
 raise ArgumentError, "No integration specs with filters: #{ARGV.join(', ')}" if specs.empty?
 

--- a/spec/integrations/pro/consumption/strategies/ftr/static_throttler_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/static_throttler_spec.rb
@@ -46,7 +46,7 @@ produce_many(DT.topic, elements)
 consumer = setup_rdkafka_consumer
 
 thread = Thread.new do
-  sleep(5)
+  sleep(10)
 
   consumer.subscribe(DT.topic)
 

--- a/spec/integrations/pro/rails/rails6_pristine/Gemfile
+++ b/spec/integrations/pro/rails/rails6_pristine/Gemfile
@@ -3,4 +3,4 @@
 source 'https://rubygems.org'
 
 gem 'karafka', path: ENV.fetch('KARAFKA_GEM_DIR'), require: true
-gem 'rails', '6.1.7.4', require: true
+gem 'rails', '6.1.7.6', require: true

--- a/spec/integrations/pro/rails/rails6_pristine/railtie_setup_spec.rb
+++ b/spec/integrations/pro/rails/rails6_pristine/railtie_setup_spec.rb
@@ -46,5 +46,5 @@ start_karafka_and_wait_until do
 end
 
 assert_equal 1, DT.data.size
-assert_equal '6.1.7.4', Rails.version
+assert_equal '6.1.7.6', Rails.version
 assert Karafka.pro?

--- a/spec/integrations/pro/rails/rails7_pristine/just_a_dependency/Gemfile
+++ b/spec/integrations/pro/rails/rails7_pristine/just_a_dependency/Gemfile
@@ -3,4 +3,4 @@
 source 'https://rubygems.org'
 
 gem 'karafka', path: ENV.fetch('KARAFKA_GEM_DIR'), require: true
-gem 'rails', '7.0.7', require: true
+gem 'rails', '7.0.8', require: true

--- a/spec/integrations/pro/rails/rails7_pristine/just_a_dependency/railtie_setup_spec.rb
+++ b/spec/integrations/pro/rails/rails7_pristine/just_a_dependency/railtie_setup_spec.rb
@@ -46,5 +46,5 @@ start_karafka_and_wait_until do
 end
 
 assert_equal 1, DT.data.size
-assert_equal '7.0.7', Rails.version
+assert_equal '7.0.8', Rails.version
 assert Karafka.pro?

--- a/spec/integrations/pro/rails/rails7_pristine/with-active_job_and_current_attributes/Gemfile
+++ b/spec/integrations/pro/rails/rails7_pristine/with-active_job_and_current_attributes/Gemfile
@@ -3,4 +3,4 @@
 source 'https://rubygems.org'
 
 gem 'karafka', path: ENV.fetch('KARAFKA_GEM_DIR'), require: true
-gem 'rails', '7.0.7', require: true
+gem 'rails', '7.0.8', require: true

--- a/spec/integrations/rails/rails6_pristine/just-a-dependency/Gemfile
+++ b/spec/integrations/rails/rails6_pristine/just-a-dependency/Gemfile
@@ -3,4 +3,4 @@
 source 'https://rubygems.org'
 
 gem 'karafka', path: ENV.fetch('KARAFKA_GEM_DIR')
-gem 'rails', '6.1.7.4', require: true
+gem 'rails', '6.1.7.6', require: true

--- a/spec/integrations/rails/rails6_pristine/with-active_job/Gemfile
+++ b/spec/integrations/rails/rails6_pristine/with-active_job/Gemfile
@@ -3,4 +3,4 @@
 source 'https://rubygems.org'
 
 gem 'karafka', path: ENV.fetch('KARAFKA_GEM_DIR'), require: true
-gem 'rails', '6.1.7.4', require: true
+gem 'rails', '6.1.7.6', require: true

--- a/spec/integrations/rails/rails6_pristine/with-active_job/railtie_setup_spec.rb
+++ b/spec/integrations/rails/rails6_pristine/with-active_job/railtie_setup_spec.rb
@@ -35,4 +35,4 @@ start_karafka_and_wait_until do
 end
 
 assert_equal 1, DT.data.size
-assert_equal '6.1.7.4', Rails.version
+assert_equal '6.1.7.6', Rails.version

--- a/spec/integrations/rails/rails6_pristine/without-a-boot-file/Gemfile
+++ b/spec/integrations/rails/rails6_pristine/without-a-boot-file/Gemfile
@@ -3,5 +3,5 @@
 source 'https://rubygems.org'
 
 gem 'karafka', path: ENV.fetch('KARAFKA_GEM_DIR'), require: true
-gem 'rails', '6.1.7.4', require: true
+gem 'rails', '6.1.7.6', require: true
 gem 'rspec-rails'

--- a/spec/integrations/rails/rails6_pristine/without-active_job/Gemfile
+++ b/spec/integrations/rails/rails6_pristine/without-active_job/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'activerecord', '6.1.7.4'
-gem 'activesupport', '6.1.7.4'
+gem 'activerecord', '6.1.7.6'
+gem 'activesupport', '6.1.7.6'
 gem 'karafka', path: ENV.fetch('KARAFKA_GEM_DIR'), require: true
-gem 'railties', '6.1.7.4'
+gem 'railties', '6.1.7.6'

--- a/spec/integrations/rails/rails6_pristine/without-active_job/railtie_setup_spec.rb
+++ b/spec/integrations/rails/rails6_pristine/without-active_job/railtie_setup_spec.rb
@@ -36,4 +36,4 @@ start_karafka_and_wait_until do
 end
 
 assert_equal 1, DT.data.size
-assert_equal '6.1.7.4', Rails.version
+assert_equal '6.1.7.6', Rails.version

--- a/spec/integrations/rails/rails6_pristine/without-active_job_rspec/Gemfile
+++ b/spec/integrations/rails/rails6_pristine/without-active_job_rspec/Gemfile
@@ -2,8 +2,8 @@
 
 source 'https://rubygems.org'
 
-gem 'activerecord', '6.1.7.4'
-gem 'activesupport', '6.1.7.4'
+gem 'activerecord', '6.1.7.6'
+gem 'activesupport', '6.1.7.6'
 gem 'karafka', path: ENV.fetch('KARAFKA_GEM_DIR'), require: true
-gem 'railties', '6.1.7.4'
+gem 'railties', '6.1.7.6'
 gem 'rspec-rails'

--- a/spec/integrations/rails/rails7_pristine/just-a-dependency/Gemfile
+++ b/spec/integrations/rails/rails7_pristine/just-a-dependency/Gemfile
@@ -3,4 +3,4 @@
 source 'https://rubygems.org'
 
 gem 'karafka', path: ENV.fetch('KARAFKA_GEM_DIR')
-gem 'rails', '7.0.7', require: true
+gem 'rails', '7.0.8', require: true

--- a/spec/integrations/rails/rails7_pristine/with-active_job/Gemfile
+++ b/spec/integrations/rails/rails7_pristine/with-active_job/Gemfile
@@ -3,4 +3,4 @@
 source 'https://rubygems.org'
 
 gem 'karafka', path: ENV.fetch('KARAFKA_GEM_DIR'), require: true
-gem 'rails', '7.0.7', require: true
+gem 'rails', '7.0.8', require: true

--- a/spec/integrations/rails/rails7_pristine/with-active_job/railtie_setup_spec.rb
+++ b/spec/integrations/rails/rails7_pristine/with-active_job/railtie_setup_spec.rb
@@ -35,4 +35,4 @@ start_karafka_and_wait_until do
 end
 
 assert_equal 1, DT.data.size
-assert_equal '7.0.7', Rails.version
+assert_equal '7.0.8', Rails.version

--- a/spec/integrations/rails/rails7_pristine/with-active_job_and_current_attributes/Gemfile
+++ b/spec/integrations/rails/rails7_pristine/with-active_job_and_current_attributes/Gemfile
@@ -3,4 +3,4 @@
 source 'https://rubygems.org'
 
 gem 'karafka', path: ENV.fetch('KARAFKA_GEM_DIR'), require: true
-gem 'rails', '7.0.7', require: true
+gem 'rails', '7.0.8', require: true

--- a/spec/integrations/rails/rails7_pristine/without-active_job/Gemfile
+++ b/spec/integrations/rails/rails7_pristine/without-active_job/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-gem 'activerecord', '7.0.7'
-gem 'activesupport', '7.0.7'
+gem 'activerecord', '7.0.8'
+gem 'activesupport', '7.0.8'
 gem 'karafka', path: ENV.fetch('KARAFKA_GEM_DIR'), require: true
-gem 'railties', '7.0.7'
+gem 'railties', '7.0.8'

--- a/spec/integrations/rails/rails7_pristine/without-active_job/railtie_setup_spec.rb
+++ b/spec/integrations/rails/rails7_pristine/without-active_job/railtie_setup_spec.rb
@@ -36,4 +36,4 @@ start_karafka_and_wait_until do
 end
 
 assert_equal 1, DT.data.size
-assert_equal '7.0.7', Rails.version
+assert_equal '7.0.8', Rails.version

--- a/spec/integrations/rails/rails7_pristine/without-active_job_rspec/Gemfile
+++ b/spec/integrations/rails/rails7_pristine/without-active_job_rspec/Gemfile
@@ -2,8 +2,8 @@
 
 source 'https://rubygems.org'
 
-gem 'activerecord', '7.0.7'
-gem 'activesupport', '7.0.7'
+gem 'activerecord', '7.0.8'
+gem 'activesupport', '7.0.8'
 gem 'karafka', path: ENV.fetch('KARAFKA_GEM_DIR'), require: true
-gem 'railties', '7.0.7'
+gem 'railties', '7.0.8'
 gem 'rspec-rails'


### PR DESCRIPTION
To make them run in parallel and not overload Kafka with crazy number of topics, etc on GH machines, this PR splits the work.

On top of that it retries (once) docker-compose in case it would fail. I've seen some docker API temporary errors that just go away with second run after backoff.

OSS integrations run now around 10 minutes
Pro around 25-30.

In total the parallel execution went down from 40-45 minutes in total to around 30m.

close https://github.com/karafka/karafka/issues/1573
superseeds: https://github.com/karafka/karafka/pull/1543