### PR TITLE
rename before_enqueue to before_schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka framework changelog
 
+## 2.2.14 (Unreleased)
+- [Change] Rename `before_enqueue` to `before_schedule` to reflect what it does and when (internal).
+
 ## 2.2.13 (2023-11-17)
 - **[Feature]** Introduce low-level extended Scheduling API for granular control of schedulers and jobs execution [Pro].
 - [Improvement] Use separate lock for user-facing synchronization.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka (2.2.13)
+    karafka (2.2.14)
       karafka-core (>= 2.2.7, < 2.3.0)
       waterdrop (>= 2.6.11, < 3.0.0)
       zeitwerk (~> 2.3)

--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -34,15 +34,15 @@ module Karafka
     # @note This should not be used by the end users as it is part of the lifecycle of things and
     #   not as a part of the public api. This should not perform any extensive operations as it is
     #   blocking and running in the listener thread.
-    def on_before_enqueue
+    def on_before_schedule
       @used = true
-      handle_before_enqueue
+      handle_before_schedule
     rescue StandardError => e
       Karafka.monitor.instrument(
         'error.occurred',
         error: e,
         caller: self,
-        type: 'consumer.before_enqueue.error'
+        type: 'consumer.before_schedule.error'
       )
     end
 

--- a/lib/karafka/connection/listener.rb
+++ b/lib/karafka/connection/listener.rb
@@ -230,7 +230,7 @@ module Karafka
             # here. In cases like this, we do not run a revocation job
             @executors.find_all(topic, partition).each do |executor|
               job = @jobs_builder.revoked(executor)
-              job.before_enqueue
+              job.before_schedule
               jobs << job
             end
 
@@ -252,7 +252,7 @@ module Karafka
 
         @executors.each do |executor|
           job = @jobs_builder.shutdown(executor)
-          job.before_enqueue
+          job.before_schedule
           jobs << job
         end
 
@@ -296,7 +296,7 @@ module Karafka
           end
         end
 
-        jobs.each(&:before_enqueue)
+        jobs.each(&:before_schedule)
 
         @scheduler.schedule_consumption(jobs)
       end

--- a/lib/karafka/instrumentation/logger_listener.rb
+++ b/lib/karafka/instrumentation/logger_listener.rb
@@ -241,8 +241,8 @@ module Karafka
         when 'consumer.revoked.error'
           error "Consumer on revoked failed due to an error: #{error}"
           error details
-        when 'consumer.before_enqueue.error'
-          error "Consumer before enqueue failed due to an error: #{error}"
+        when 'consumer.before_schedule.error'
+          error "Consumer before schedule failed due to an error: #{error}"
           error details
         when 'consumer.before_consume.error'
           error "Consumer before consume failed due to an error: #{error}"

--- a/lib/karafka/instrumentation/notifications.rb
+++ b/lib/karafka/instrumentation/notifications.rb
@@ -43,7 +43,7 @@ module Karafka
         rebalance.partitions_revoke
         rebalance.partitions_revoked
 
-        consumer.before_enqueue
+        consumer.before_schedule
         consumer.consume
         consumer.consumed
         consumer.consuming.pause

--- a/lib/karafka/instrumentation/vendors/datadog/logger_listener.rb
+++ b/lib/karafka/instrumentation/vendors/datadog/logger_listener.rb
@@ -94,8 +94,8 @@ module Karafka
               error "Consumer consuming error: #{error}"
             when 'consumer.revoked.error'
               error "Consumer on revoked failed due to an error: #{error}"
-            when 'consumer.before_enqueue.error'
-              error "Consumer before enqueue failed due to an error: #{error}"
+            when 'consumer.before_schedule.error'
+              error "Consumer before schedule failed due to an error: #{error}"
             when 'consumer.before_consume.error'
               error "Consumer before consume failed due to an error: #{error}"
             when 'consumer.after_consume.error'

--- a/lib/karafka/pro/processing/strategies/aj/lrj_mom_vp.rb
+++ b/lib/karafka/pro/processing/strategies/aj/lrj_mom_vp.rb
@@ -33,7 +33,7 @@ module Karafka
             ].freeze
 
             # No actions needed for the standard flow here
