### PR TITLE
inline insights auto-delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Karafka framework changelog
 
 ## 2.2.7 (Unreleased)
-- **[Feature]** Introduce Inline Insights to both OSS and Pro. Inline Insights allow you to get the Kafka insights/metrics from the consumer instance and use them to alter the processing flow.
+- **[Feature]** Introduce Inline Insights to both OSS and Pro. Inline Insights allow you to get the Kafka insights/metrics from the consumer instance and use them to alter the processing flow. In Pro, there's an extra filter flow allowing to ensure, that the insignts exist during consumption.
 - [Enhancement] Make sure, that subscription groups ids are unique by including their consumer group id in them similar to how topics ids are handled (not a breaking change).
+- [Enhancement] Expose `#attempt` method on a consumer to directly indicate number of attempt of processing given data.
 
 ## 2.2.6 (2023-09-26)
 - [Enhancement] Retry `Karafka::Admin#read_watermark_offsets` fetching upon `not_leader_for_partition` that can occur mostly on newly created topics in KRaft and after crashes during leader selection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Karafka framework changelog
 
 ## 2.2.7 (Unreleased)
-- **[Feature]** Introduce Inline Insights to both OSS and Pro. Inline Insights allow you to get the Kafka insights/metrics from the consumer instance and use them to alter the processing flow. In Pro, there's an extra filter flow allowing to ensure, that the insignts exist during consumption.
+- **[Feature]** Introduce Inline Insights to both OSS and Pro. Inline Insights allow you to get the Kafka insights/metrics from the consumer instance and use them to alter the processing flow. In Pro, there's an extra filter flow allowing to ensure, that the insights exist during consumption.
 - [Enhancement] Make sure, that subscription groups ids are unique by including their consumer group id in them similar to how topics ids are handled (not a breaking change).
 - [Enhancement] Expose `#attempt` method on a consumer to directly indicate number of attempt of processing given data.
 

--- a/config/locales/pro_errors.yml
+++ b/config/locales/pro_errors.yml
@@ -31,6 +31,9 @@ en:
       patterns.active_format: 'needs to be boolean'
       patterns.type_format: 'needs to be :matcher, :discovered or :regular'
 
+      inline_insights.active_format: 'needs to be boolean'
+      inline_insights.required_format: 'needs to be boolean'
+
     consumer_group:
       patterns_format: must be an array with hashes
       patterns_missing: needs to be present

--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -252,7 +252,13 @@ module Karafka
     #   different flow after there is an error, for example for resources cleanup, small manual
     #   backoff or different instrumentation tracking.
     def retrying?
-      coordinator.pause_tracker.attempt > 1
+      attempt > 1
+    end
+
+    # @return [Integer] attempt of processing given batch. 1 if this is the first attempt or higher
+    #  in case it is a retry
+    def attempt
+      coordinator.pause_tracker.attempt
     end
 
     # Pauses the processing from the last offset to retry on given message

--- a/lib/karafka/pro/processing/filters/inline_insights_delayer.rb
+++ b/lib/karafka/pro/processing/filters/inline_insights_delayer.rb
@@ -21,7 +21,11 @@ module Karafka
         # In case it would take more than five seconds to load insights, it will just pause again
         #
         # This filter ensures, that we always have inline insights that a consumer can use
+        #
+        # It is relevant in most cases only during the process start, when first poll may not
+        # yield statistics yet but will give some data.
         class InlineInsightsDelayer < Base
+          # Minimum how long should we pause when there are no metrics
           PAUSE_TIMEOUT = 5_000
 
           private_constant :PAUSE_TIMEOUT

