### PR TITLE
Limit concurrent ruby usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.2.13 (Unreleased)
 - [Improvement] Instrument `consumer.before_enqueue`.
+- [Improvement] Limit usage of `concurrent-ruby` (plan to remove it as a dependency fully)
 
 ## 2.2.12 (2023-11-09)
 - [Improvement] Rewrite the polling engine to update statistics and error callbacks despite longer non LRJ processing or long `max_wait_time` setups. This change provides stability to the statistics and background error emitting making them time-reliable.

--- a/lib/karafka.rb
+++ b/lib/karafka.rb
@@ -16,7 +16,6 @@
   singleton
   digest
   zeitwerk
-  concurrent/atomic/atomic_fixnum
 ].each(&method(:require))
 
 # Karafka framework main namespace

--- a/lib/karafka/routing/builder.rb
+++ b/lib/karafka/routing/builder.rb
@@ -21,7 +21,7 @@ module Karafka
 
       def initialize
         @mutex = Mutex.new
-        @draws = Array.new
+        @draws = []
         @defaults = EMPTY_DEFAULTS
         super
       end
@@ -78,9 +78,9 @@ module Karafka
       # @param block [Proc] block with per-topic evaluated defaults
       # @return [Proc] defaults that should be evaluated per topic
       def defaults(&block)
-        @mutex.synchronize do
-          return @defaults unless block
+        return @defaults unless block
 
+        @mutex.synchronize do
           @defaults = block
         end
       end

--- a/lib/karafka/routing/builder.rb
+++ b/lib/karafka/routing/builder.rb
@@ -80,8 +80,12 @@ module Karafka
       def defaults(&block)
         return @defaults unless block
 
-        @mutex.synchronize do
+        if @mutex.owned?
           @defaults = block
+        else
+          @mutex.synchronize do
+            @defaults = block
+          end
         end
       end
 

--- a/lib/karafka/routing/builder.rb
+++ b/lib/karafka/routing/builder.rb
@@ -3,20 +3,25 @@
 module Karafka
   module Routing
     # Builder used as a DSL layer for building consumers and telling them which topics to consume
+    #
+    # @note We lock the access just in case this is used in patterns. The locks here do not have
+    #   any impact on routing usage unless being expanded, so no race conditions risks.
+    #
     # @example Build a simple (most common) route
     #   consumers do
     #     topic :new_videos do
     #       consumer NewVideosConsumer
     #     end
     #   end
-    class Builder < Concurrent::Array
+    class Builder < Array
       # Empty default per-topic config
       EMPTY_DEFAULTS = ->(_) {}.freeze
 
       private_constant :EMPTY_DEFAULTS
 
       def initialize
-        @draws = Concurrent::Array.new
+        @mutex = Mutex.new
+        @draws = Array.new
         @defaults = EMPTY_DEFAULTS
         super
       end
@@ -34,21 +39,23 @@ module Karafka
       #     end
       #   end
       def draw(&block)
-        @draws << block
+        @mutex.synchronize do
+          @draws << block
 
-        instance_eval(&block)
+          instance_eval(&block)
 
-        each do |consumer_group|
-          # Validate consumer group settings
-          Contracts::ConsumerGroup.new.validate!(consumer_group.to_h)
+          each do |consumer_group|
+            # Validate consumer group settings
+            Contracts::ConsumerGroup.new.validate!(consumer_group.to_h)
 
-          # and then its topics settings
-          consumer_group.topics.each do |topic|
-            Contracts::Topic.new.validate!(topic.to_h)
+            # and then its topics settings
+            consumer_group.topics.each do |topic|
+              Contracts::Topic.new.validate!(topic.to_h)
+            end
+
+            # Initialize subscription groups after all the routing is done
+            consumer_group.subscription_groups
           end
-
-          # Initialize subscription groups after all the routing is done
-          consumer_group.subscription_groups
         end
       end
 
@@ -61,17 +68,21 @@ module Karafka
 
       # Clears the builder and the draws memory
       def clear