-            def handle_before_enqueue
+            def handle_before_schedule
               super
 
               coordinator.on_enqueued do

--- a/lib/karafka/pro/processing/strategies/default.rb
+++ b/lib/karafka/pro/processing/strategies/default.rb
@@ -28,8 +28,8 @@ module Karafka
           FEATURES = %i[].freeze
 
           # No actions needed for the standard flow here
-          def handle_before_enqueue
-            Karafka.monitor.instrument('consumer.before_enqueue', caller: self)
+          def handle_before_schedule
+            Karafka.monitor.instrument('consumer.before_schedule', caller: self)
 
             nil
           end

--- a/lib/karafka/pro/processing/strategies/lrj/default.rb
+++ b/lib/karafka/pro/processing/strategies/lrj/default.rb
@@ -29,7 +29,7 @@ module Karafka
             ].freeze
 
             # We always need to pause prior to doing any jobs for LRJ
-            def handle_before_enqueue
+            def handle_before_schedule
               super
 
               # This ensures that when running LRJ with VP, things operate as expected run only

--- a/lib/karafka/pro/processing/strategies/lrj/mom.rb
+++ b/lib/karafka/pro/processing/strategies/lrj/mom.rb
@@ -29,7 +29,7 @@ module Karafka
             ].freeze
 
             # We always need to pause prior to doing any jobs for LRJ
-            def handle_before_enqueue
+            def handle_before_schedule
               super
 
               # This ensures that when running LRJ with VP, things operate as expected run only

--- a/lib/karafka/pro/processing/strategies/vp/default.rb
+++ b/lib/karafka/pro/processing/strategies/vp/default.rb
@@ -112,7 +112,7 @@ module Karafka
             #
             # @note This can be done without the mutex, because it happens from the same thread
             #   for all the work (listener thread)
-            def handle_before_enqueue
+            def handle_before_schedule
               super
 
               coordinator.virtual_offset_manager.register(

--- a/lib/karafka/processing/executor.rb
+++ b/lib/karafka/processing/executor.rb
@@ -39,11 +39,11 @@ module Karafka
       end
 
       # Allows us to prepare the consumer in the listener thread prior to the job being send to
-      # the queue. It also allows to run some code that is time sensitive and cannot wait in the
+      # be scheduled. It also allows to run some code that is time sensitive and cannot wait in the
       # queue as it could cause starvation.
       #
       # @param messages [Array<Karafka::Messages::Message>]
-      def before_enqueue(messages)
+      def before_schedule(messages)
         # Recreate consumer with each batch if persistence is not enabled
         # We reload the consumers with each batch instead of relying on some external signals
         # when needed for consistency. That way devs may have it on or off and not in this
@@ -60,7 +60,7 @@ module Karafka
           Time.now
         )
 
-        consumer.on_before_enqueue
+        consumer.on_before_schedule
       end
 
       # Runs setup and warm-up code in the worker prior to running the consumption

--- a/lib/karafka/processing/jobs/base.rb
+++ b/lib/karafka/processing/jobs/base.rb
@@ -24,7 +24,7 @@ module Karafka
 
         # When redefined can run any code prior to the job being enqueued
         # @note This will run in the listener thread and not in the worker
-        def before_enqueue; end
+        def before_schedule; end
 
         # When redefined can run any code that should run before executing the proper code
         def before_call; end

--- a/lib/karafka/processing/jobs/consume.rb
+++ b/lib/karafka/processing/jobs/consume.rb
@@ -21,8 +21,8 @@ module Karafka
 
         # Runs all the preparation code on the executor that needs to happen before the job is
         # enqueued.
-        def before_enqueue
-          executor.before_enqueue(@messages)
+        def before_schedule
+          executor.before_schedule(@messages)
         end
 
         # Runs the before consumption preparations on the executor

--- a/lib/karafka/processing/strategies/base.rb
+++ b/lib/karafka/processing/strategies/base.rb
@@ -11,9 +11,9 @@ module Karafka
     module Strategies
       # Base strategy that should be included in each strategy, just to ensure the API
       module Base
