### PR TITLE
Retry watermark offsets reading for lack of leader of partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka framework changelog
 
+## 2.2.6 (Unreleased)
+- [Enhancement] Retry `Karafka::Admin#read_watermark_offsets` fetching upon `not_leader_for_partition` that can occur mostly on newly created topics in KRaft and after crashes during leader selection.
+
 ## 2.2.5 (2023-09-25)
 - [Enhancement] Ensure, that when topic related operations end, the result is usable. There were few cases where admin operations on topics would finish successfully but internal Kafka caches would not report changes for a short period of time.
 - [Enhancement] Stabilize cooperative-sticky early shutdown procedure.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka (2.2.5)
+    karafka (2.2.6)
       karafka-core (>= 2.2.2, < 2.3.0)
       thor (>= 0.20)
       waterdrop (>= 2.6.6, < 3.0.0)

--- a/lib/karafka/admin.rb
+++ b/lib/karafka/admin.rb
@@ -142,7 +142,12 @@ module Karafka
       # @return [Array<Integer, Integer>] low watermark offset and high watermark offset
       def read_watermark_offsets(name, partition)
         with_consumer do |consumer|
-          consumer.query_watermark_offsets(name, partition)
+          # For newly created topics or in cases where we're trying to get them but there is no
+          # leader, this can fail. It happens more often for new topics under KRaft, however we
+          # still want to make sure things operate as expected even then
+          with_rdkafka_retry(codes: %i[not_leader_for_partition]) do
+            consumer.query_watermark_offsets(name, partition)
+          end
         end
       end
 
@@ -226,6 +231,31 @@ module Karafka
         retry if attempt <= app_config.admin.max_attempts
 
         raise
+      end
+
+      # Handles retries for rdkafka related errors that we specify in `:codes`.
+      #
+      # Some operations temporarily fail, especially for cases where we changed something fast
+      # like topic creation or repartitioning. In cases like this it is ok to retry operations that
+      # do not change the state as it will usually recover.
+      #
+      # @param codes [Array<Symbol>] librdkafka error codes on which we want to retry
+      # @param max_attempts [Integer] number of attempts (including initial) after which we should
+      #   give up
+      #
+      # @note This code implements a simple backoff that increases with each attempt.
+      def with_rdkafka_retry(codes:, max_attempts: 5)
+        attempt ||= 0
+        attempt += 1
+
+        yield
+      rescue Rdkafka::RdkafkaError => e
+        raise unless codes.include?(e.code)
+        raise if attempt >= max_attempts
+
+        sleep(max_attempts)
+
+        retry
       end
 
       # @param type [Symbol] type of config we want

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '2.2.5'
+  VERSION = '2.2.6'
 end


### PR DESCRIPTION
In this update, I've added a retry mechanism to the `Karafka::Admin#read_watermark_offsets` method. This enhancement addresses the `not_leader_for_partition` error that can often arise under two main scenarios:

- When topics are newly created in KRaft.
- Following unexpected crashes that happen during the leader selection phase.

The primary goal of this enhancement is to ensure that our system remains resilient and can recover gracefully in cases where the `not_leader_for_partition` error is encountered. By implementing this retry logic, I aim to provide a smoother and more reliable user experience, especially in the above mentioned scenarios.

ref https://github.com/appsignal/rdkafka-ruby/issues/289