--- a/lib/karafka/pro/processing/filters/inline_insights_delayer.rb
+++ b/lib/karafka/pro/processing/filters/inline_insights_delayer.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Processing
+      module Filters
+        # Delayer that checks if we have appropriate insights available. If not, pauses for
+        # 5 seconds so the insights can be loaded from the broker.
+        #
+        # In case it would take more than five seconds to load insights, it will just pause again
+        #
+        # This filter ensures, that we always have inline insights that a consumer can use
+        class InlineInsightsDelayer < Base
+          PAUSE_TIMEOUT = 5_000
+
+          private_constant :PAUSE_TIMEOUT
+
+          # @param topic [Karafka::Routing::Topic]
+          # @param partition [Integer] partition
+          def initialize(topic, partition)
+            super()
+            @topic = topic
+            @partition = partition
+          end
+
+          # Pauses if inline insights would not be available. Does nothing otherwise
+          #
+          # @param messages [Array<Karafka::Messages::Message>]
+          def apply!(messages)
+            @applied = false
+            @cursor = messages.first
+
+            # Nothing to do if there were no messages
+            # This can happen when we chain filters
+            return unless @cursor
+
+            insights = ::Karafka::Processing::InlineInsights::Tracker.find(
+              @topic,
+              @partition
+            )
+
+            # If insights are available, also nothing to do here and we can just process
+            return unless insights.empty?
+
+            messages.clear
+
+            @applied = true
+          end
+
+          # @return [Integer] ms timeout in case of pause
+          def timeout
+            @cursor && applied? ? PAUSE_TIMEOUT : 0
+          end
+
+          # Pause when we had to back-off or skip if delay is not needed
+          def action
+            applied? ? :pause : :skip
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/routing/features/inline_insights.rb
+++ b/lib/karafka/pro/routing/features/inline_insights.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Routing
+      module Features
+        # Enhanced inline insights
+        # Allows you to set up an automatic filter that will ensure, that metrics are always
+        # available when processing starts.
+        class InlineInsights < Base
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/routing/features/inline_insights/config.rb
+++ b/lib/karafka/pro/routing/features/inline_insights/config.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Routing
+      module Features
+        class InlineInsights < Base
+          # Config of this feature
+          Config = Struct.new(
+            :active,
+            :required,
+            keyword_init: true
+          ) do
+            alias_method :active?, :active
+            alias_method :required?, :required
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/routing/features/inline_insights/contracts/topic.rb
+++ b/lib/karafka/pro/routing/features/inline_insights/contracts/topic.rb
@@ -23,7 +23,7 @@ module Karafka
               configure do |config|
                 config.error_messages = YAML.safe_load(
                   File.read(
-                    File.join(Karafka.gem_root, 'config', 'locales', 'errors.yml')
+                    File.join(Karafka.gem_root, 'config', 'locales', 'pro_errors.yml')
                   )
                 ).fetch('en').fetch('validations').fetch('topic')
               end

--- a/lib/karafka/pro/routing/features/inline_insights/contracts/topic.rb
+++ b/lib/karafka/pro/routing/features/inline_insights/contracts/topic.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Routing
+      module Features
+        class InlineInsights < Base
+          # Inline Insights related contracts namespace
+          module Contracts
+            # Contract for inline insights topic setup
+            class Topic < Karafka::Contracts::Base
+              configure do |config|
+                config.error_messages = YAML.safe_load(
+                  File.read(
+                    File.join(Karafka.gem_root, 'config', 'locales', 'errors.yml')
+                  )
+                ).fetch('en').fetch('validations').fetch('topic')
+              end
+
+              nested :inline_insights do
+                required(:active) { |val| [true, false].include?(val) }
+                required(:required) { |val| [true, false].include?(val) }
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/routing/features/inline_insights/topic.rb
+++ b/lib/karafka/pro/routing/features/inline_insights/topic.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Routing
+      module Features
+        class InlineInsights < Base
+          # Routing topic inline insights API
+          module Topic
+            # @param active [Boolean] should inline insights be activated
+            # @param required [Boolean] are the insights required to operate
+            def inline_insights(active = -1, required: -1)
+              # This weird style of checking allows us to activate inline insights in few ways:
+              #   - inline_insights(true)
+              #   - inline_insights(required: true)
+              #   - inline_insights(required: false)
+              #
+              # In each of those cases inline insights will become active
+              @inline_insights ||= begin
+                config = Config.new(
+                  active: active == true || (active == -1 && required != -1),
+                  required: required == true
+                )
+
+                if config.active? && config.required?
+                  factory = lambda do |topic, partition|
+                    Pro::Processing::Filters::InlineInsightsDelayer.new(topic, partition)
+                  end
+
+                  filter(factory)
+                end
+
+                config
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/integrations/consumption/retrying_flow_spec.rb
+++ b/spec/integrations/consumption/retrying_flow_spec.rb
@@ -6,7 +6,7 @@ setup_karafka(allow_errors: true)
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    DT[0] << [retrying?, coordinator.pause_tracker.attempt]
+    DT[0] << [retrying?, attempt]
 
     raise StandardError
   end

--- a/spec/integrations/pro/consumption/inline_insights/from_earliest_required_spec.rb
+++ b/spec/integrations/pro/consumption/inline_insights/from_earliest_required_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# When insights are required, we should not proceed without them
+# Because initial metrics fetch is slightly unpredictable (different with KRaft) and can be
+# impacted by the cpu load, we simulate lack by patching the tracker so first first 10 seconds
+# of running the process it returns no data
+
+setup_karafka
+
+module Patch
+  include Karafka::Core::Helpers::Time
+
+  def find(*args)
+    @started_at ||= monotonic_now
+
+    return {} if monotonic_now - @started_at < 10_000
+
+    super
+  end
+end
+
+Karafka::Processing::InlineInsights::Tracker.prepend(Patch)
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[:stats] << statistics
+    DT[:stats] << insights
+    DT[:stats_exist] << statistics?
+    DT[:stats_exist] << insights?
+
+    messages.each { |message| DT[:offsets] << message.offset }
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    inline_insights(required: true)
+  end
+end
+
+elements = DT.uuids(10)
+produce_many(DT.topic, elements)
+
+start_karafka_and_wait_until do
+  DT.key?(:stats) &&
+    DT[:stats_exist].include?(true) &&
+    !DT[:stats].last.empty? &&
+    DT[:offsets] == (0..9).to_a
+end
+
+assert_equal 0, DT[:stats].last['partition']

