### PR TITLE
Provide time-reliable events polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka framework changelog
 
+## 2.2.12 (Unreleased)
+- [Improvement] Rewrite the polling engine to update statistics and error callbacks despite longer non LRJ processings or long `max_wait_time` setups. This change provides stability to the statistics and background error emitting making them time-reliable.
+
 ## 2.2.11 (2023-11-03)
 - [Improvement] Allow marking as consumed in the user `#synchronize` block.
 - [Improvement] Make whole Pro VP marking as consumed concurrency safe for both async and sync scenarios.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Karafka framework changelog
 
 ## 2.2.12 (Unreleased)
-- [Improvement] Rewrite the polling engine to update statistics and error callbacks despite longer non LRJ processings or long `max_wait_time` setups. This change provides stability to the statistics and background error emitting making them time-reliable.
+- [Improvement] Rewrite the polling engine to update statistics and error callbacks despite longer non LRJ processing or long `max_wait_time` setups. This change provides stability to the statistics and background error emitting making them time-reliable.
 
 ## 2.2.11 (2023-11-03)
 - [Improvement] Allow marking as consumed in the user `#synchronize` block.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    karafka (2.2.11)
-      karafka-core (>= 2.2.6, < 2.3.0)
-      waterdrop (>= 2.6.10, < 3.0.0)
+    karafka (2.2.12)
+      karafka-core (>= 2.2.7, < 2.3.0)
+      waterdrop (>= 2.6.11, < 3.0.0)
       zeitwerk (~> 2.3)
 
 GEM
@@ -39,10 +39,10 @@ GEM
       activesupport (>= 6.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    karafka-core (2.2.6)
+    karafka-core (2.2.7)
       concurrent-ruby (>= 1.1)
-      karafka-rdkafka (>= 0.13.8, < 0.15.0)
-    karafka-rdkafka (0.13.8)
+      karafka-rdkafka (>= 0.13.9, < 0.15.0)
+    karafka-rdkafka (0.13.9)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)

--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -26,6 +26,7 @@ en:
       internal.active_job.consumer_class: cannot be nil
       internal.status_format: needs to be present
       internal.process_format: needs to be present
+      internal.tick_interval_format: needs to be an integer bigger or equal to 1000
       internal.routing.builder_format: needs to be present
       internal.routing.subscription_groups_builder_format: needs to be present
       internal.connection.proxy.query_watermark_offsets.timeout_format: needs to be an integer bigger than 0

--- a/karafka.gemspec
+++ b/karafka.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
     without having to focus on things that are not your business domain.
   DESC
 
-  spec.add_dependency 'karafka-core', '>= 2.2.6', '< 2.3.0'
-  spec.add_dependency 'waterdrop', '>= 2.6.10', '< 3.0.0'
+  spec.add_dependency 'karafka-core', '>= 2.2.7', '< 2.3.0'
+  spec.add_dependency 'waterdrop', '>= 2.6.11', '< 3.0.0'
   spec.add_dependency 'zeitwerk', '~> 2.3'
 
   if $PROGRAM_NAME.end_with?('gem')

--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -100,7 +100,7 @@ module Karafka
           #
           # We also do early break, so the information about rebalance is used as soon as possible
           if @rebalance_manager.changed?
-            # Since rebalanes do not occur often, we can run events polling as well without
+            # Since rebalances do not occur often, we can run events polling as well without
             # any throttling
             events_poll
             remove_revoked_and_duplicated_messages
@@ -530,16 +530,14 @@ module Karafka
         # polling again as we are withing user expected max wait time
         used = remaining - time_poll.remaining
 
-        if used >= poll_tick
-          # If we did not exceed total time allocated, it means that we finished because of the
-          # tick interval time limitations and not because time run out without any data
-          time_poll.exceeded? ? nil : :tick_time
-        else
-          # In case we did not use enough time, it means that an internal event occured that
-          # means that something has changed without messages being published. For example a
-          # rebalance. In cases like this we finish early as well
-          nil
-        end
+        # In case we did not use enough time, it means that an internal event occured that means
+        # that something has changed without messages being published. For example a rebalance.
+        # In cases like this we finish early as well
+        return nil if used < poll_tick
+
+        # If we did not exceed total time allocated, it means that we finished because of the
+        # tick interval time limitations and not because time run out without any data
+        time_poll.exceeded? ? nil : :tick_time
       rescue ::Rdkafka::RdkafkaError => e
         early_report = false
 

--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -311,13 +311,13 @@ module Karafka
         @kafka = build_consumer
       end
 
-      # Runs a single poll ignoring all the potential errors
+      # Runs a single poll on the main queue and consumer queue ignoring all the potential errors
       # This is used as a keep-alive in the shutdown stage and any errors that happen here are
       # irrelevant from the shutdown process perspective
       #
