### PR TITLE
Stateful state-aware scheduling API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka framework changelog
 
 ## 2.2.13 (Unreleased)
+- **[Feature]** Introduce low-level extended Scheduling API for granular control of schedulers and jobs execution [Pro].
 - [Improvement] Use separate lock for user-facing synchronization.
 - [Improvement] Instrument `consumer.before_enqueue`.
 - [Improvement] Limit usage of `concurrent-ruby` (plan to remove it as a dependency fully)

--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -16,6 +16,7 @@ en:
       max_wait_time_format: needs to be an integer bigger than 0
       kafka_format: needs to be a filled hash
       internal.processing.jobs_builder_format: cannot be nil
+      internal.processing.jobs_queue_class_format: cannot be nil
       internal.processing.scheduler_class_format: cannot be nil
       internal.processing.coordinator_class_format: cannot be nil
       internal.processing.partitioner_class_format: cannot be nil

--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -16,7 +16,7 @@ en:
       max_wait_time_format: needs to be an integer bigger than 0
       kafka_format: needs to be a filled hash
       internal.processing.jobs_builder_format: cannot be nil
-      internal.processing.scheduler_format: cannot be nil
+      internal.processing.scheduler_class_format: cannot be nil
       internal.processing.coordinator_class_format: cannot be nil
       internal.processing.partitioner_class_format: cannot be nil
       internal.processing.strategy_selector_format: cannot be nil

--- a/lib/karafka/connection/listeners_batch.rb
+++ b/lib/karafka/connection/listeners_batch.rb
@@ -9,9 +9,12 @@ module Karafka
       attr_reader :coordinators
 
       # @param jobs_queue [JobsQueue]
-      # @param scheduler [Karafka::Processing::Scheduler] scheduler we want to use
       # @return [ListenersBatch]
-      def initialize(jobs_queue, scheduler)
+      def initialize(jobs_queue)
+        # We need one scheduler for all the listeners because in case of complex schedulers, they
+        # should be able to distribute work whenever any work is done in any of the listeners
+        scheduler = App.config.internal.processing.scheduler_class.new(jobs_queue)
+
         @coordinators = []
 
         @batch = App.subscription_groups.flat_map do |_consumer_group, subscription_groups|

--- a/lib/karafka/connection/listeners_batch.rb
+++ b/lib/karafka/connection/listeners_batch.rb
@@ -9,8 +9,9 @@ module Karafka
       attr_reader :coordinators
 
       # @param jobs_queue [JobsQueue]
+      # @param scheduler [Karafka::Processing::Scheduler] scheduler we want to use
       # @return [ListenersBatch]
-      def initialize(jobs_queue)
+      def initialize(jobs_queue, scheduler)
         @coordinators = []
 
         @batch = App.subscription_groups.flat_map do |_consumer_group, subscription_groups|
@@ -24,7 +25,8 @@ module Karafka
             Connection::Listener.new(
               consumer_group_coordinator,
               subscription_group,
-              jobs_queue
+              jobs_queue,
+              scheduler
             )
           end
         end

--- a/lib/karafka/contracts/config.rb
+++ b/lib/karafka/contracts/config.rb
@@ -73,7 +73,7 @@ module Karafka
 
         nested(:processing) do
           required(:jobs_builder) { |val| !val.nil? }
-          required(:scheduler) { |val| !val.nil? }
+          required(:scheduler_class) { |val| !val.nil? }
           required(:coordinator_class) { |val| !val.nil? }
           required(:partitioner_class) { |val| !val.nil? }
           required(:strategy_selector) { |val| !val.nil? }

--- a/lib/karafka/contracts/config.rb
+++ b/lib/karafka/contracts/config.rb
@@ -73,6 +73,7 @@ module Karafka
 
         nested(:processing) do
           required(:jobs_builder) { |val| !val.nil? }
+          required(:jobs_queue_class) { |val| !val.nil? }
           required(:scheduler_class) { |val| !val.nil? }
           required(:coordinator_class) { |val| !val.nil? }
           required(:partitioner_class) { |val| !val.nil? }

--- a/lib/karafka/pro/loader.rb
+++ b/lib/karafka/pro/loader.rb
@@ -85,6 +85,7 @@ module Karafka
           icfg.processing.coordinator_class = Processing::Coordinator
           icfg.processing.partitioner_class = Processing::Partitioner
           icfg.processing.scheduler_class = Processing::Scheduler
+          icfg.processing.jobs_queue_class = Processing::JobsQueue
           icfg.processing.jobs_builder = Processing::JobsBuilder.new
           icfg.processing.strategy_selector = Processing::StrategySelector.new
 

--- a/lib/karafka/pro/loader.rb
+++ b/lib/karafka/pro/loader.rb
@@ -84,7 +84,7 @@ module Karafka
 
           icfg.processing.coordinator_class = Processing::Coordinator
           icfg.processing.partitioner_class = Processing::Partitioner
-          icfg.processing.scheduler = Processing::Scheduler.new
+          icfg.processing.scheduler_class = Processing::Scheduler
           icfg.processing.jobs_builder = Processing::JobsBuilder.new
           icfg.processing.strategy_selector = Processing::StrategySelector.new
 

--- a/lib/karafka/pro/processing/jobs_queue.rb
+++ b/lib/karafka/pro/processing/jobs_queue.rb
@@ -23,6 +23,17 @@ module Karafka
         def initialize
           super
           @in_waiting = Hash.new { |h, k| h[k] = [] }
+          @in_waiting_count = 0
+        end
+
+        # Returns number of jobs that are either enqueued or in processing (but not finished) or
+        #   in waiting. All of those jobs need to finish.
+        #
+        # @return [Integer] number of elements in the queue or waiting to go there or being
+        #   processed
+        # @note Using `#pop` won't decrease this number as only marking job as completed does this
+        def size
+          @in_processing_count + @in_waiting_count
         end
 
         # Method that allows us to lock queue on a given subscription group without enqueuing the a
@@ -36,6 +47,7 @@ module Karafka
 
             raise(Errors::JobsQueueSynchronizationError, job.group_id) if group.include?(job)
 
+            @in_waiting_count += 1
             group << job
           end
         end
@@ -46,6 +58,7 @@ module Karafka
         # @param job [Jobs::Base] job that locked the queue
         def unlock(job)
           @mutex.synchronize do
