### PR TITLE
Improve InlineInsights tracker stability

### DIFF
--- a/lib/karafka/processing/inline_insights/tracker.rb
+++ b/lib/karafka/processing/inline_insights/tracker.rb
@@ -15,7 +15,7 @@ module Karafka
       #   when using LRJ a lost partition data would not be present anymore, however we would still
       #   be in the processing phase. Since those metrics are published with each `poll`, regular
       #   processing is not a subject of this issue. For LRJ we keep the reference. The only case
-      #   where this could be switched midway is when LRJ is running for an extended perio of time
+      #   where this could be switched midway is when LRJ is running for an extended period of time
       #   after the involuntary revocation. Having a time based cache instead of tracking
       #   simplifies the design as we do not have to deal with state tracking, especially since
       #   we would have to track also operations running in a revoked state.

--- a/lib/karafka/processing/inline_insights/tracker.rb
+++ b/lib/karafka/processing/inline_insights/tracker.rb
@@ -3,20 +3,47 @@
 module Karafka
   module Processing
     module InlineInsights
-      # Object used to t
+      # Object used to track statistics coming from librdkafka in a way that can be accessible by
+      # the consumers
       #
       # We use a single tracker because we do not need state management here as our consumer groups
       # clients identified by statistics name value are unique. On top of that, having a per
       # process one that is a singleton allows us to use tracker easily also from other places like
       # filtering API etc.
+      #
+      # @note We include cache of 5 minutes for revoked partitions to compensate for cases where
+      #   when using LRJ a lost partition data would not be present anymore, however we would still
+      #   be in the processing phase. Since those metrics are published with each `poll`, regular
+      #   processing is not a subject of this issue. For LRJ we keep the reference. The only case
+      #   where this could be switched midway is when LRJ is running for an extended perio of time
+      #   after the involuntary revocation. Having a time based cache instead of tracking
+      #   simplifies the design as we do not have to deal with state tracking, especially since
+      #   we would have to track also operations running in a revoked state.
+      #
+      # @note This tracker keeps in memory data about all topics and partitions that it encounters
+      #   because in case of routing patterns, we may start getting statistics prior to registering
+      #   given topic via dynamic routing expansions. In such case we would not have insights
+      #   where they were actually available for us to use.
+      #
+      # @note Memory usage is negligible as long as we can evict expired data. Single metrics set
+      #   for a single partition contains around 4KB of data. This means, that in case of an
+      #   assignment of 1000 partitions, we use around 4MB of space for tracking those metrics.
       class Tracker
         include Singleton
+        include Karafka::Core::Helpers::Time
 
         # Empty hash we want to return in any case where we could not locate appropriate topic
         # partition statistics.
         EMPTY_HASH = {}.freeze
 
-        private_constant :EMPTY_HASH
+        # Empty array to save on memory allocations.
+        EMPTY_ARRAY = [].freeze
+
+        # 5 minutes of cache. We cache last result per consumer group topic partition so we are
+        # not affected by involuntary rebalances during LRJ execution.
+        TTL = 5 * 60 * 1_000
+
+        private_constant :EMPTY_HASH, :EMPTY_ARRAY, :TTL
 
         class << self
           extend Forwardable
@@ -25,21 +52,30 @@ module Karafka
         end
 
         def initialize
-          @accu = Hash.new { |h, k| h[k] = {} }
+          @accu = {}
           @mutex = Mutex.new
         end
 
-        # Adds client statistics into internal accumulator. Single statistics set may contain data
-        # from multiple topics and their partitions because a single client can operate on multiple
-        # topics and partitions. This is why during the `#find` request we locate appropriate data
-        # from within of this set of metrics
+        # Adds each partition statistics into internal accumulator. Single statistics set may
+        # contain data from multiple topics and their partitions because a single client can
+        # operate on multiple topics and partitions.
+        #
+        # We iterate over those topics and partitions and store topics partitions data only.
         #
         # @param consumer_group_id [String] id of the consumer group for which statistics were
         #   emitted.
         # @param statistics [Hash] librdkafka enriched statistics
         def add(consumer_group_id, statistics)
           @mutex.synchronize do
-            @accu[consumer_group_id][statistics.fetch('name')] = statistics
+            statistics.fetch('topics', EMPTY_HASH).each do |topic_name, t_details|
+              t_details.fetch('partitions', EMPTY_HASH).each do |partition_id, p_details|
+                key = "#{consumer_group_id}_#{topic_name}_#{partition_id}"
+
+                @accu[key] = [monotonic_now, p_details]
+              end
+            end
+
+            evict
           end
         end
 
@@ -51,21 +87,10 @@ module Karafka
         #
         # @note We do not enclose it with a mutex mainly because the only thing that could happen
         #   here that would be a race-condition is a miss that anyhow we need to support due to
-        #   how librdkafka ships metrics.
+        #   how librdkafka ships metrics and a potential removal of data on heavily revoked LRJ.
         def find(topic, partition)
-          @accu
-            .fetch(topic.consumer_group.id, EMPTY_HASH)
-            .each_value do |statistics|
-              result = statistics
-                       .fetch('topics', EMPTY_HASH)
-                       .fetch(topic.name, EMPTY_HASH)
-                       .fetch('partitions', EMPTY_HASH)
-                       .fetch(partition.to_s, false)
-
-              return result if result
-            end
-
-          EMPTY_HASH
+          key = "#{topic.consumer_group.id}_#{topic.name}_#{partition}"
+          @accu.fetch(key, EMPTY_ARRAY).last || EMPTY_HASH
         end
 
         # @param topic [Karafka::Routing::Topic]
@@ -78,6 +103,13 @@ module Karafka
         # Clears the tracker
         def clear
           @mutex.synchronize { @accu.clear }
+        end
+
+        private
+
+        # Evicts expired data from the cache
+        def evict
+          @accu.delete_if { |_, details| monotonic_now - details.first > TTL }
         end
       end
     end


### PR DESCRIPTION
This improves the inline insights tracker, so metrics are not evicted upon new statistics availability in case new stats do not have a given topic partition anymore due to eviction.

In the case of regular processing, this change is irrelevant because `poll` occurs only when processing is done; hence the state would not change, but it is important for LRJ since LRJs run independently from `poll`. This means that upon a rebalance a partition would be revoked. we would immediately loose all the metrics that might have been still relevant to the underlying consumer instance. This change ensures that for 5 minutes AFTER the revocation, we still have them accumulated. Since the recommendation for LRJ is to periodically check `revoked?` these should be more than enough time to check it.