-      # This is used only to trigger rebalance callbacks
+      # This is used only to trigger rebalance callbacks and other callbacks
       def ping
-        @events_poller.call
+        events_poll(100)
         poll(100)
       rescue Rdkafka::RdkafkaError
         nil

--- a/lib/karafka/connection/listener.rb
+++ b/lib/karafka/connection/listener.rb
@@ -14,7 +14,7 @@ module Karafka
       # @return [String] id of this listener
       attr_reader :id
 
-      # How long to wait in the initial events poll. Increases changes of having the initial events
+      # How long to wait in the initial events poll. Increases chances of having the initial events
       # immediately available
       INITIAL_EVENTS_POLL_TIMEOUT = 100
 

--- a/lib/karafka/connection/listener.rb
+++ b/lib/karafka/connection/listener.rb
@@ -97,7 +97,7 @@ module Karafka
         # In theory this may slow down the initial boot but we limit it up to 100ms, so it should
         # not have a big initial impact. It may not be enough but Karafka does not give the boot
         # warranties of statistics or other callbacks being immediately available, hence this is
-        # a fair tradeoff
+        # a fair trade-off
         @client.events_poll(INITIAL_EVENTS_POLL_TIMEOUT)
 
         # Run the main loop as long as we are not stopping or moving into quiet mode

--- a/lib/karafka/contracts/config.rb
+++ b/lib/karafka/contracts/config.rb
@@ -46,6 +46,9 @@ module Karafka
       nested(:internal) do
         required(:status) { |val| !val.nil? }
         required(:process) { |val| !val.nil? }
+        # In theory this could be less than a second, however this would impact the maximum time
+        # of a single consumer queue poll, hence we prevent it
+        required(:tick_interval) { |val| val.is_a?(Integer) && val >= 1_000 }
 
         nested(:connection) do
           nested(:proxy) do

--- a/lib/karafka/helpers/interval_runner.rb
+++ b/lib/karafka/helpers/interval_runner.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Karafka
+  module Helpers
+    # Object responsible for running given code with a given interval. It won't run given code
+    # more often than with a given interval.
+    #
+    # This allows us to execute certain code only once in a while.
+    #
+    # This can be used when we have code that could be invoked often due to it being in loops
+    # or other places but would only slow things down if would run with each tick.
+    class IntervalRunner
+      include Karafka::Core::Helpers::Time
+
+      # @param interval [Integer] interval in ms for running the provided code. Defaults to the
+      #   `internal.tick_interval` value
+      # @param block [Proc] block of code we want to run once in a while
+      def initialize(interval: ::Karafka::App.config.internal.tick_interval, &block)
+        @block = block
+        @interval = interval
+        @last_called_at = monotonic_now - @interval
+      end
+
+      # Runs the requested code if it was not executed previously recently
+      def call
+        return if monotonic_now - @last_called_at < @interval
+
+        @last_called_at = monotonic_now
+
+        @block.call
+      end
+
+      # Resets the runner, so next `#call` will run the underlying code
+      def reset
+        @last_called_at = monotonic_now - @interval
+      end
+    end
+  end
+end

--- a/lib/karafka/processing/timed_queue.rb
+++ b/lib/karafka/processing/timed_queue.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Karafka
+  module Processing
+    # Minimal queue with timeout for Ruby 3.1 and lower.
+    #
+    # It is needed because only since 3.2, Ruby has a timeout on `#pop`
+    class TimedQueue
+      include Karafka::Core::Helpers::Time
+
+      def initialize
+        @queue = Queue.new
+        @mutex = Thread::Mutex.new
+        @resource = Thread::ConditionVariable.new
+      end
+
+      # Adds element to the queue
+      #
+      # @param obj [Object] pushes an element onto the queue
+      def push(obj)
+        @mutex.synchronize do
+          @queue << obj
+          @resource.broadcast
+        end
+      end
+
+      alias << push
+
+      # No timeout means waiting up to 31 years
+      #
+      # @param timeout [Integer] max number of seconds to wait on the pop
+      # @return [Object] element inserted on the array or `nil` on timeout
+      #
+      # @note We use timeout in seconds because this is how Ruby 3.2+ works and we want to have
+      #   the same API for newer and older Ruby versions
+      def pop(timeout: 10_000_000_000)
+        deadline = monotonic_now + timeout * 1000
+
+        @mutex.synchronize do
+          loop do
+            return @queue.pop unless @queue.empty?
+            return @queue.pop if @queue.closed?
+
+            to_wait = (deadline - monotonic_now) / 1_000.0
+
+            return nil if to_wait <= 0
+
+            @resource.wait(@mutex, to_wait)
+          end
+        end
+      end
+
+      # Closes the internal queue and releases the lock
+      def close
+        @mutex.synchronize do
+          @queue.close
+          @resource.broadcast
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -152,6 +152,17 @@ module Karafka
         #   instances
         setting :process, default: Process.new
 