+            @in_waiting_count -= 1
             @in_waiting[job.group_id].delete(job)
           end
         end
@@ -56,7 +69,10 @@ module Karafka
         # @param group_id [String]
         def clear(group_id)
           @mutex.synchronize do
+            @in_processing_count -= @in_processing[group_id].size
             @in_processing[group_id].clear
+
+            @in_waiting_count -= @in_waiting[group_id].size
             @in_waiting[group_id].clear
 
             # We unlock it just in case it was blocked when clearing started
@@ -73,6 +89,17 @@ module Karafka
             @in_processing[group_id].empty? &&
               @in_waiting[group_id].empty?
           end
+        end
+
+        # - `busy` - number of jobs that are currently being processed (active work)
+        # - `enqueued` - number of jobs in the queue that are waiting to be picked up by a worker
+        #
+        # @return [Hash] hash with basic usage statistics of this queue.
+        def statistics
+          {
+            busy: size - @queue.size - @in_waiting_count,
+            enqueued: @queue.size + @in_waiting_count
+          }.freeze
         end
 
         private

--- a/lib/karafka/pro/processing/jobs_queue.rb
+++ b/lib/karafka/pro/processing/jobs_queue.rb
@@ -16,6 +16,8 @@ module Karafka
     module Processing
       # Enhanced processing queue that provides ability to build complex work-distribution
       # schedulers dedicated to particular job types
+      #
+      # Aside from the OSS queue capabilities it allows for jobless locking for advanced schedulers
       class JobsQueue < Karafka::Processing::JobsQueue
         # @return [Karafka::Pro::Processing::JobsQueue]
         def initialize

--- a/lib/karafka/pro/processing/jobs_queue.rb
+++ b/lib/karafka/pro/processing/jobs_queue.rb
@@ -40,8 +40,8 @@ module Karafka
           end
         end
 
-        # Method for unlocking the given subscription group queue space that was locked with a given
-        # job that was **not** added to the queue but used via `#lock`.
+        # Method for unlocking the given subscription group queue space that was locked with a
+        # given job that was **not** added to the queue but used via `#lock`.
         #
         # @param job [Jobs::Base] job that locked the queue
         def unlock(job)