--- a/spec/integrations/pro/consumption/inline_insights/from_earliest_spec.rb
+++ b/spec/integrations/pro/consumption/inline_insights/from_earliest_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# We should be able to get the insights and use them via the API when they are defined
+# In Pro despite extra option, should behave same as in OSS when no forced required
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[:stats] << statistics
+    DT[:stats] << insights
+    DT[:stats_exist] << statistics?
+    DT[:stats_exist] << insights?
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    inline_insights(true)
+  end
+end
+
+elements = DT.uuids(10)
+produce_many(DT.topic, elements)
+
+start_karafka_and_wait_until do
+  DT.key?(:stats) && DT[:stats_exist].include?(true) && !DT[:stats].last.empty?
+end
+
+assert_equal 0, DT[:stats].last['partition']

--- a/spec/integrations/pro/consumption/inline_insights/multi_topic_partition_spec.rb
+++ b/spec/integrations/pro/consumption/inline_insights/multi_topic_partition_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Inline Insights should ship correct partition and topic details and not mix them
+# In Pro despite extra option, should behave same as in OSS when no forced required
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT["#{topic.name}-#{partition}"] << insights
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    config(partitions: 2)
+    consumer Consumer
+    inline_insights(true)
+  end
+
+  topic DT.topics[1] do
+    config(partitions: 2)
+    consumer Consumer
+    inline_insights(true)
+  end
+end
+
+[
+  DT.topics[0],
+  DT.topics[1]
+].each do |topic|
+  2.times do |partition|
+    elements = DT.uuids(10)
+    produce_many(topic, elements, partition: partition)
+  end
+end
+
+start_karafka_and_wait_until do
+  DT.data.size >= 4 && DT.data.all? { |sub| !sub.last.empty? }
+end
+
+DT.data.each do |key, values|
+  _topic, partition = key.split('-')
+
+  assert_equal partition.to_i, values.last['partition']
+end

--- a/spec/integrations/pro/consumption/inline_insights/post_involuntary_revocation_spec.rb
+++ b/spec/integrations/pro/consumption/inline_insights/post_involuntary_revocation_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # When given partition is lost involuntary, we still should have last info
+# In Pro despite extra option, should behave same as in OSS when no forced required
 
 setup_karafka(allow_errors: true) do |config|
   config.max_messages = 1

--- a/spec/integrations/pro/consumption/inline_insights/post_revocation_insights_lrj_spec.rb
+++ b/spec/integrations/pro/consumption/inline_insights/post_revocation_insights_lrj_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # When given partition is revoked for LRJ, we should still have its last available statistics
+# In Pro despite extra option, should behave same as in OSS when no forced required
 
 setup_karafka do |config|
   config.max_messages = 1

--- a/spec/integrations/pro/consumption/inline_insights/without_being_enabled_spec.rb
+++ b/spec/integrations/pro/consumption/inline_insights/without_being_enabled_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Karafka should not have the insights methods when insights are not enabled
+# In Pro despite extra option, should behave same as in OSS when no forced required
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[:stats] << intercept { statistics }
+    DT[:stats] << intercept { insights }
+    DT[:stats_exist] << intercept { statistics? }
+    DT[:stats_exist] << intercept { insights? }
+  end
+
+  def intercept
+    yield
+  rescue NameError
+    -1
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+  end
+end
+
+produce_many(DT.topic, DT.uuids(1))
+
+start_karafka_and_wait_until do
+  DT.key?(:stats) && DT.key?(:stats_exist)
+end
+
+assert(DT[:stats].all? { |val| val == -1 })
+assert(DT[:stats_exist].all? { |val| val == -1 })

--- a/spec/lib/karafka/base_consumer_spec.rb
+++ b/spec/lib/karafka/base_consumer_spec.rb
@@ -458,4 +458,12 @@ RSpec.describe_current do
       expect(coordinator.pause_tracker).to have_received(:expire)
     end
   end
+
+  describe '#attempt' do
+    before { allow(consumer.coordinator.pause_tracker).to receive(:attempt).and_return(1) }
+
+    it 'expect to return attempt from the pause tracker' do
+      expect(consumer.send(:attempt)).to eq(1)
+    end
+  end
 end