+        # Interval of "ticking". This is used to define the maximum time between consecutive
+        # polling of the main rdkafka queue. It should match also the `statistics.interval.ms`
+        # smallest value defined in any of the per-kafka settings, so metrics are published with
+        # the desired frequency. It is set to 5 seconds because `statistics.interval.ms` is also
+        # set to five seconds.
+        #
+        # It is NOT allowed to set it to a value less than 1 seconds because it could cause polling
+        # not to have enough time to run. This (not directly) defines also a single poll
+        # max timeout as to allow for frequent enough events polling
+        setting :tick_interval, default: 5_000
+
         # Namespace for CLI related settings
         setting :cli do
           # option contract [Object] cli setup validation contract (in the context of options and

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '2.2.11'
+  VERSION = '2.2.12'
 end

--- a/spec/integrations/instrumentation/statistics_publishing_on_long_poll_spec.rb
+++ b/spec/integrations/instrumentation/statistics_publishing_on_long_poll_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Karafka should publish statistics even when a long blocking processing occurs and there are no
+# processing workers available as it should happen from one of the main threads.
+
+setup_karafka do |config|
+  config.concurrency = 1
+  # Publish every one second to check if this is going to be as often within the time-frame of
+  # the processing as expected
+  config.kafka[:'statistics.interval.ms'] = 1_000
+  config.internal.tick_interval = 1_000
+  config.max_wait_time = 30_000
+  config.shutdown_timeout = 35_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    raise
+  end
+end
+
+draw_routes(nil, create_topics: false) do
+  topic DT.topic do
+    consumer Consumer
+  end
+end
+
+Karafka::App.monitor.subscribe('statistics.emitted') do |event|
+  DT[:stats] << Time.now.to_f
+end
+
+Karafka::App.monitor.subscribe('connection.listener.fetch_loop.received') do |event|
+  DT[:polls] << ((Time.now.to_f - event[:time] / 1_000)..Time.now.to_f)
+end
+
+start_karafka_and_wait_until do
+  sleep(10)
+  true
+end
+
+in_polls = 0
+
+DT[:polls].each do |poll|
+  DT[:stats].each do |stat|
+    in_polls += 1 if poll.include?(stat)
+  end
+end
+
+assert DT[:stats].size >= 30
+assert in_polls >= 28

--- a/spec/integrations/instrumentation/statistics_publishing_on_long_poll_spec.rb
+++ b/spec/integrations/instrumentation/statistics_publishing_on_long_poll_spec.rb
@@ -25,7 +25,7 @@ draw_routes(nil, create_topics: false) do
   end
 end
 
-Karafka::App.monitor.subscribe('statistics.emitted') do |event|
+Karafka::App.monitor.subscribe('statistics.emitted') do |_event|
   DT[:stats] << Time.now.to_f
 end
 

--- a/spec/integrations/instrumentation/statistics_publishing_on_long_processing_spec.rb
+++ b/spec/integrations/instrumentation/statistics_publishing_on_long_processing_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Karafka should publish statistics even when a long blocking processing occurs and there are no
+# processing workers available as it should happen from one of the main threads.
+
+setup_karafka do |config|
+  config.concurrency = 1
+  # Publish every one second to check if this is going to be as often within the time-frame of
+  # the processing as expected
+  config.kafka[:'statistics.interval.ms'] = 1_000
+  config.internal.tick_interval = 1_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[:start] = Time.now.to_f
+    sleep(15)
+    DT[:stop] = Time.now.to_f
+  end
+end
+
+draw_routes(nil, create_topics: false) do
+  topic DT.topic do
+    consumer Consumer
+  end
+end
+
+produce_many(DT.topic, DT.uuids(1))
+
+Karafka::App.monitor.subscribe('statistics.emitted') do |_event|
+  DT[:stats] << Time.now.to_f
+end
+
+start_karafka_and_wait_until do
+  DT.key?(:stop)
+end
+
+range = DT[:start]..DT[:stop]
+
+in_between = DT[:stats].select { |time| range.include?(time) }.size
+
+# It should be in between 14 and 16 as we have 15 seconds and we tick every second
+assert in_between >= 14
+assert in_between <= 16

--- a/spec/integrations/instrumentation/statistics_publishing_on_long_processing_spec.rb
+++ b/spec/integrations/instrumentation/statistics_publishing_on_long_processing_spec.rb
@@ -37,7 +37,7 @@ end
 
 range = DT[:start]..DT[:stop]
 