-        # What should happen before jobs are enqueued
+        # What should happen before jobs are scheduled
         # @note This runs from the listener thread, not recommended to put anything slow here
-        def handle_before_enqueue
+        def handle_before_schedule
           raise NotImplementedError, 'Implement in a subclass'
         end
 

--- a/lib/karafka/processing/strategies/default.rb
+++ b/lib/karafka/processing/strategies/default.rb
@@ -77,8 +77,8 @@ module Karafka
         end
 
         # No actions needed for the standard flow here
-        def handle_before_enqueue
-          Karafka.monitor.instrument('consumer.before_enqueue', caller: self)
+        def handle_before_schedule
+          Karafka.monitor.instrument('consumer.before_schedule', caller: self)
 
           nil
         end

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '2.2.13'
+  VERSION = '2.2.14'
 end

--- a/spec/integrations/instrumentation/before_enqueue_jobs_tracking_spec.rb
+++ b/spec/integrations/instrumentation/before_enqueue_jobs_tracking_spec.rb
@@ -15,7 +15,7 @@ draw_routes(Consumer)
 elements = DT.uuids(10)
 produce_many(DT.topic, elements)
 
-Karafka::App.monitor.subscribe('consumer.before_enqueue') do |event|
+Karafka::App.monitor.subscribe('consumer.before_schedule') do |event|
   DT[:events] << event[:caller]
 end
 

--- a/spec/lib/karafka/instrumentation/logger_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/logger_listener_spec.rb
@@ -310,9 +310,9 @@ RSpec.describe_current do
       it { expect(Karafka.logger).to have_received(:error).with(message) }
     end
 
-    context 'when it is a consumer.before_enqueue.error' do
-      let(:type) { 'consumer.before_enqueue.error' }
-      let(:message) { "Consumer before enqueue failed due to an error: #{error}" }
+    context 'when it is a consumer.before_schedule.error' do
+      let(:type) { 'consumer.before_schedule.error' }
+      let(:message) { "Consumer before schedule failed due to an error: #{error}" }
 
       it { expect(Karafka.logger).to have_received(:error).with(message) }
     end

--- a/spec/lib/karafka/pro/active_job/consumer_spec.rb
+++ b/spec/lib/karafka/pro/active_job/consumer_spec.rb
@@ -28,12 +28,12 @@ RSpec.describe_current do
 
   it { expect(described_class).to be < Karafka::BaseConsumer }
 
-  describe '#on_before_enqueue behaviour' do
+  describe '#on_before_schedule behaviour' do
     before { allow(consumer).to receive(:pause) }
 
     context 'when it is not a lrj' do
       it 'expect not to pause' do
-        consumer.on_before_enqueue
+        consumer.on_before_schedule
 
         expect(consumer).not_to have_received(:pause)
       end
@@ -48,7 +48,7 @@ RSpec.describe_current do
       end
 
       it 'expect to pause forever on our first message' do
-        consumer.on_before_enqueue
+        consumer.on_before_schedule
 
         expect(consumer).to have_received(:pause).with(:consecutive, 1_000_000_000_000, false)
       end

--- a/spec/lib/karafka/pro/base_consumer_spec.rb
+++ b/spec/lib/karafka/pro/base_consumer_spec.rb
@@ -59,13 +59,13 @@ RSpec.describe Karafka::BaseConsumer, type: :pro do
     allow(client).to receive(:assignment_lost?).and_return(false)
   end
 
-  describe '#on_before_enqueue for non LRJ' do
+  describe '#on_before_schedule for non LRJ' do
     let(:strategy) { Karafka::Pro::Processing::Strategies::Default }
 
     before { allow(client).to receive(:pause) }
 
     it 'expect not to pause the partition' do
-      consumer.on_before_enqueue
+      consumer.on_before_schedule
       expect(client).not_to have_received(:pause)
     end
   end
@@ -87,7 +87,7 @@ RSpec.describe Karafka::BaseConsumer, type: :pro do
 
     let(:consume_with_after) do
       lambda do
