### PR TITLE
Cross consumer synchronization API for VPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka framework changelog
 
 ## 2.2.8 (Unreleased)
+- [Improvement] Expose `#synchronize` for VPs to allow for locks when cross-VP consumers work is needed.
 - [Improvement] Provide `#collapse_until!` direct consumer API to allow for collapsed virtual partitions consumer operations together with the Filtering API for advanced use-cases.
 - [Refactor] Reorganize how rebalance events are propagated from `librdkafka` to Karafka. Replace `connection.client.rebalance_callback` with `rebalance.partitions_assigned` and `rebalance.partitions_revoked`. Introduce two extra events: `rebalance.partitions_assign` and `rebalance.partitions_revoke` to handle pre-rebalance future work.
 

--- a/lib/karafka/pro/processing/coordinator.rb
+++ b/lib/karafka/pro/processing/coordinator.rb
@@ -21,8 +21,6 @@ module Karafka
 
         def_delegators :@collapser, :collapsed?, :collapse_until!
 
-        def_delegators :@consumers_lock, :synchronize
-
         attr_reader :filter, :virtual_offset_manager
 
         # @param args [Object] anything the base coordinator accepts
@@ -31,8 +29,6 @@ module Karafka
 
           @executed = []
           @flow_lock = Mutex.new
-          # Cross-consumer lock for consumers operating in the same VP
-          @consumers_lock = Mutex.new
           @collapser = Collapser.new
           @filter = FiltersApplier.new(self)
 

--- a/lib/karafka/pro/processing/coordinator.rb
+++ b/lib/karafka/pro/processing/coordinator.rb
@@ -21,6 +21,8 @@ module Karafka
 
         def_delegators :@collapser, :collapsed?, :collapse_until!
 
+        def_delegators :@consumers_lock, :synchronize
+
         attr_reader :filter, :virtual_offset_manager
 
         # @param args [Object] anything the base coordinator accepts
@@ -29,6 +31,8 @@ module Karafka
 
           @executed = []
           @flow_lock = Mutex.new
+          # Cross-consumer lock for consumers operating in the same VP
+          @consumers_lock = Mutex.new
           @collapser = Collapser.new
           @filter = FiltersApplier.new(self)
 

--- a/lib/karafka/pro/processing/strategies/vp/default.rb
+++ b/lib/karafka/pro/processing/strategies/vp/default.rb
@@ -99,7 +99,7 @@ module Karafka
             # per partition at the same time, so no coordination is needed directly for the
             # end users
             #
-            # @parm block [Proc] block we want to run in a mutex to prevent race-conditions
+            # @param block [Proc] block we want to run in a mutex to prevent race-conditions
             def synchronize(&block)
               coordinator.synchronize(&block)
             end

--- a/lib/karafka/pro/processing/strategies/vp/default.rb
+++ b/lib/karafka/pro/processing/strategies/vp/default.rb
@@ -93,6 +93,11 @@ module Karafka
               coordinator.failure?
             end
 
+            # Allows for cross-virtual-partition consumers locks
+            def synchronize(&block)
+              coordinator.synchronize(&block)
+            end
+
             private
 
             # Prior to adding work to the queue, registers all the messages offsets into the

--- a/lib/karafka/pro/processing/strategies/vp/default.rb
+++ b/lib/karafka/pro/processing/strategies/vp/default.rb
@@ -94,6 +94,12 @@ module Karafka
             end
 
             # Allows for cross-virtual-partition consumers locks
+            #
+            # This is not needed in the non-VP flows because there is always only one consumer
+            # per partition at the same time, so no coordination is needed directly for the
+            # end users
+            #
+            # @parm block [Proc] block we want to run in a mutex to prevent race-conditions
             def synchronize(&block)
               coordinator.synchronize(&block)
             end

--- a/spec/integrations/pro/consumption/strategies/vp/pausing_concurrently_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/pausing_concurrently_spec.rb
@@ -55,7 +55,7 @@ groups = Array.new(100) { [] }
 group = 0
 
 DT[:pauses].each do |pause|
-  group += 1 unless ((current_time - 3)..(current_time + 3)).include?(pause.last)
+  group += 1 unless ((current_time - 3)..(current_time + 3)).cover?(pause.last)
 
   groups[group] << pause.first
 

--- a/spec/integrations/pro/consumption/strategies/vp/pausing_concurrently_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/pausing_concurrently_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# When we invoke pause from multiple VPs, the last one should win
+
+setup_karafka do |config|
+  config.concurrency = 10
+  config.max_messages = 500
+end
+
+DT[:in_progress] = 0
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    synchronize { DT[:in_progress] += 1 }
+
+    messages.each { |message| DT[0] << message.offset }
+
+    if DT[:in_progress] > 1
+      sleep(5)
+
+      synchronize do
+        # This should be overwritten with above, doing that twice to check, that the last one
+        # is selected for target pausing
+        pause(0, 5_000)
+        pause_offset = messages.first.offset + 5
+        DT[:pauses] << [pause_offset, Time.now.to_f]
+        pause(pause_offset, 5_000)
+      end
+    end
+
+    sleep(5)
+
+    synchronize { DT[:in_progress] -= 1 }
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    virtual_partitions(
+      partitioner: ->(msg) { msg.raw_payload }
+    )
+  end
+end
+
+produce_many(DT.topic, DT.uuids(1000))
+
+start_karafka_and_wait_until do
+  DT[0].size >= 1000
+end
+
+current_time = DT[:pauses].first.last
+
+groups = Array.new(100) { [] }
+group = 0
+
+DT[:pauses].each do |pause|
+  group += 1 unless ((current_time - 3)..(current_time + 3)).include?(pause.last)
+
+  groups[group] << pause.first
+
+  current_time = pause.last
+end
+
+first = groups.delete_if(&:empty?).map(&:last).first
+
+# No messages before the first pause should ever be processed again
+
+DT[0]
+  .sort
+  .select { |offset| offset < first }
+  .group_by(&:itself)
+  .values
+  .map(&:size)
+  .all? { |size| size == 1 }
+  .then { |no_duplicates| assert no_duplicates }


### PR DESCRIPTION
This PR introduces a cross-consumer synchronization API for VP consumers running on the same topic partition. It may ease some operations.

Additionally it adds spec to make sure that the last pause on multiple VPs is the one in use.