--- a/spec/lib/karafka/pro/processing/filters/inline_insights_delayer_spec.rb
+++ b/spec/lib/karafka/pro/processing/filters/inline_insights_delayer_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:delayer) { described_class.new(topic, partition) }
+
+  let(:topic) { build(:routing_topic) }
+  let(:partition) { rand(100) }
+  let(:message) { build(:messages_message, topic: topic.name, partition: partition) }
+
+  context 'when there are no messages' do
+    before { delayer.apply!([]) }
+
+    it { expect(delayer.applied?).to eq(false) }
+    it { expect(delayer.timeout).to eq(0) }
+    it { expect(delayer.action).to eq(:skip) }
+  end
+
+  context 'when insights exist' do
+    before do
+      expect(Karafka::Processing::InlineInsights::Tracker)
+        .to receive(:find)
+        .with(topic, partition)
+        .and_return(rand => rand)
+
+      delayer.apply!([message])
+    end
+
+    it { expect(delayer.applied?).to eq(false) }
+    it { expect(delayer.timeout).to eq(0) }
+    it { expect(delayer.action).to eq(:skip) }
+  end
+
+  context 'when insights do not exist' do
+    before { delayer.apply!([message]) }
+
+    it { expect(delayer.applied?).to eq(true) }
+    it { expect(delayer.timeout).to eq(5_000) }
+    it { expect(delayer.action).to eq(:pause) }
+  end
+end

--- a/spec/lib/karafka/pro/processing/filters/inline_insights_delayer_spec.rb
+++ b/spec/lib/karafka/pro/processing/filters/inline_insights_delayer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe_current do
 
   context 'when insights exist' do
     before do
-      expect(Karafka::Processing::InlineInsights::Tracker)
+      allow(Karafka::Processing::InlineInsights::Tracker)
         .to receive(:find)
         .with(topic, partition)
         .and_return(rand => rand)

--- a/spec/lib/karafka/pro/routing/features/inline_insights/config_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/inline_insights/config_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:config) { described_class.new(active: active, required: required) }
+
+  let(:active) { true }
+  let(:required) { true }
+
+  describe '#active?' do
+    context 'when active' do
+      let(:active) { true }
+
+      it { expect(config.active?).to eq(true) }
+    end
+
+    context 'when not active' do
+      let(:active) { false }
+
+      it { expect(config.active?).to eq(false) }
+    end
+  end
+
+  describe '#required?' do
+    context 'when required' do
+      let(:required) { true }
+
+      it { expect(config.required?).to eq(true) }
+    end
+
+    context 'when not required' do
+      let(:required) { false }
+
+      it { expect(config.required?).to eq(false) }
+    end
+  end
+end

--- a/spec/lib/karafka/pro/routing/features/inline_insights/contracts/topic_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/inline_insights/contracts/topic_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:check) { described_class.new.call(config) }
+
+  let(:config) do
+    {
+      inline_insights: {
+        active: true,
+        required: true
+      }
+    }
+  end
+
+  context 'when config is valid' do
+    it { expect(check).to be_success }
+  end
+
+  context 'when active flag is not boolean' do
+    before { config[:inline_insights][:active] = rand }
+
+    it { expect(check).not_to be_success }
+  end
+
+  context 'when required is not boolean' do
+    before { config[:inline_insights][:required] = rand }
+
+    it { expect(check).not_to be_success }
+  end
+end

--- a/spec/lib/karafka/pro/routing/features/inline_insights/topic_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/inline_insights/topic_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:topic) { build(:routing_topic) }
+
+  describe '#inline_insights' do
+    context 'when we use inline_insights without any arguments' do
+      it 'expect to initialize with defaults' do
+        expect(topic.inline_insights.active?).to eq(false)
+      end
+    end
+
+    context 'when we use inline_insights with a true' do
+      it 'expect to use proper active status' do
+        topic.inline_insights(true)
+        expect(topic.inline_insights.active?).to eq(true)
+      end
+    end
+
+    context 'when we use inline_insights via setting only required' do
+      it 'expect to use proper active status' do
+        topic.inline_insights(required: true)
+        expect(topic.inline_insights.active?).to eq(true)
+        expect(topic.inline_insights.required?).to eq(true)
+      end
+    end
+
+    context 'when we use inline_insights multiple times with different values' do
+      before do
+        topic.inline_insights(true)
+        topic.inline_insights(false)
+      end
+
+      it 'expect to use proper active status' do
+        expect(topic.inline_insights.active?).to eq(true)
+      end
+
+      it 'expect not to add any filters' do
+        expect(topic.filter.factories.count).to eq(0)
+      end
+    end
+  end
+
+  describe '#to_h' do
+    it { expect(topic.to_h[:inline_insights]).to eq(topic.inline_insights.to_h) }
+  end
+end

--- a/spec/lib/karafka/pro/routing/features/inline_insights_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/inline_insights_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  pending
+end


### PR DESCRIPTION
this PR adds the auto-backoff filter in cases where insights would not be yet available to the consumer