### PR TITLE
improve spec stability

### DIFF
--- a/spec/integrations/pro/rails/active_job/ordered_jobs_with_key_spec.rb
+++ b/spec/integrations/pro/rails/active_job/ordered_jobs_with_key_spec.rb
@@ -35,11 +35,11 @@ end
 counts = 0
 
 # First loop kicks in before initialization of the connection and we want to publish after, that
-# is why we don't run it on the first run
+# is why we don't run it on the first runs
 Karafka::App.monitor.subscribe('connection.listener.fetch_loop') do
   counts += 1
 
-  if counts == 10
+  if counts == 20
     # We dispatch in order per partition, in case it all would go to one without partitioner or
     # in case it would fail, the order will break
     2.downto(0) do |partition|


### PR DESCRIPTION
fixes this: https://github.com/karafka/karafka/actions/runs/6407381882/job/17394055431?pr=1652

it happens because we start publishing too early in this scenario.