-in_between = DT[:stats].select { |time| range.include?(time) }.size
+in_between = DT[:stats].count { |time| range.include?(time) }
 
 # It should be in between 14 and 16 as we have 15 seconds and we tick every second
 assert in_between >= 14

--- a/spec/integrations/pro/consumption/strategies/lrj/default/concurrent_operations_execution_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/default/concurrent_operations_execution_spec.rb
@@ -76,7 +76,7 @@ start_karafka_and_wait_until do
   DT.key?(:done)
 end
 
-assert_equal 2, DT[:polls].size
+assert DT[:polls].size >= 2
 
 border_poll = DT[:polls].last
 

--- a/spec/lib/karafka/contracts/config_spec.rb
+++ b/spec/lib/karafka/contracts/config_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe_current do
       internal: {
         status: Karafka::Status.new,
         process: Karafka::Process.new,
+        tick_interval: 5_000,
         connection: {
           proxy: {
             query_watermark_offsets: {
@@ -374,6 +375,18 @@ RSpec.describe_current do
   context 'when we validate internal components' do
     context 'when internals are missing' do
       before { config.delete(:internal) }
+
+      it { expect(contract.call(config)).not_to be_success }
+    end
+
+    context  'when tick_interval is less than 1 second' do
+      before { config[:internal][:tick_interval] = 999 }
+
+      it { expect(contract.call(config)).not_to be_success }
+    end
+
+    context  'when tick_interval is missing' do
+      before { config[:internal].delete(:tick_interval) }
 
       it { expect(contract.call(config)).not_to be_success }
     end

--- a/spec/lib/karafka/helpers/interval_runner_spec.rb
+++ b/spec/lib/karafka/helpers/interval_runner_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:runner) { described_class.new(interval: 500) { buffer << true } }
+
+  let(:buffer) { [] }
+
+  context 'when we run it for the first time' do
+    it { expect { runner.call }.to change(buffer, :size).from(0).to(1) }
+  end
+
+  context 'when consecutive calls within time window' do
+    before { runner.call }
+
+    it { expect { 100.times { runner.call } }.not_to change(buffer, :size) }
+  end
+
+  context 'when running after reset' do
+    before do
+      runner.call
+      runner.reset
+    end
+
+    it { expect { runner.call }.to change(buffer, :size).from(1).to(2) }
+  end
+
+  context 'when running after the window' do
+    before do
+      runner.call
+      sleep(0.5)
+    end
+
+    it { expect { runner.call }.to change(buffer, :size).from(1).to(2) }
+  end
+end

--- a/spec/lib/karafka/processing/timed_queue_spec.rb
+++ b/spec/lib/karafka/processing/timed_queue_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  let(:queue) { described_class.new }
+  let(:object) { Object.new }
+
+  describe '#push and #pop' do
+    it 'allows pushing and popping an object' do
+      expect { queue.push(object) }.to change { queue.pop(timeout: 0) }.from(nil).to(object)
+    end
+  end
+
+  describe '#pop' do
+    context 'when queue is empty' do
+      it 'returns nil when timeout is exceeded' do
+        expect(queue.pop(timeout: 0.1)).to be_nil
+      end
+
+      it 'waits for an object to be pushed and pops it' do
+        popped_object = nil
+        thread = Thread.new { popped_object = queue.pop(timeout: 1) }
+
+        # Ensure the thread is waiting
+        sleep(0.1)
+        queue.push(object)
+
+        thread.join # wait for the thread to end
+        expect(popped_object).to eq object
+      end
+    end
+
+    context 'when the queue has elements' do
+      before do
+        queue.push(object)
+      end
+
+      it 'returns the object immediately' do
+        expect(queue.pop(timeout: 1)).to eq object
+      end
+    end
+
+    context 'when the queue is closed' do
+      it 'returns nil immediately' do
+        queue.close
+        expect(queue.pop(timeout: 1)).to be_nil
+      end
+    end
+  end
+
+  describe '#close' do
+    let(:threads) do
+      Array.new(3) do
+        Thread.new do
+          queue.pop(timeout: 1)
+        end
+      end
+    end
+
+    it 'causes #pop to return nil' do
+      queue.close
+      expect(queue.pop(timeout: 1)).to be_nil
+    end
+
+    it 'wakes up all waiting threads with nil' do
+      sleep(0.1) # give threads time to block
+      queue.close
+      threads.each(&:join) # wait for all threads to end
+
+      threads.each { |thread| expect(thread.value).to be_nil }
+    end
+  end
+end


### PR DESCRIPTION
This PR replaces a single queue based consumer client with one that handles consumer and other events independently + provides a tick engine for periodic checking also when locked during processing or long pollings.

It does NOT increase number of threads needed and performance impact should be neglectable.

This PR allows us to ensure we are publishing statistics more or less every 5 seconds and that they are updated despite processing state or any features usage.