-        consumer.on_before_enqueue
+        consumer.on_before_schedule
         consumer.on_before_consume
         consumer.on_consume
         consumer.on_after_consume
@@ -222,7 +222,7 @@ RSpec.describe Karafka::BaseConsumer, type: :pro do
     end
   end
 
-  describe '#on_before_enqueue for LRJ' do
+  describe '#on_before_schedule for LRJ' do
     let(:strategy) { Karafka::Pro::Processing::Strategies::Lrj::Default }
 
     before do
@@ -232,7 +232,7 @@ RSpec.describe Karafka::BaseConsumer, type: :pro do
     end
 
     it 'expect not to pause the partition' do
-      consumer.on_before_enqueue
+      consumer.on_before_schedule
       expect(client).to have_received(:pause).with(topic.name, 0, nil)
     end
   end
@@ -252,7 +252,7 @@ RSpec.describe Karafka::BaseConsumer, type: :pro do
       consumer.coordinator = coordinator
       consumer.client = client
       consumer.messages = messages
-      consumer.on_before_enqueue
+      consumer.on_before_schedule
       consumer.on_before_consume
       allow(coordinator.pause_tracker).to receive(:pause)
     end

--- a/spec/lib/karafka/pro/processing/jobs/consume_non_blocking_spec.rb
+++ b/spec/lib/karafka/pro/processing/jobs/consume_non_blocking_spec.rb
@@ -10,15 +10,15 @@ RSpec.describe_current do
   it { expect(job.non_blocking?).to eq(true) }
   it { expect(described_class).to be < ::Karafka::Processing::Jobs::Consume }
 
-  describe '#before_enqueue' do
+  describe '#before_schedule' do
     before do
       allow(Time).to receive(:now).and_return(time_now)
-      allow(executor).to receive(:before_enqueue)
+      allow(executor).to receive(:before_schedule)
     end
 
-    it 'expect to run before_enqueue on the executor with time and messages' do
-      job.before_enqueue
-      expect(executor).to have_received(:before_enqueue).with(messages)
+    it 'expect to run before_schedule on the executor with time and messages' do
+      job.before_schedule
+      expect(executor).to have_received(:before_schedule).with(messages)
     end
   end
 end

--- a/spec/lib/karafka/pro/processing/strategies/base_spec.rb
+++ b/spec/lib/karafka/pro/processing/strategies/base_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe_current do
     klass.new
   end
 
-  describe '#handle_before_enqueue' do
-    it { expect { runner.handle_before_enqueue }.to raise_error(NotImplementedError) }
+  describe '#handle_before_schedule' do
+    it { expect { runner.handle_before_schedule }.to raise_error(NotImplementedError) }
   end
 
   describe '#handle_after_consume' do

--- a/spec/lib/karafka/pro/processing/strategies_spec.rb
+++ b/spec/lib/karafka/pro/processing/strategies_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe_current do
         context 'when using VPs and VPs virtual marking' do
           before { consumer.singleton_class.include(strategy) }
 
-          it 'expect its #handle_before_enqueue to always register virtual offsets groups' do
-            consumer.send(:handle_before_enqueue)
+          it 'expect its #handle_before_schedule to always register virtual offsets groups' do
+            consumer.send(:handle_before_schedule)
 
             expect(coordinator.virtual_offset_manager.groups).not_to be_empty
           end
@@ -71,14 +71,14 @@ RSpec.describe_current do
           end
         end
 
-        it 'expect its #handle_before_enqueue to never register virtual offsets groups' do
-          consumer.send(:handle_before_enqueue)
+        it 'expect its #handle_before_schedule to never register virtual offsets groups' do
+          consumer.send(:handle_before_schedule)
 
           expect(coordinator.virtual_offset_manager).to be_nil
         end
 
-        it 'expect its #handle_before_enqueue to not fail without virtual_offset_manager' do
-          expect { consumer.send(:handle_before_enqueue) }.not_to raise_error
+        it 'expect its #handle_before_schedule to not fail without virtual_offset_manager' do
+          expect { consumer.send(:handle_before_schedule) }.not_to raise_error
         end
       end
     end
