### PR TITLE
Instrument before enqueue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka framework changelog
 
+## 2.2.13 (Unreleased)
+- [Improvement] Instrument `consumer.before_enqueue`.
+
 ## 2.2.12 (2023-11-09)
 - [Improvement] Rewrite the polling engine to update statistics and error callbacks despite longer non LRJ processing or long `max_wait_time` setups. This change provides stability to the statistics and background error emitting making them time-reliable.
 - [Improvement] Auto-update Inline Insights if new insights are present for all consumers and not only LRJ (OSS and Pro).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka (2.2.12)
+    karafka (2.2.13)
       karafka-core (>= 2.2.7, < 2.3.0)
       waterdrop (>= 2.6.11, < 3.0.0)
       zeitwerk (~> 2.3)

--- a/lib/karafka/instrumentation/notifications.rb
+++ b/lib/karafka/instrumentation/notifications.rb
@@ -43,6 +43,7 @@ module Karafka
         rebalance.partitions_revoke
         rebalance.partitions_revoked
 
+        consumer.before_enqueue
         consumer.consume
         consumer.consumed
         consumer.consuming.pause

--- a/lib/karafka/pro/processing/strategies/default.rb
+++ b/lib/karafka/pro/processing/strategies/default.rb
@@ -29,6 +29,8 @@ module Karafka
 
           # No actions needed for the standard flow here
           def handle_before_enqueue
+            Karafka.monitor.instrument('consumer.before_enqueue', caller: self)
+
             nil
           end
 

--- a/lib/karafka/pro/processing/strategies/vp/default.rb
+++ b/lib/karafka/pro/processing/strategies/vp/default.rb
@@ -111,6 +111,8 @@ module Karafka
             # @note This can be done without the mutex, because it happens from the same thread
             #   for all the work (listener thread)
             def handle_before_enqueue
+              super
+
               coordinator.virtual_offset_manager.register(
                 messages.map(&:offset)
               )

--- a/lib/karafka/processing/strategies/default.rb
+++ b/lib/karafka/processing/strategies/default.rb
@@ -78,6 +78,8 @@ module Karafka
 
         # No actions needed for the standard flow here
         def handle_before_enqueue
+          Karafka.monitor.instrument('consumer.before_enqueue', caller: self)
+
           nil
         end
 

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '2.2.12'
+  VERSION = '2.2.13'
 end

--- a/spec/integrations/instrumentation/before_enqueue_jobs_tracking_spec.rb
+++ b/spec/integrations/instrumentation/before_enqueue_jobs_tracking_spec.rb
@@ -23,4 +23,4 @@ start_karafka_and_wait_until do
   DT[:events].size >= 10
 end
 
-assert DT[:events].all? { |detail| detail.is_a?(Consumer) }
+assert(DT[:events].all? { |detail| detail.is_a?(Consumer) })

--- a/spec/integrations/instrumentation/before_enqueue_jobs_tracking_spec.rb
+++ b/spec/integrations/instrumentation/before_enqueue_jobs_tracking_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Karafka should instrument prior to each consumer being enqueued
+
+setup_karafka do |config|
+  config.max_messages = 1
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume; end
+end
+
+draw_routes(Consumer)
+
+elements = DT.uuids(10)
+produce_many(DT.topic, elements)
+
+Karafka::App.monitor.subscribe('consumer.before_enqueue') do |event|
+  DT[:events] << event[:caller]
+end
+
+start_karafka_and_wait_until do
+  DT[:events].size >= 10
+end
+
+assert DT[:events].all? { |detail| detail.is_a?(Consumer) }


### PR DESCRIPTION
This PR adds instrumentation to the before enqueue event. Useful for monitoring work that will be saturated.
