### PR TITLE
Exclude specs from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ]
+  ],
+  // Do not auto-update locked Rails versions in integrations
+  // Otherwise it was trying to updat Rails 7 to 7.1 etc, where we want to always test each
+  "ignorePaths": [
+      "spec/integrations"
+  ],
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+      "config:base"
   ],
-  // Do not auto-update locked Rails versions in integrations
-  // Otherwise it was trying to updat Rails 7 to 7.1 etc, where we want to always test each
   "ignorePaths": [
       "spec/integrations"
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,5 @@
   // Otherwise it was trying to updat Rails 7 to 7.1 etc, where we want to always test each
   "ignorePaths": [
       "spec/integrations"
-  ],
+  ]
 }


### PR DESCRIPTION
Renovate creates immortal PRs for updating from Rails 7 to Rails 7.1 etc where we want to test not the latest release but each that we support. Hence we need to exclude those from Renovate not to update them.
