### PR TITLE
Move the locking from coordinator to VPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka framework changelog
 
+## 2.2.11 (Unreleased)
+- [Improvement] Make whole Pro VP marking as consumed concurrency safe for both async and sync scenarios.
+
 ## 2.2.10 (2023-11-02)
 - [Improvement] Allow for running `#pause` without specifying the offset (provide offset or `:consecutive`). This allows for pausing on the consecutive message (last received + 1), so after resume we will get last message received + 1 effectively not using `#seek` and not purging `librdafka` buffer preserving on networking. Please be mindful that this uses notion of last message passed from **librdkafka**, and not the last one available in the consumer (`messages.last`). While for regular cases they will be the same, when using things like DLQ, LRJs, VPs or Filtering API, those may not be the same.
 - [Improvement] **Drastically** improve network efficiency of operating with LRJ by using the `:consecutive` offset as default strategy for running LRJs without moving the offset in place and purging the data.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka framework changelog
 
 ## 2.2.11 (Unreleased)
+- [Improvement] Allow marking as consumed in the user `#synchronize` block.
 - [Improvement] Make whole Pro VP marking as consumed concurrency safe for both async and sync scenarios.
 
 ## 2.2.10 (2023-11-02)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka (2.2.10)
+    karafka (2.2.11)
       karafka-core (>= 2.2.2, < 2.3.0)
       waterdrop (>= 2.6.10, < 3.0.0)
       zeitwerk (~> 2.3)

--- a/lib/karafka/pro/processing/strategies/vp/default.rb
+++ b/lib/karafka/pro/processing/strategies/vp/default.rb
@@ -47,9 +47,9 @@ module Karafka
                 manager.mark_until(message) if coordinator.finished?
 
                 return revoked? unless manager.markable?
-              end
 
-              manager.markable? ? super(manager.markable) : revoked?
+                manager.markable? ? super(manager.markable) : revoked?
+              end
             end
 
             # @param message [Karafka::Messages::Message] blocking marks message as consumed
@@ -61,9 +61,8 @@ module Karafka
               coordinator.synchronize do
                 manager.mark(message)
                 manager.mark_until(message) if coordinator.finished?
+                manager.markable? ? super(manager.markable) : revoked?
               end
-
-              manager.markable? ? super(manager.markable) : revoked?
             end
 
             # @return [Boolean] is the virtual processing collapsed in the context of given

--- a/lib/karafka/processing/coordinator.rb
+++ b/lib/karafka/processing/coordinator.rb
@@ -59,10 +59,8 @@ module Karafka
 
       # @param offset [Integer] message offset
       def seek_offset=(offset)
-        synchronize do
-          @marked = true
-          @seek_offset = offset
-        end
+        @marked = true
+        @seek_offset = offset
       end
 
       # Increases number of jobs that we handle with this coordinator

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '2.2.10'
+  VERSION = '2.2.11'
 end

--- a/spec/integrations/pro/consumption/strategies/vp/synchronized_with_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/synchronized_with_marking_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Karafka should be able to run marking from a synchronization block and not crash despite using
+# the same lock. This ensures, that user can run synchronized code that will also mark and that
+# our internal synchronization is aligned with it.
+
+setup_karafka do |config|
+  config.concurrency = 10
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[0] << true
+
+      synchronize do
+        mark_as_consumed(message)
+        mark_as_consumed!(message)
+      end
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    virtual_partitions(
+      partitioner: ->(msg) { msg.raw_payload }
+    )
+  end
+end
+
+produce_many(DT.topic, DT.uuids(100))
+
+start_karafka_and_wait_until do
+  DT[0].size >= 100
+end
+
+# False here will mean there was nothing more to consume aside from the 100 we already did
+assert_equal false, fetch_first_offset


### PR DESCRIPTION
This PR moves the locking from the coordinator seek_offset to the VPs via the coordinator lock. This ensures that only one full marking (sync and async) can operate at the same time.