### PR TITLE
alias server as consumer in the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.2.11 (2023-11-03)
 - [Improvement] Allow marking as consumed in the user `#synchronize` block.
 - [Improvement] Make whole Pro VP marking as consumed concurrency safe for both async and sync scenarios.
+- [Improvement] Provide new alias to `karafka server`, that is: `karafka consumer`.
 
 ## 2.2.10 (2023-11-02)
 - [Improvement] Allow for running `#pause` without specifying the offset (provide offset or `:consecutive`). This allows for pausing on the consecutive message (last received + 1), so after resume we will get last message received + 1 effectively not using `#seek` and not purging `librdafka` buffer preserving on networking. Please be mindful that this uses notion of last message passed from **librdkafka**, and not the last one available in the consumer (`messages.last`). While for regular cases they will be the same, when using things like DLQ, LRJs, VPs or Filtering API, those may not be the same.

--- a/lib/karafka/cli/server.rb
+++ b/lib/karafka/cli/server.rb
@@ -12,9 +12,9 @@ module Karafka
 
       private_constant :SUPPORTED_TYPES
 
-      desc 'Starts the Karafka server (short-cut alias: "s")'
+      desc 'Starts the Karafka server (short-cut aliases: "s", "consumer")'
 
-      aliases :s
+      aliases :s, :consumer
 
       option(
         :consumer_groups,

--- a/spec/lib/karafka/cli/help_spec.rb
+++ b/spec/lib/karafka/cli/help_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe_current do
           help       # Describes available commands
           info       # Prints configuration details and other options of your application
           install    # Installs all required things for Karafka application in current directory
-          server     # Starts the Karafka server (short-cut alias: "s")
+          server     # Starts the Karafka server (short-cut aliases: "s", "consumer")
           topics     # Allows for the topics management (create, delete, reset, repartition)
       HELP
     end

--- a/spec/lib/karafka/cli/server_spec.rb
+++ b/spec/lib/karafka/cli/server_spec.rb
@@ -23,6 +23,6 @@ RSpec.describe_current do
   end
 
   describe '#names' do
-    it { expect(server_cli.class.names).to eq %w[s server] }
+    it { expect(server_cli.class.names.sort).to eq %w[s server consumer].sort }
   end
 end


### PR DESCRIPTION
close https://github.com/karafka/karafka/issues/1676

server is used everywhere so lets keep it but provide alias `karafka consumer` for ppl that want to be exact