@@ -98,8 +98,8 @@ RSpec.describe_current do
           allow(client).to receive(:pause)
         end
 
-        it 'expect its #handle_before_enqueue to invoke pause on a client' do
-          consumer.send(:handle_before_enqueue)
+        it 'expect its #handle_before_schedule to invoke pause on a client' do
+          consumer.send(:handle_before_schedule)
 
           expect(client).to have_received(:pause)
         end
@@ -121,8 +121,8 @@ RSpec.describe_current do
           allow(client).to receive(:pause)
         end
 
-        it 'expect its #handle_before_enqueue to never invoke pause on a client' do
-          consumer.send(:handle_before_enqueue)
+        it 'expect its #handle_before_schedule to never invoke pause on a client' do
+          consumer.send(:handle_before_schedule)
 
           expect(client).not_to have_received(:pause)
         end

--- a/spec/lib/karafka/processing/executor_spec.rb
+++ b/spec/lib/karafka/processing/executor_spec.rb
@@ -31,31 +31,31 @@ RSpec.describe_current do
     it { expect(executor.group_id).to eq(group_id) }
   end
 
-  describe '#before_enqueue' do
-    before { allow(consumer).to receive(:on_before_enqueue) }
+  describe '#before_schedule' do
+    before { allow(consumer).to receive(:on_before_schedule) }
 
     it do
-      expect { executor.before_enqueue(messages) }.not_to raise_error
+      expect { executor.before_schedule(messages) }.not_to raise_error
     end
 
     it 'expect to build appropriate messages batch' do
-      executor.before_enqueue(messages)
+      executor.before_schedule(messages)
       expect(consumer.messages.first.raw_payload).to eq(messages.first.raw_payload)
     end
 
     it 'expect to assign appropriate coordinator' do
-      executor.before_enqueue(messages)
+      executor.before_schedule(messages)
       expect(consumer.coordinator).to eq(coordinator)
     end
 
     it 'expect to build metadata with proper details' do
-      executor.before_enqueue(messages)
+      executor.before_schedule(messages)
       expect(consumer.messages.metadata.topic).to eq(topic.name)
     end
 
-    it 'expect to run consumer on_before_enqueue' do
-      executor.before_enqueue(messages)
-      expect(consumer).to have_received(:on_before_enqueue).with(no_args)
+    it 'expect to run consumer on_before_schedule' do
+      executor.before_schedule(messages)
+      expect(consumer).to have_received(:on_before_schedule).with(no_args)
     end
   end
 

--- a/spec/lib/karafka/processing/jobs/consume_spec.rb
+++ b/spec/lib/karafka/processing/jobs/consume_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe_current do
 
   it { expect(job.non_blocking?).to eq(false) }
 
-  describe '#before_enqueue' do
+  describe '#before_schedule' do
     before do
-      allow(executor).to receive(:before_enqueue)
-      job.before_enqueue
+      allow(executor).to receive(:before_schedule)
+      job.before_schedule
     end
 
-    it 'expect to run before_enqueue on the executor with time and messages' do
-      expect(executor).to have_received(:before_enqueue).with(messages)
+    it 'expect to run before_schedule on the executor with time and messages' do
+      expect(executor).to have_received(:before_schedule).with(messages)
     end
   end
 

--- a/spec/lib/karafka/processing/strategies/base_spec.rb
+++ b/spec/lib/karafka/processing/strategies/base_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe_current do
     klass.new
   end
 
-  describe '#handle_before_enqueue' do
-    it { expect { runner.handle_before_enqueue }.to raise_error(NotImplementedError) }
+  describe '#handle_before_schedule' do
+    it { expect { runner.handle_before_schedule }.to raise_error(NotImplementedError) }
   end
 
   describe '#handle_before_consume' do


### PR DESCRIPTION
This PR renames the `before_enqueue` to `before_schedule` as with the scheduler introduction we no longer run it before enqueuing but before scheduling that may not immediately enqueue job to the queue.
