### PR TITLE
cancel previous runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: ci
 
-concurrency: ci-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
   pull_request:


### PR DESCRIPTION
Automatically will cancel previous runs on pushes.

This saves a lot of minutes in CI especially in karafka.