-        @defaults = EMPTY_DEFAULTS
-        @draws.clear
-        super
+        @mutex.synchronize do
+          @defaults = EMPTY_DEFAULTS
+          @draws.clear
+          super
+        end
       end
 
       # @param block [Proc] block with per-topic evaluated defaults
       # @return [Proc] defaults that should be evaluated per topic
       def defaults(&block)
-        return @defaults unless block
+        @mutex.synchronize do
+          return @defaults unless block
 
-        @defaults = block
+          @defaults = block
+        end
       end
 
       private

--- a/spec/integrations/consumption/with_mixed_performance_in_subscription_group_spec.rb
+++ b/spec/integrations/consumption/with_mixed_performance_in_subscription_group_spec.rb
@@ -19,7 +19,7 @@ setup_karafka do |config|
   config.concurrency = 10
 end
 
-POLL = Concurrent::Array.new(6) { |i| i }
+POLL = Array.new(6) { |i| i }
 POLL << 8
 POLL.reverse!
 

--- a/spec/integrations/pro/consumption/strategies/ftr/static_throttler_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/static_throttler_spec.rb
@@ -19,18 +19,17 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-module Factory
-  THROTTLERS = {}
-
+class Factory
   MUTEX = Mutex.new
 
   class << self
     def call(topic, partition)
       MUTEX.synchronize do
-        THROTTLERS["#{topic.name}-#{partition}"] ||= begin
-          # We set 10 seconds so we can trigger a rebalance and check that it still complies
-          ::Karafka::Pro::Processing::Filters::Throttler.new(5, 10_000)
-        end
+        @cache ||= {}
+
+        key = "#{topic.name}-#{partition}"
+        # We set 10 seconds so we can trigger a rebalance and check that it still complies
+        @cache[key] ||= ::Karafka::Pro::Processing::Filters::Throttler.new(5, 10_000)
       end
     end
   end

--- a/spec/integrations/pro/consumption/strategies/vp/many_distributed_batches_end_order_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/many_distributed_batches_end_order_spec.rb
@@ -10,7 +10,7 @@ end
 Karafka.monitor.subscribe('connection.listener.fetch_loop.received') do |event|
   next if event.payload[:messages_buffer].empty?
 
-  DT[:batches] << Concurrent::Array.new
+  DT[:batches] << []
 end
 
 class Consumer < Karafka::BaseConsumer

--- a/spec/integrations/rebalancing/on_partition_data_revoked_spec.rb
+++ b/spec/integrations/rebalancing/on_partition_data_revoked_spec.rb
@@ -6,7 +6,7 @@
 
 setup_karafka
 
-DT[:revoked] = Concurrent::Array.new
+DT[:revoked] = []
 DT[:pre] = Set.new
 DT[:post] = Set.new
 

--- a/spec/support/data_collector.rb
+++ b/spec/support/data_collector.rb
@@ -25,7 +25,7 @@ class DataCollector
       instance.topics
     end
 
-    # @return [Concurrent::Hash] structure for aggregating data
+    # @return [Hash] structure for aggregating data
     def data
       instance.data
     end
@@ -99,15 +99,13 @@ class DataCollector
   # Creates a collector
   def initialize
     @mutex = Mutex.new
-    @topics = Concurrent::Array.new(100) { SecureRandom.hex(8) }
+    @topics = Array.new(100) { SecureRandom.hex(8) }
     @consumer_groups = @topics
-    # We need to use a concurrent hash and not a map because we want to print this data upon
-    # failures and debugging
-    @data = Concurrent::Hash.new do |hash, key|
+    @data = Hash.new do |hash, key|
       @mutex.synchronize do
         break hash[key] if hash.key?(key)
 
-        hash[key] = ::Concurrent::Array.new
+        hash[key] = []
       end
     end
   end


### PR DESCRIPTION
This PR removes part of the concurrent-ruby 

part of https://github.com/karafka/karafka/issues/1741