--- a/lib/karafka/pro/processing/jobs_queue.rb
+++ b/lib/karafka/pro/processing/jobs_queue.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Processing
+      # Enhanced processing queue that provides ability to build complex work-distribution
+      # schedulers dedicated to particular job types
+      class JobsQueue < Karafka::Processing::JobsQueue
+        # @return [Karafka::Pro::Processing::JobsQueue]
+        def initialize
+          super
+          @in_waiting = Hash.new { |h, k| h[k] = [] }
+        end
+
+        # Method that allows us to lock queue on a given subscription group without enqueuing the a
+        # job. This can be used when building complex schedulers that want to postpone enqueuing
+        # before certain conditions are met.
+        #
+        # @param job [Jobs::Base] job used for locking
+        def lock(job)
+          @mutex.synchronize do
+            group = @in_waiting[job.group_id]
+
+            raise(Errors::JobsQueueSynchronizationError, job.group_id) if group.include?(job)
+
+            group << job
+          end
+        end
+
+        # Method for unlocking the given subscription group queue space that was locked with a given
+        # job that was **not** added to the queue but used via `#lock`.
+        #
+        # @param job [Jobs::Base] job that locked the queue
+        def unlock(job)
+          @mutex.synchronize do
+            @in_waiting[job.group_id].delete(job)
+          end
+        end
+
+        # Clears the processing states for a provided group. Useful when a recovery happens and we
+        # need to clean up state but only for a given subscription group.
+        #
+        # @param group_id [String]
+        def clear(group_id)
+          @mutex.synchronize do
+            @in_processing[group_id].clear
+            @in_waiting[group_id].clear
+
+            # We unlock it just in case it was blocked when clearing started
+            tick(group_id)
+          end
+        end
+
+        # @param group_id [String]
+        #
+        # @return [Boolean] tell us if we have anything in the processing (or for processing) from
+        # a given group.
+        def empty?(group_id)
+          @mutex.synchronize do
+            @in_processing[group_id].empty? &&
+              @in_waiting[group_id].empty?
+          end
+        end
+
+        private
+
+        # @param group_id [String] id of the group in which jobs we're interested.
+        # @return [Boolean] should we keep waiting or not
+        # @note We do not wait for non-blocking jobs. Their flow should allow for `poll` running
+        #   as they may exceed `max.poll.interval`
+        def wait?(group_id)
+          !(
+            @in_processing[group_id].all?(&:non_blocking?) &&
+            @in_waiting[group_id].all?(&:non_blocking?)
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/processing/scheduler.rb
+++ b/lib/karafka/pro/processing/scheduler.rb
@@ -27,10 +27,9 @@ module Karafka
       class Scheduler < ::Karafka::Processing::Scheduler
         # Schedules jobs in the LJF order for consumption
         #
-        # @param queue [Karafka::Processing::JobsQueue] queue where we want to put the jobs
         # @param jobs_array [Array<Karafka::Processing::Jobs::Base>] jobs we want to schedule
         #
-        def schedule_consumption(queue, jobs_array)
+        def schedule_consumption(jobs_array)
           perf_tracker = PerformanceTracker.instance
 
           ordered = []
@@ -47,7 +46,7 @@ module Karafka
           ordered.map!(&:first)
 
           ordered.each do |job|
-            queue << job
+            @queue << job
           end
         end
 

--- a/lib/karafka/processing/jobs_queue.rb
+++ b/lib/karafka/processing/jobs_queue.rb
@@ -8,8 +8,11 @@ module Karafka
     # We need to take into consideration fact, that more than one subscription group can operate
     # on this queue, that's why internally we keep track of processing per group.
     #
-    # We work with the assumption, that partitions data is evenly distributed.
+    # This job queue provides also an API for complex schedulers that can distribute work only
+    # to some threads, etc
     class JobsQueue
+      attr_reader :in_processing
+
       # @return [Karafka::Processing::JobsQueue]
       def initialize
         @queue = Queue.new
@@ -28,6 +31,7 @@ module Karafka
 
         @tick_interval = ::Karafka::App.config.internal.tick_interval
         @in_processing = Hash.new { |h, k| h[k] = [] }
+        @in_waiting = Hash.new { |h, k| h[k] = [] }
 
         @mutex = Mutex.new
       end
@@ -56,6 +60,31 @@ module Karafka
           group << job
 
           @queue << job
+        end
+      end
+
+      # Method that allows us to lock queue on a given subscription group without enqueuing the a
+      # job. This can be used when building complex schedulers that want to postpone enqueuing
+      # before certain conditions are met.
+      #
+      # @param job [Jobs::Base] job used for locking
+      def lock(job)
+        @mutex.synchronize do
+          group = @in_waiting[job.group_id]
+
+          raise(Errors::JobsQueueSynchronizationError, job.group_id) if group.include?(job)
+
+          group << job
+        end
+      end
+
+      # Method for unlocking the given subscription group queue space that was locked with a given
+      # job that was **not** added to the queue but used via `#lock`.
+      #
+      # @param job [Jobs::Base] job that locked the queue
+      def unlock(job)
+        @mutex.synchronize do
+          @in_waiting[job.group_id].delete(job)
         end
       end
 
@@ -92,6 +121,8 @@ module Karafka
       def clear(group_id)
         @mutex.synchronize do
           @in_processing[group_id].clear
+          @in_waiting[group_id].clear
+
           # We unlock it just in case it was blocked when clearing started
           tick(group_id)
         end
@@ -113,7 +144,8 @@ module Karafka
       # a given group.
       def empty?(group_id)
         @mutex.synchronize do
-          @in_processing[group_id].empty?
+          @in_processing[group_id].empty? &&
+            @in_waiting[group_id].empty?
         end
       end
 
@@ -154,7 +186,10 @@ module Karafka
       # @note We do not wait for non-blocking jobs. Their flow should allow for `poll` running
       #   as they may exceed `max.poll.interval`
       def wait?(group_id)
-        !@in_processing[group_id].all?(&:non_blocking?)
+        !(
+          @in_processing[group_id].all?(&:non_blocking?) &&
+          @in_waiting[group_id].all?(&:non_blocking?)
+        )
       end
     end
   end

--- a/lib/karafka/processing/scheduler.rb
+++ b/lib/karafka/processing/scheduler.rb
@@ -4,19 +4,35 @@ module Karafka
   module Processing
     # FIFO scheduler for messages coming from various topics and partitions
     class Scheduler
+      # @param queue [Karafka::Processing::JobsQueue] queue where we want to put the jobs
+      def initialize(queue)
+        @queue = queue
+      end
+
       # Schedules jobs in the fifo order
       #
-      # @param queue [Karafka::Processing::JobsQueue] queue where we want to put the jobs
       # @param jobs_array [Array<Karafka::Processing::Jobs::Base>] jobs we want to schedule
-      def schedule_consumption(queue, jobs_array)
+      def schedule_consumption(jobs_array)
         jobs_array.each do |job|
-          queue << job
+          @queue << job
         end
       end
 
       # Both revocation and shutdown jobs can also run in fifo by default
       alias schedule_revocation schedule_consumption
       alias schedule_shutdown schedule_consumption
+
+      # This scheduler does not have anything to manage as it is a pass through and has no state
+      def manage
+        nil
+      end
+
+      # This scheduler does not need to be cleared because it is stateless
+      #
+      # @param _group_id [String] Subscription group id
+      def clear(_group_id)
+        nil
+      end
     end
   end
 end

--- a/lib/karafka/processing/scheduler.rb
+++ b/lib/karafka/processing/scheduler.rb
@@ -13,7 +13,6 @@ module Karafka
       #
       # @param jobs_array [Array<Karafka::Processing::Jobs::Base>] jobs we want to schedule
       def schedule_consumption(jobs_array)
-        p 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
         jobs_array.each do |job|
           @queue << job
         end

--- a/lib/karafka/processing/scheduler.rb
+++ b/lib/karafka/processing/scheduler.rb
@@ -13,6 +13,7 @@ module Karafka
       #
       # @param jobs_array [Array<Karafka::Processing::Jobs::Base>] jobs we want to schedule
       def schedule_consumption(jobs_array)
+        p 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
         jobs_array.each do |job|
           @queue << job
         end

--- a/lib/karafka/runner.rb
+++ b/lib/karafka/runner.rb
@@ -9,12 +9,9 @@ module Karafka
       # Despite possibility of having several independent listeners, we aim to have one queue for
       # jobs across and one workers poll for that
       jobs_queue = App.config.internal.processing.jobs_queue_class.new
-      # We need one scheduler for all the listeners because in case of complex schedulers, they
-      # should be able to distribute work whenever any work is done in any of the listeners
-      scheduler = App.config.internal.processing.scheduler_class.new(jobs_queue)
 
       workers = Processing::WorkersBatch.new(jobs_queue)
-      listeners = Connection::ListenersBatch.new(jobs_queue, scheduler)
+      listeners = Connection::ListenersBatch.new(jobs_queue)
 
       workers.each(&:async_call)
       listeners.each(&:async_call)

--- a/lib/karafka/runner.rb
+++ b/lib/karafka/runner.rb
@@ -9,9 +9,12 @@ module Karafka
       # Despite possibility of having several independent listeners, we aim to have one queue for
       # jobs across and one workers poll for that
       jobs_queue = Processing::JobsQueue.new
+      # We need one scheduler for all the listeners because in case of complex schedulers, they
+      # should be able to distribute work whenever any work is done in any of the listeners
+      scheduler = App.config.internal.processing.scheduler_class.new(jobs_queue)
 
       workers = Processing::WorkersBatch.new(jobs_queue)
-      listeners = Connection::ListenersBatch.new(jobs_queue)
+      listeners = Connection::ListenersBatch.new(jobs_queue, scheduler)
 
       workers.each(&:async_call)
       listeners.each(&:async_call)

--- a/lib/karafka/runner.rb
+++ b/lib/karafka/runner.rb
@@ -8,7 +8,7 @@ module Karafka
     def call
       # Despite possibility of having several independent listeners, we aim to have one queue for
       # jobs across and one workers poll for that
-      jobs_queue = Processing::JobsQueue.new
+      jobs_queue = App.config.internal.processing.jobs_queue_class.new
       # We need one scheduler for all the listeners because in case of complex schedulers, they
       # should be able to distribute work whenever any work is done in any of the listeners
       scheduler = App.config.internal.processing.scheduler_class.new(jobs_queue)

--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -210,7 +210,7 @@ module Karafka
 
         setting :processing do
           # option scheduler [Object] scheduler we will be using
-          setting :scheduler, default: Processing::Scheduler.new
+          setting :scheduler_class, default: Processing::Scheduler
           # option jobs_builder [Object] jobs builder we want to use
           setting :jobs_builder, default: Processing::JobsBuilder.new
           # option coordinator [Class] work coordinator we want to user for processing coordination

--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -209,6 +209,7 @@ module Karafka
         end
 
         setting :processing do
+          setting :jobs_queue_class, default: Processing::JobsQueue
           # option scheduler [Object] scheduler we will be using
           setting :scheduler_class, default: Processing::Scheduler
           # option jobs_builder [Object] jobs builder we want to use

--- a/spec/integrations/pro/consumption/scheduling/with_single_thread_materialization_scheduler_spec.rb
+++ b/spec/integrations/pro/consumption/scheduling/with_single_thread_materialization_scheduler_spec.rb
@@ -52,7 +52,6 @@ end
 setup_karafka do |config|
   config.concurrency = 10
   config.max_messages = 50
-  config.shutdown_timeout = 5_000
   config.internal.processing.scheduler_class = OneThreadScheduler
 end
 

--- a/spec/integrations/pro/consumption/scheduling/with_single_thread_materialization_scheduler_spec.rb
+++ b/spec/integrations/pro/consumption/scheduling/with_single_thread_materialization_scheduler_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+# When using a scheduler that would allow only a single thread, despite having more, we should
+# never use them in any way
+
+become_pro!
+
+class OneThreadScheduler < ::Karafka::Pro::Processing::Scheduler
+  def initialize(queue)
+    super
+    @mutex = Mutex.new
+    @jobs_buffer = []
+  end
+
+  def schedule_consumption(jobs_array)
+    @mutex.synchronize do
+      jobs_array.each do |job|
+        @jobs_buffer << job
+        @queue.lock(job)
+      end
+
+      internal_manage
+    end
+  end
+
+  def manage
+    @mutex.synchronize do
+      internal_manage
+    end
+  end
+
+  def clear(group_id)
+    @mutex.synchronize do
+      @jobs_buffer.delete_if { |job| job.group_id == group_id }
+    end
+  end
+
+  private
+
+  def internal_manage
+    @jobs_buffer.delete_if do |job|
+      next unless @queue.statistics[:busy].zero?
+
+      @queue << job
+      @queue.unlock(job)
+
+      true
+    end
+  end
+end
+
+setup_karafka do |config|
+  config.concurrency = 10
+  config.max_messages = 50
+  config.shutdown_timeout = 5_000
+  config.internal.processing.scheduler_class = OneThreadScheduler
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each { DT[:total] << true }
+
+    start = Time.now.to_f
+    sleep(rand)
+    stop = Time.now.to_f
+    DT[:runs] << (start..stop)
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    virtual_partitions(
+      partitioner: ->(_) { rand(10) }
+    )
+  end
+end
+
+produce_many(DT.topic, DT.uuids(100))
+
+start_karafka_and_wait_until do
+  DT[:total].size >= 100
+end
+
+DT[:runs].each do |run1|
+  DT[:runs].each do |run2|
+    next if run1 == run2
+
+    assert_no_overlap(run1, run2)
+  end
+end

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_lrj_mom_vp/with_non_recoverable_job_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_lrj_mom_vp/with_non_recoverable_job_error_spec.rb
@@ -11,7 +11,7 @@ setup_karafka(allow_errors: true) do |config|
   config.kafka[:'max.poll.interval.ms'] = 10_000
   config.kafka[:'session.timeout.ms'] = 10_000
   # Use the non-Pro scheduler to achieve FIFO scheduling to stabilize this spec
-  config.internal.processing.scheduler = ::Karafka::Processing::Scheduler.new
+  config.internal.processing.scheduler_class = ::Karafka::Processing::Scheduler
 end
 
 class DlqConsumer < Karafka::BaseConsumer

--- a/spec/integrations/pro/licensing/configure_with_valid_token_spec.rb
+++ b/spec/integrations/pro/licensing/configure_with_valid_token_spec.rb
@@ -37,7 +37,8 @@ assert const_visible?('Karafka::Pro::PerformanceTracker')
 assert_equal pro::Processing::StrategySelector, config.processing.strategy_selector.class
 assert_equal pro::Processing::Partitioner, config.processing.partitioner_class
 assert_equal pro::Processing::Coordinator, config.processing.coordinator_class
-assert_equal pro::Processing::Scheduler, config.processing.scheduler.class
+assert_equal pro::Processing::Scheduler, config.processing.scheduler_class
+assert_equal pro::Processing::JobsQueue, config.processing.jobs_queue_class
 assert_equal pro::Processing::JobsBuilder, config.processing.jobs_builder.class
 assert_equal pro::ActiveJob::Dispatcher, config.active_job.dispatcher.class
 assert_equal pro::ActiveJob::Consumer, config.active_job.consumer_class

--- a/spec/lib/karafka/connection/listener_spec.rb
+++ b/spec/lib/karafka/connection/listener_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe_current do
     end
 
     it 'expect the revoke job to be consumed meanwhile' do
-      expect(jobs_queue.size).to eq(0)
+      expect(jobs_queue.statistics).to eq(busy: 0, enqueued: 0)
     end
   end
 

--- a/spec/lib/karafka/connection/listener_spec.rb
+++ b/spec/lib/karafka/connection/listener_spec.rb
@@ -5,13 +5,15 @@ RSpec.describe_current do
     described_class.new(
       consumer_group_coordinator,
       subscription_group,
-      jobs_queue
+      jobs_queue,
+      scheduler
     )
   end
 
   let(:consumer_group_coordinator) { Karafka::Connection::ConsumerGroupCoordinator.new(0) }
   let(:subscription_group) { build(:routing_subscription_group, topics: [routing_topic]) }
   let(:jobs_queue) { Karafka::Processing::JobsQueue.new }
+  let(:scheduler) { Karafka::Processing::Scheduler.new(jobs_queue) }
   let(:client) { Karafka::Connection::Client.new(subscription_group) }
   let(:routing_topic) { build(:routing_topic) }
   let(:workers_batch) { Karafka::Processing::WorkersBatch.new(jobs_queue).each(&:async_call) }

--- a/spec/lib/karafka/connection/listeners_batch_spec.rb
+++ b/spec/lib/karafka/connection/listeners_batch_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 RSpec.describe_current do
-  subject(:batch) { described_class.new(jobs_queue) }
+  subject(:batch) { described_class.new(jobs_queue, scheduler) }
 
   let(:jobs_queue) { Karafka::Processing::JobsQueue.new }
+  let(:scheduler) { Karafka::Processing::Scheduler.new(jobs_queue) }
   let(:consumer_group) { build(:routing_consumer_group) }
   let(:subscription_group) { build(:routing_subscription_group) }
 

--- a/spec/lib/karafka/connection/listeners_batch_spec.rb
+++ b/spec/lib/karafka/connection/listeners_batch_spec.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe_current do
-  subject(:batch) { described_class.new(jobs_queue, scheduler) }
+  subject(:batch) { described_class.new(jobs_queue) }
 
   let(:jobs_queue) { Karafka::Processing::JobsQueue.new }
-  let(:scheduler) { Karafka::Processing::Scheduler.new(jobs_queue) }
   let(:consumer_group) { build(:routing_consumer_group) }
   let(:subscription_group) { build(:routing_subscription_group) }
 

--- a/spec/lib/karafka/contracts/config_spec.rb
+++ b/spec/lib/karafka/contracts/config_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe_current do
         processing: {
           scheduler_class: Karafka::Processing::Scheduler,
           jobs_builder: Karafka::Processing::JobsBuilder.new,
+          jobs_queue_class: Karafka::Processing::JobsQueue,
           coordinator_class: Karafka::Processing::Coordinator,
           partitioner_class: Karafka::Processing::Partitioner,
           strategy_selector: Karafka::Processing::StrategySelector.new,
@@ -446,6 +447,7 @@ RSpec.describe_current do
 
     %i[
       jobs_builder
+      jobs_queue_class
       scheduler_class
       coordinator_class
       partitioner_class
@@ -485,6 +487,12 @@ RSpec.describe_current do
 
     context 'when processing scheduler_class is missing' do
       before { config[:internal][:processing].delete(:scheduler_class) }
+
+      it { expect(contract.call(config)).not_to be_success }
+    end
+
+    context 'when processing jobs_queue_class is missing' do
+      before { config[:internal][:processing].delete(:jobs_queue_class) }
 
       it { expect(contract.call(config)).not_to be_success }
     end

--- a/spec/lib/karafka/contracts/config_spec.rb
+++ b/spec/lib/karafka/contracts/config_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe_current do
           subscription_groups_builder: Karafka::Routing::SubscriptionGroupsBuilder.new
         },
         processing: {
-          scheduler: Karafka::Processing::Scheduler.new,
+          scheduler_class: Karafka::Processing::Scheduler,
           jobs_builder: Karafka::Processing::JobsBuilder.new,
           coordinator_class: Karafka::Processing::Coordinator,
           partitioner_class: Karafka::Processing::Partitioner,
@@ -446,7 +446,7 @@ RSpec.describe_current do
 
     %i[
       jobs_builder
-      scheduler
+      scheduler_class
       coordinator_class
       partitioner_class
       strategy_selector
@@ -483,8 +483,8 @@ RSpec.describe_current do
       it { expect(contract.call(config)).not_to be_success }
     end
 
-    context 'when processing scheduler is missing' do
-      before { config[:internal][:processing].delete(:scheduler) }
+    context 'when processing scheduler_class is missing' do
+      before { config[:internal][:processing].delete(:scheduler_class) }
 
       it { expect(contract.call(config)).not_to be_success }
     end

--- a/spec/lib/karafka/pro/processing/jobs_queue_spec.rb
+++ b/spec/lib/karafka/pro/processing/jobs_queue_spec.rb
@@ -74,6 +74,14 @@ RSpec.describe_current do
     end
   end
 
+  describe '#lock' do
+    pending
+  end
+
+  describe '#unlock' do
+    pending
+  end
+
   describe '#close' do
     context 'when queues are closed already' do
       before { internal_queue.close }
@@ -267,5 +275,35 @@ RSpec.describe_current do
 
   describe '#statistics' do
     it { expect(queue.statistics).to eq(enqueued: 0, busy: 0) }
+
+    context 'when we have enqueued and waiting jobs' do
+      before do
+        queue << job1
+        queue << job2
+        queue.lock(job2)
+      end
+
+      it { expect(queue.statistics).to eq(enqueued: 3, busy: 0) }
+    end
+
+    context 'when we have enqueued, waiting and running jobs' do
+      before do
+        queue << job1
+        queue << job2
+        queue.lock(job2)
+        queue.pop
+      end
+
+      it { expect(queue.statistics).to eq(enqueued: 2, busy: 1) }
+    end
+
+    context 'when we have only waiting jobs' do
+      before do
+        queue.lock(job1)
+        queue.lock(job2)
+      end
+
+      it { expect(queue.statistics).to eq(enqueued: 2, busy: 0) }
+    end
   end
 end

--- a/spec/lib/karafka/pro/processing/jobs_queue_spec.rb
+++ b/spec/lib/karafka/pro/processing/jobs_queue_spec.rb
@@ -3,9 +3,12 @@
 RSpec.describe_current do
   subject(:queue) { described_class.new }
 
-  let(:job1) { OpenStruct.new(group_id: 1, id: 1, call: true, non_blocking?: false) }
-  let(:job2) { OpenStruct.new(group_id: 2, id: 1, call: true, non_blocking?: false) }
+  let(:job1) { job_n.call }
+  let(:job2) { job_n.call }
   let(:internal_queue) { ::Queue.new }
+  let(:job_n) do
+    -> { OpenStruct.new(group_id: 2, id: SecureRandom.uuid, call: true, non_blocking?: false) }
+  end
 
   before { queue.instance_variable_set('@queue', internal_queue) }
 
@@ -16,15 +19,13 @@ RSpec.describe_current do
         queue << job1
       end
 
-      it { expect(queue.size).to eq(0) }
-      it { expect(queue.statistics).to eq(enqueued: 0, busy: 0) }
+      it { expect(queue.statistics).to eq(enqueued: 0, busy: 0, waiting: 0) }
     end
 
     context 'when the queue is not closed' do
       before { queue << job1 }
 
-      it { expect(queue.size).to eq(1) }
-      it { expect(queue.statistics).to eq(enqueued: 1, busy: 0) }
+      it { expect(queue.statistics).to eq(busy: 1, enqueued: 0, waiting: 0) }
     end
 
     context 'when we want to add a job from a group that is in processing' do
@@ -39,8 +40,13 @@ RSpec.describe_current do
       before { queue << job1 }
 
       it { expect { queue << job2 }.not_to raise_error }
-      it { expect { queue << job2 }.to change(queue, :size).from(1).to(2) }
-      it { expect(queue.statistics).to eq(enqueued: 1, busy: 0) }
+      it { expect(queue.statistics).to eq(busy: 1, enqueued: 0, waiting: 0) }
+
+      context 'when all workers are busy' do
+        before { 10.times { queue << job_n.call } }
+
+        it { expect(queue.statistics).to eq(busy: 5, enqueued: 6, waiting: 0) }
+      end
     end
   end
 
@@ -48,8 +54,7 @@ RSpec.describe_current do
     before { queue << job1 }
 
     it { expect(queue.pop).to eq(job1) }
-    it { expect { queue.pop }.not_to change(queue, :size) }
-    it { expect(queue.statistics).to eq(enqueued: 1, busy: 0) }
+    it { expect(queue.statistics).to eq(busy: 1, enqueued: 0, waiting: 0) }
   end
 
   describe '#complete' do
@@ -59,7 +64,19 @@ RSpec.describe_current do
     end
 
     context 'when there is a job in the queue and we mark it as completed' do
-      it { expect { queue.complete(job1) }.to change(queue, :size).from(2).to(1) }
+      before { queue.complete(queue.pop) }
+
+      it { expect(queue.statistics).to eq(busy: 1, enqueued: 0, waiting: 0) }
+    end
+
+    context 'when there are more jobs than concurrency and we complete' do
+      before do
+        8.times { queue << job_n.call }
+
+        queue.complete(queue.pop)
+      end
+
+      it { expect(queue.statistics).to eq(busy: 5, enqueued: 4, waiting: 0) }
     end
   end
 
@@ -70,7 +87,7 @@ RSpec.describe_current do
     end
 
     it 'expect to clear a given group only' do
-      expect { queue.clear(job1.group_id) }.to change(queue, :size).from(2).to(1)
+      expect { queue.clear(job1.group_id) }.not_to change(queue, :statistics)
     end
   end
 
@@ -78,8 +95,7 @@ RSpec.describe_current do
     context 'when we lock a job' do
       before { queue.lock(job1) }
 
-      it { expect(queue.size).to eq(1) }
-      it { expect(queue.statistics).to eq(busy: 0, enqueued: 1) }
+      it { expect(queue.statistics).to eq(busy: 0, enqueued: 0, waiting: 1) }
 
       context 'when we try to lock the same job twice' do
         let(:expected_error) { Karafka::Errors::JobsQueueSynchronizationError }
@@ -96,8 +112,7 @@ RSpec.describe_current do
         queue.unlock(job1)
       end
 
-      it { expect(queue.size).to eq(0) }
-      it { expect(queue.statistics).to eq(busy: 0, enqueued: 0) }
+      it { expect(queue.statistics).to eq(busy: 0, enqueued: 0, waiting: 0) }
 
       context 'when we try to unlock the same job twice' do
         let(:expected_error) { Karafka::Errors::JobsQueueSynchronizationError }
@@ -251,9 +266,9 @@ RSpec.describe_current do
     end
   end
 
-  describe '#size' do
+  describe '#statistics' do
     context 'when there are no jobs' do
-      it { expect(queue.size).to eq(0) }
+      it { expect(queue.statistics).to eq(busy: 0, enqueued: 0, waiting: 0) }
     end
 
     context 'when there are jobs from one group' do
@@ -265,7 +280,7 @@ RSpec.describe_current do
         queue << job2
       end
 
-      it { expect(queue.size).to eq(2) }
+      it { expect(queue.statistics).to eq(busy: 2, enqueued: 0, waiting: 0) }
     end
 
     context 'when there are jobs from multiple groups' do
@@ -274,7 +289,7 @@ RSpec.describe_current do
         queue << job2
       end
 
-      it { expect(queue.size).to eq(2) }
+      it { expect(queue.statistics).to eq(busy: 2, enqueued: 0, waiting: 0) }
     end
   end
 
@@ -295,40 +310,6 @@ RSpec.describe_current do
       before { queue << job }
 
       it { expect(queue.empty?(job.group_id)).to eq(false) }
-    end
-  end
-
-  describe '#statistics' do
-    it { expect(queue.statistics).to eq(enqueued: 0, busy: 0) }
-
-    context 'when we have enqueued and waiting jobs' do
-      before do
-        queue << job1
-        queue << job2
-        queue.lock(job2)
-      end
-
-      it { expect(queue.statistics).to eq(enqueued: 3, busy: 0) }
-    end
-
-    context 'when we have enqueued, waiting and running jobs' do
-      before do
-        queue << job1
-        queue << job2
-        queue.lock(job2)
-        queue.pop
-      end
-
-      it { expect(queue.statistics).to eq(enqueued: 2, busy: 1) }
-    end
-
-    context 'when we have only waiting jobs' do
-      before do
-        queue.lock(job1)
-        queue.lock(job2)
-      end
-
-      it { expect(queue.statistics).to eq(enqueued: 2, busy: 0) }
     end
   end
 end

--- a/spec/lib/karafka/pro/processing/jobs_queue_spec.rb
+++ b/spec/lib/karafka/pro/processing/jobs_queue_spec.rb
@@ -75,11 +75,36 @@ RSpec.describe_current do
   end
 
   describe '#lock' do
-    pending
+    context 'when we lock a job' do
+      before { queue.lock(job1) }
+
+      it { expect(queue.size).to eq(1) }
+      it { expect(queue.statistics).to eq(busy: 0, enqueued: 1) }
+
+      context 'when we try to lock the same job twice' do
+        let(:expected_error) { Karafka::Errors::JobsQueueSynchronizationError }
+
+        it { expect { queue.lock(job1) }.to raise_error(expected_error) }
+      end
+    end
   end
 
   describe '#unlock' do
-    pending
+    context 'when we unlock a job' do
+      before do
+        queue.lock(job1)
+        queue.unlock(job1)
+      end
+
+      it { expect(queue.size).to eq(0) }
+      it { expect(queue.statistics).to eq(busy: 0, enqueued: 0) }
+
+      context 'when we try to unlock the same job twice' do
+        let(:expected_error) { Karafka::Errors::JobsQueueSynchronizationError }
+
+        it { expect { queue.unlock(job1) }.to raise_error(expected_error) }
+      end
+    end
   end
 
   describe '#close' do

--- a/spec/lib/karafka/pro/processing/jobs_queue_spec.rb
+++ b/spec/lib/karafka/pro/processing/jobs_queue_spec.rb
@@ -10,7 +10,10 @@ RSpec.describe_current do
     -> { OpenStruct.new(group_id: 2, id: SecureRandom.uuid, call: true, non_blocking?: false) }
   end
 
-  before { queue.instance_variable_set('@queue', internal_queue) }
+  before do
+    allow(Karafka::App.config).to receive(:concurrency).and_return(5)
+    queue.instance_variable_set('@queue', internal_queue)
+  end
 
   describe '#<<' do
     context 'when queue is closed' do

--- a/spec/lib/karafka/pro/processing/jobs_queue_spec.rb
+++ b/spec/lib/karafka/pro/processing/jobs_queue_spec.rb
@@ -1,0 +1,271 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:queue) { described_class.new }
+
+  let(:job1) { OpenStruct.new(group_id: 1, id: 1, call: true, non_blocking?: false) }
+  let(:job2) { OpenStruct.new(group_id: 2, id: 1, call: true, non_blocking?: false) }
+  let(:internal_queue) { ::Queue.new }
+
+  before { queue.instance_variable_set('@queue', internal_queue) }
+
+  describe '#<<' do
+    context 'when queue is closed' do
+      before do
+        queue.close
+        queue << job1
+      end
+
+      it { expect(queue.size).to eq(0) }
+      it { expect(queue.statistics).to eq(enqueued: 0, busy: 0) }
+    end
+
+    context 'when the queue is not closed' do
+      before { queue << job1 }
+
+      it { expect(queue.size).to eq(1) }
+      it { expect(queue.statistics).to eq(enqueued: 1, busy: 0) }
+    end
+
+    context 'when we want to add a job from a group that is in processing' do
+      let(:expected_error) { Karafka::Errors::JobsQueueSynchronizationError }
+
+      before { queue << job1 }
+
+      it { expect { queue << job1 }.to raise_error(expected_error) }
+    end
+
+    context 'when we want to add a job from a group that is not in processing' do
+      before { queue << job1 }
+
+      it { expect { queue << job2 }.not_to raise_error }
+      it { expect { queue << job2 }.to change(queue, :size).from(1).to(2) }
+      it { expect(queue.statistics).to eq(enqueued: 1, busy: 0) }
+    end
+  end
+
+  describe '#pop' do
+    before { queue << job1 }
+
+    it { expect(queue.pop).to eq(job1) }
+    it { expect { queue.pop }.not_to change(queue, :size) }
+    it { expect(queue.statistics).to eq(enqueued: 1, busy: 0) }
+  end
+
+  describe '#complete' do
+    before do
+      queue << job1
+      queue << job2
+    end
+
+    context 'when there is a job in the queue and we mark it as completed' do
+      it { expect { queue.complete(job1) }.to change(queue, :size).from(2).to(1) }
+    end
+  end
+
+  describe '#clear' do
+    before do
+      queue << job1
+      queue << job2
+    end
+
+    it 'expect to clear a given group only' do
+      expect { queue.clear(job1.group_id) }.to change(queue, :size).from(2).to(1)
+    end
+  end
+
+  describe '#close' do
+    context 'when queues are closed already' do
+      before { internal_queue.close }
+
+      it { expect { queue.close }.not_to raise_error }
+
+      it 'expect not to close internal queue again' do
+        allow(internal_queue).to receive(:close)
+        queue.close
+        expect(internal_queue).not_to have_received(:close)
+      end
+    end
+
+    context 'when queue is not yet closed' do
+      it { expect { queue.close }.not_to raise_error }
+
+      it 'expect close internal queue' do
+        allow(internal_queue).to receive(:close)
+        queue.close
+        expect(internal_queue).to have_received(:close)
+      end
+    end
+  end
+
+  # Each of those specs would hang forever if something would be wrong, that's why we can easily
+  # just run and see if finished. No need for assertions.
+  describe '#wait' do
+    context 'when we do not have to wait' do
+      it 'expect not to pass on the thread execution' do
+        queue.wait(job1.group_id)
+      end
+    end
+
+    context 'when we have to wait for a job' do
+      let(:thread) do
+        Thread.new do
+          sleep(0.01)
+          queue.complete(job1)
+        end
+      end
+
+      before do
+        thread
+        queue << job1
+      end
+
+      after { thread.join }
+
+      it 'expect to pass until no longer needing to wait' do
+        queue.wait(job1.group_id)
+      end
+    end
+
+    context 'when we have to wait and tick runs' do
+      let(:thread1) do
+        Thread.new do
+          sleep(0.1)
+          10.times { queue.tick(job1.group_id) }
+        end
+      end
+
+      let(:thread2) do
+        Thread.new do
+          sleep(1)
+          queue.complete(job1)
+        end
+      end
+
+      before do
+        queue << job1
+
+        thread1
+        thread2
+      end
+
+      after do
+        thread1.join
+        thread2.join
+      end
+
+      # tick should not allow for wait skipping, it should just trigger a re-check
+      it 'expect not to pass until the queue is actually closed' do
+        before = Time.now.to_f
+        queue.wait(job1.group_id)
+        expect(Time.now.to_f - before).to be >= 1
+      end
+    end
+
+    context 'when we have non blocking jobs in the queue only' do
+      before { queue << OpenStruct.new(group_id: 1, id: 1, call: true, non_blocking?: true) }
+
+      it 'expect not to block' do
+        queue.wait(job1.group_id)
+      end
+    end
+
+    context 'when Karafka is stopping and the queue is empty' do
+      before { allow(Karafka::App).to receive(:stopping?).and_return(true) }
+
+      it 'expect not to wait' do
+        queue.wait(job1.group_id)
+      end
+    end
+
+    context 'when Karafka is stopping and the queue is not empty' do
+      let(:thread) do
+        Thread.new do
+          sleep(0.01)
+          queue.complete(job1)
+        end
+      end
+
+      before do
+        thread
+        allow(Karafka::App).to receive(:stopping?).and_return(true)
+        queue << job1
+      end
+
+      after do
+        thread.join
+      end
+
+      it 'expect to wait' do
+        queue.wait(job1.group_id)
+      end
+    end
+
+    context 'when queue is closed' do
+      before { queue.close }
+
+      it 'expect not to wait' do
+        queue.wait(job1.group_id)
+      end
+    end
+
+    context 'when there are no jobs of a given group' do
+      let(:group_id) { SecureRandom.hex(6) }
+
+      it 'expect not to wait' do
+        queue.wait(group_id)
+      end
+    end
+  end
+
+  describe '#size' do
+    context 'when there are no jobs' do
+      it { expect(queue.size).to eq(0) }
+    end
+
+    context 'when there are jobs from one group' do
+      let(:job1) { OpenStruct.new(group_id: 1, id: 1, call: true) }
+      let(:job2) { OpenStruct.new(group_id: 1, id: 2, call: true) }
+
+      before do
+        queue << job1
+        queue << job2
+      end
+
+      it { expect(queue.size).to eq(2) }
+    end
+
+    context 'when there are jobs from multiple groups' do
+      before do
+        queue << job1
+        queue << job2
+      end
+
+      it { expect(queue.size).to eq(2) }
+    end
+  end
+
+  describe '#empty?' do
+    let(:job) { OpenStruct.new(group_id: 1, id: 1, call: true) }
+
+    context 'when there are no jobs at all' do
+      it { expect(queue.empty?(1)).to eq(true) }
+    end
+
+    context 'when there are jobs from a different subscription group' do
+      before { queue << job }
+
+      it { expect(queue.empty?(2)).to eq(true) }
+    end
+
+    context 'when there are jobs from our subscription group' do
+      before { queue << job }
+
+      it { expect(queue.empty?(job.group_id)).to eq(false) }
+    end
+  end
+
+  describe '#statistics' do
+    it { expect(queue.statistics).to eq(enqueued: 0, busy: 0) }
+  end
+end

--- a/spec/lib/karafka/pro/processing/scheduler_spec.rb
+++ b/spec/lib/karafka/pro/processing/scheduler_spec.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe_current do
+  subject(:scheduler) { described_class.new(queue) }
+
   let(:queue) { [] }
 
   describe '#schedule_consumption' do
-    subject(:schedule) { described_class.new.schedule_consumption(queue, jobs_array) }
+    subject(:schedule) { scheduler.schedule_consumption(jobs_array) }
 
     4.times { |i| let("message#{i}") { build(:messages_message) } }
 

--- a/spec/lib/karafka/processing/jobs_queue_spec.rb
+++ b/spec/lib/karafka/processing/jobs_queue_spec.rb
@@ -10,7 +10,10 @@ RSpec.describe_current do
     -> { OpenStruct.new(group_id: 2, id: SecureRandom.uuid, call: true, non_blocking?: false) }
   end
 
-  before { queue.instance_variable_set('@queue', internal_queue) }
+  before do
+    allow(Karafka::App.config).to receive(:concurrency).and_return(5)
+    queue.instance_variable_set('@queue', internal_queue)
+  end
 
   describe '#<<' do
     context 'when queue is closed' do

--- a/spec/lib/karafka/processing/scheduler_spec.rb
+++ b/spec/lib/karafka/processing/scheduler_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe_current do
-  subject(:scheduler) { described_class.new }
+  subject(:scheduler) { described_class.new(queue) }
+
+  let(:queue) { [] }
+  let(:jobs_array) { [] }
 
   describe '#schedule_consumption' do
-    subject(:schedule) { scheduler.schedule_consumption(queue, jobs_array) }
-
-    let(:queue) { [] }
-    let(:jobs_array) { [] }
+    subject(:schedule) { scheduler.schedule_consumption(jobs_array) }
 
     context 'when there are no messages' do
       it 'expect not to schedule anything' do
@@ -31,5 +31,13 @@ RSpec.describe_current do
         expect(queue).to eq(jobs_array)
       end
     end
+  end
+
+  describe '#manage' do
+    it { expect { scheduler.manage }.not_to raise_error }
+  end
+
+  describe '#clear' do
+    it { expect { scheduler.clear(rand.to_s) }.not_to raise_error }
   end
 end

--- a/spec/lib/karafka/server_spec.rb
+++ b/spec/lib/karafka/server_spec.rb
@@ -17,9 +17,8 @@ RSpec.describe_current do
     allow(runner).to receive(:call)
 
     jobs_queue = Karafka::Processing::JobsQueue.new
-    scheduler = Karafka::Processing::Scheduler.new(jobs_queue)
 
-    described_class.listeners = ::Karafka::Connection::ListenersBatch.new(jobs_queue, scheduler)
+    described_class.listeners = ::Karafka::Connection::ListenersBatch.new(jobs_queue)
     described_class.workers = []
   end
 

--- a/spec/lib/karafka/server_spec.rb
+++ b/spec/lib/karafka/server_spec.rb
@@ -17,8 +17,9 @@ RSpec.describe_current do
     allow(runner).to receive(:call)
 
     jobs_queue = Karafka::Processing::JobsQueue.new
+    scheduler = Karafka::Processing::Scheduler.new(jobs_queue)
 
-    described_class.listeners = ::Karafka::Connection::ListenersBatch.new(jobs_queue)
+    described_class.listeners = ::Karafka::Connection::ListenersBatch.new(jobs_queue, scheduler)
     described_class.workers = []
   end
 


### PR DESCRIPTION
This is a LOW LEVEL API for building state-aware schedulers.

This PR introduces a low-level API for building advanced multi-level schedulers.

Initially, we've wanted to introduce a separate workers' polls management for work distribution; however, due to the nature of work and the fact that it is often dynamically assigned, such an approach would drastically limit us. For example user would be forced to assign idle threads for LRJ (assuming wanted to have 2 workers) to all processes even if they would not have any LRJs assignments.

This API mitigates this by allowing to introduce a pre-buffer with active work distribution on ticks. With that we can make smart state based decisions on final work scheduling depending on the resources availability and assignmnets.

No performance regression.
There are no breaking changes since we only alter the internal scoped configuration that the end users should not change.

part of https://github.com/karafka/karafka/issues/871