### PR TITLE
Split single before schedule to per-action one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Karafka framework changelog
 
 ## 2.2.14 (Unreleased)
+- [Change] Replace single `#before_schedule` with appropriate methods and events for scheduling various types of work. This is needed as we first of all may run different framework logic on those and second for accurate jobs tracking with advanced schedulers.
 - [Change] Rename `before_enqueue` to `before_schedule` to reflect what it does and when (internal).
+- [Change] Remove not needed error catchers for strategies code. This code if errors, should be considered critical and should not be silenced.
 
 ## 2.2.13 (2023-11-17)
 - **[Feature]** Introduce low-level extended Scheduling API for granular control of schedulers and jobs execution [Pro].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Karafka framework changelog
 
 ## 2.2.14 (Unreleased)
-- [Change] Replace single `#before_schedule` with appropriate methods and events for scheduling various types of work. This is needed as we first of all may run different framework logic on those and second for accurate jobs tracking with advanced schedulers.
+- [Change] Replace single #before_schedule with appropriate methods and events for scheduling various types of work. This is needed as we may run different framework logic on those and, second, for accurate job tracking with advanced schedulers.
 - [Change] Rename `before_enqueue` to `before_schedule` to reflect what it does and when (internal).
 - [Change] Remove not needed error catchers for strategies code. This code if errors, should be considered critical and should not be silenced.
 

--- a/lib/karafka/instrumentation/logger_listener.rb
+++ b/lib/karafka/instrumentation/logger_listener.rb
@@ -241,15 +241,6 @@ module Karafka
         when 'consumer.revoked.error'
           error "Consumer on revoked failed due to an error: #{error}"
           error details
-        when 'consumer.before_schedule.error'
-          error "Consumer before schedule failed due to an error: #{error}"
-          error details
-        when 'consumer.before_consume.error'
-          error "Consumer before consume failed due to an error: #{error}"
-          error details
-        when 'consumer.after_consume.error'
-          error "Consumer after consume failed due to an error: #{error}"
-          error details
         when 'consumer.idle.error'
           error "Consumer idle failed due to an error: #{error}"
           error details

--- a/lib/karafka/instrumentation/notifications.rb
+++ b/lib/karafka/instrumentation/notifications.rb
@@ -43,14 +43,17 @@ module Karafka
         rebalance.partitions_revoke
         rebalance.partitions_revoked
 
-        consumer.before_schedule
+        consumer.before_schedule_consume
         consumer.consume
         consumer.consumed
         consumer.consuming.pause
         consumer.consuming.retry
+        consumer.before_schedule_idle
         consumer.idle
+        consumer.before_schedule_revoked
         consumer.revoke
         consumer.revoked
+        consumer.before_schedule_shutdown
         consumer.shutting_down
         consumer.shutdown
 

--- a/lib/karafka/pro/processing/strategies/aj/lrj_mom_vp.rb
+++ b/lib/karafka/pro/processing/strategies/aj/lrj_mom_vp.rb
@@ -33,7 +33,7 @@ module Karafka
             ].freeze
 
             # No actions needed for the standard flow here
-            def handle_before_schedule
+            def handle_before_schedule_consume
               super
 
               coordinator.on_enqueued do

--- a/lib/karafka/pro/processing/strategies/default.rb
+++ b/lib/karafka/pro/processing/strategies/default.rb
@@ -28,8 +28,8 @@ module Karafka
           FEATURES = %i[].freeze
 
           # No actions needed for the standard flow here
-          def handle_before_schedule
-            Karafka.monitor.instrument('consumer.before_schedule', caller: self)
+          def handle_before_schedule_consume
+            Karafka.monitor.instrument('consumer.before_schedule_consume', caller: self)
 
             nil
           end

--- a/lib/karafka/pro/processing/strategies/lrj/default.rb
+++ b/lib/karafka/pro/processing/strategies/lrj/default.rb
@@ -29,7 +29,7 @@ module Karafka
             ].freeze
 
             # We always need to pause prior to doing any jobs for LRJ
-            def handle_before_schedule
+            def handle_before_schedule_consume
               super
 
               # This ensures that when running LRJ with VP, things operate as expected run only

--- a/lib/karafka/pro/processing/strategies/lrj/mom.rb
+++ b/lib/karafka/pro/processing/strategies/lrj/mom.rb
@@ -29,7 +29,7 @@ module Karafka
             ].freeze
 
             # We always need to pause prior to doing any jobs for LRJ
-            def handle_before_schedule
+            def handle_before_schedule_consume
               super
 
               # This ensures that when running LRJ with VP, things operate as expected run only

--- a/lib/karafka/pro/processing/strategies/vp/default.rb
+++ b/lib/karafka/pro/processing/strategies/vp/default.rb
@@ -112,7 +112,7 @@ module Karafka
             #
             # @note This can be done without the mutex, because it happens from the same thread
             #   for all the work (listener thread)
-            def handle_before_schedule
+            def handle_before_schedule_consume
               super
 
               coordinator.virtual_offset_manager.register(

--- a/lib/karafka/processing/jobs/base.rb
+++ b/lib/karafka/processing/jobs/base.rb
@@ -22,9 +22,11 @@ module Karafka
           @non_blocking = false
         end
 
-        # When redefined can run any code prior to the job being enqueued
+        # When redefined can run any code prior to the job being scheduled
         # @note This will run in the listener thread and not in the worker
-        def before_schedule; end
+        def before_schedule
+          raise NotImplementedError, 'Please implement in a subclass'
+        end
 
         # When redefined can run any code that should run before executing the proper code
         def before_call; end

--- a/lib/karafka/processing/jobs/consume.rb
+++ b/lib/karafka/processing/jobs/consume.rb
@@ -20,9 +20,9 @@ module Karafka
         end
 
         # Runs all the preparation code on the executor that needs to happen before the job is
-        # enqueued.
+        # scheduled.
         def before_schedule
-          executor.before_schedule(@messages)
+          executor.before_schedule_consume(@messages)
         end
 
         # Runs the before consumption preparations on the executor

--- a/lib/karafka/processing/jobs/idle.rb
+++ b/lib/karafka/processing/jobs/idle.rb
@@ -14,6 +14,11 @@ module Karafka
           super()
         end
 
+        # Runs code prior to scheduling this idle job
+        def before_schedule
+          executor.before_schedule_idle
+        end
+
         # Run the idle work via the executor
         def call
           executor.idle

--- a/lib/karafka/processing/jobs/revoked.rb
+++ b/lib/karafka/processing/jobs/revoked.rb
@@ -12,6 +12,11 @@ module Karafka
           super()
         end
 
+        # Runs code prior to scheduling this revoked job
+        def before_schedule
+          executor.before_schedule_revoked
+        end
+
         # Runs the revoking job via an executor.
         def call
           executor.revoked

--- a/lib/karafka/processing/jobs/shutdown.rb
+++ b/lib/karafka/processing/jobs/shutdown.rb
@@ -13,6 +13,11 @@ module Karafka
           super()
         end
 
+        # Runs code prior to scheduling this shutdown job
+        def before_schedule
+          executor.before_schedule_shutdown
+        end
+
         # Runs the shutdown job via an executor.
         def call
           executor.shutdown

--- a/lib/karafka/processing/strategies/base.rb
+++ b/lib/karafka/processing/strategies/base.rb
@@ -11,10 +11,19 @@ module Karafka
     module Strategies
       # Base strategy that should be included in each strategy, just to ensure the API
       module Base
-        # What should happen before jobs are scheduled
-        # @note This runs from the listener thread, not recommended to put anything slow here
-        def handle_before_schedule
-          raise NotImplementedError, 'Implement in a subclass'
+        # Defines all the before schedule handlers for appropriate actions
+        %i[
+          consume
+          idle
+          revoked
+          shutdown
+        ].each do |action|
+          class_eval <<~RUBY, __FILE__, __LINE__ + 1
+            def handle_before_schedule_#{action}
+              # What should happen before scheduling this work
+              raise NotImplementedError, 'Implement in a subclass'
+            end
+          RUBY
         end
 
         # What should happen before we kick in the processing

--- a/spec/integrations/instrumentation/before_enqueue_jobs_tracking_spec.rb
+++ b/spec/integrations/instrumentation/before_enqueue_jobs_tracking_spec.rb
@@ -15,7 +15,7 @@ draw_routes(Consumer)
 elements = DT.uuids(10)
 produce_many(DT.topic, elements)
 
-Karafka::App.monitor.subscribe('consumer.before_schedule') do |event|
+Karafka::App.monitor.subscribe('consumer.before_schedule_consume') do |event|
   DT[:events] << event[:caller]
 end
 

--- a/spec/integrations/instrumentation/revocation_before_schedule_event_spec.rb
+++ b/spec/integrations/instrumentation/revocation_before_schedule_event_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Karafka should trigger proper before schedule event for revocation
+
+setup_karafka
+
+DT[:revoked] = []
+DT[:pre] = Set.new
+DT[:post] = Set.new
+
+Karafka::App.monitor.subscribe('consumer.before_schedule_revoked') do
+  DT[:revoked] << Time.now.to_f
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    if DT[:revoked].empty?
+      DT[:pre] << messages.metadata.partition
+    else
+      DT[:post] << messages.metadata.partition
+    end
+  end
+
+  def revoked
+    DT[:revoked] << { messages.metadata.partition => Time.now }
+  end
+end
+
+draw_routes do
+  consumer_group DT.topic do
+    topic DT.topic do
+      config(partitions: 3)
+      consumer Consumer
+      manual_offset_management true
+    end
+  end
+end
+
+elements = DT.uuids(100)
+elements.each { |data| produce(DT.topic, data, partition: rand(0..2)) }
+
+consumer = setup_rdkafka_consumer
+
+other =  Thread.new do
+  sleep(10)
+
+  consumer.subscribe(DT.topic)
+  consumer.poll(100) while DT[:end].empty?
+
+  sleep(2)
+end
+
+start_karafka_and_wait_until do
+  if DT[:post].empty?
+    false
+  else
+    sleep 2
+    true
+  end
+end
+
+DT[:end] << true
+
+assert DT.key?(:revoked)
+
+other.join
+consumer.close

--- a/spec/lib/karafka/base_consumer_spec.rb
+++ b/spec/lib/karafka/base_consumer_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe_current do
 
       it { expect { consumer.on_revoked }.not_to raise_error }
 
-      it 'expect to run the error instrumentation' do
+      it 'expect to raise' do
         Karafka.monitor.subscribe('error.occurred') do |event|
           expect(event.payload[:caller]).to eq(consumer)
           expect(event.payload[:error]).to be_a(StandardError)

--- a/spec/lib/karafka/instrumentation/logger_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/logger_listener_spec.rb
@@ -310,27 +310,6 @@ RSpec.describe_current do
       it { expect(Karafka.logger).to have_received(:error).with(message) }
     end
 
-    context 'when it is a consumer.before_schedule.error' do
-      let(:type) { 'consumer.before_schedule.error' }
-      let(:message) { "Consumer before schedule failed due to an error: #{error}" }
-
-      it { expect(Karafka.logger).to have_received(:error).with(message) }
-    end
-
-    context 'when it is a consumer.before_consume.error' do
-      let(:type) { 'consumer.before_consume.error' }
-      let(:message) { "Consumer before consume failed due to an error: #{error}" }
-
-      it { expect(Karafka.logger).to have_received(:error).with(message) }
-    end
-
-    context 'when it is a consumer.after_consume.error' do
-      let(:type) { 'consumer.after_consume.error' }
-      let(:message) { "Consumer after consume failed due to an error: #{error}" }
-
-      it { expect(Karafka.logger).to have_received(:error).with(message) }
-    end
-
     context 'when it is a consumer.idle.error' do
       let(:type) { 'consumer.idle.error' }
       let(:message) { "Consumer idle failed due to an error: #{error}" }

--- a/spec/lib/karafka/pro/active_job/consumer_spec.rb
+++ b/spec/lib/karafka/pro/active_job/consumer_spec.rb
@@ -28,12 +28,12 @@ RSpec.describe_current do
 
   it { expect(described_class).to be < Karafka::BaseConsumer }
 
-  describe '#on_before_schedule behaviour' do
+  describe '#on_before_schedule_consume behaviour' do
     before { allow(consumer).to receive(:pause) }
 
     context 'when it is not a lrj' do
       it 'expect not to pause' do
-        consumer.on_before_schedule
+        consumer.on_before_schedule_consume
 
         expect(consumer).not_to have_received(:pause)
       end
@@ -48,7 +48,7 @@ RSpec.describe_current do
       end
 
       it 'expect to pause forever on our first message' do
-        consumer.on_before_schedule
+        consumer.on_before_schedule_consume
 
         expect(consumer).to have_received(:pause).with(:consecutive, 1_000_000_000_000, false)
       end

--- a/spec/lib/karafka/pro/base_consumer_spec.rb
+++ b/spec/lib/karafka/pro/base_consumer_spec.rb
@@ -59,13 +59,13 @@ RSpec.describe Karafka::BaseConsumer, type: :pro do
     allow(client).to receive(:assignment_lost?).and_return(false)
   end
 
-  describe '#on_before_schedule for non LRJ' do
+  describe '#on_before_schedule_consume for non LRJ' do
     let(:strategy) { Karafka::Pro::Processing::Strategies::Default }
 
     before { allow(client).to receive(:pause) }
 
     it 'expect not to pause the partition' do
-      consumer.on_before_schedule
+      consumer.on_before_schedule_consume
       expect(client).not_to have_received(:pause)
     end
   end
@@ -87,7 +87,7 @@ RSpec.describe Karafka::BaseConsumer, type: :pro do
 
     let(:consume_with_after) do
       lambda do
-        consumer.on_before_schedule
+        consumer.on_before_schedule_consume
         consumer.on_before_consume
         consumer.on_consume
         consumer.on_after_consume
@@ -222,7 +222,7 @@ RSpec.describe Karafka::BaseConsumer, type: :pro do
     end
   end
 
-  describe '#on_before_schedule for LRJ' do
+  describe '#on_before_schedule_consume for LRJ' do
     let(:strategy) { Karafka::Pro::Processing::Strategies::Lrj::Default }
 
     before do
@@ -232,7 +232,7 @@ RSpec.describe Karafka::BaseConsumer, type: :pro do
     end
 
     it 'expect not to pause the partition' do
-      consumer.on_before_schedule
+      consumer.on_before_schedule_consume
       expect(client).to have_received(:pause).with(topic.name, 0, nil)
     end
   end
@@ -252,7 +252,7 @@ RSpec.describe Karafka::BaseConsumer, type: :pro do
       consumer.coordinator = coordinator
       consumer.client = client
       consumer.messages = messages
-      consumer.on_before_schedule
+      consumer.on_before_schedule_consume
       consumer.on_before_consume
       allow(coordinator.pause_tracker).to receive(:pause)
     end

--- a/spec/lib/karafka/pro/processing/jobs/consume_non_blocking_spec.rb
+++ b/spec/lib/karafka/pro/processing/jobs/consume_non_blocking_spec.rb
@@ -10,15 +10,15 @@ RSpec.describe_current do
   it { expect(job.non_blocking?).to eq(true) }
   it { expect(described_class).to be < ::Karafka::Processing::Jobs::Consume }
 
-  describe '#before_schedule' do
+  describe '#before_schedule_consume' do
     before do
       allow(Time).to receive(:now).and_return(time_now)
-      allow(executor).to receive(:before_schedule)
+      allow(executor).to receive(:before_schedule_consume)
     end
 
-    it 'expect to run before_schedule on the executor with time and messages' do
+    it 'expect to run before_schedule_consume on the executor with time and messages' do
       job.before_schedule
-      expect(executor).to have_received(:before_schedule).with(messages)
+      expect(executor).to have_received(:before_schedule_consume).with(messages)
     end
   end
 end

--- a/spec/lib/karafka/pro/processing/strategies/base_spec.rb
+++ b/spec/lib/karafka/pro/processing/strategies/base_spec.rb
@@ -11,15 +11,39 @@ RSpec.describe_current do
     klass.new
   end
 
-  describe '#handle_before_schedule' do
-    it { expect { runner.handle_before_schedule }.to raise_error(NotImplementedError) }
+  describe '#handle_before_schedule_consume' do
+    it { expect { runner.handle_before_schedule_consume }.to raise_error(NotImplementedError) }
+  end
+
+  describe '#handle_before_consume' do
+    it { expect { runner.handle_before_consume }.to raise_error(NotImplementedError) }
   end
 
   describe '#handle_after_consume' do
     it { expect { runner.handle_after_consume }.to raise_error(NotImplementedError) }
   end
 
+  describe '#handle_before_schedule_revoked' do
+    it { expect { runner.handle_before_schedule_revoked }.to raise_error(NotImplementedError) }
+  end
+
   describe '#handle_revoked' do
     it { expect { runner.handle_revoked }.to raise_error(NotImplementedError) }
+  end
+
+  describe '#handle_before_schedule_shutdown' do
+    it { expect { runner.handle_before_schedule_shutdown }.to raise_error(NotImplementedError) }
+  end
+
+  describe '#handle_shutdown' do
+    it { expect { runner.handle_shutdown }.to raise_error(NotImplementedError) }
+  end
+
+  describe '#handle_before_schedule_idle' do
+    it { expect { runner.handle_before_schedule_idle }.to raise_error(NotImplementedError) }
+  end
+
+  describe '#handle_idle' do
+    it { expect { runner.handle_idle }.to raise_error(NotImplementedError) }
   end
 end

--- a/spec/lib/karafka/pro/processing/strategies_spec.rb
+++ b/spec/lib/karafka/pro/processing/strategies_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe_current do
         context 'when using VPs and VPs virtual marking' do
           before { consumer.singleton_class.include(strategy) }
 
-          it 'expect its #handle_before_schedule_consume to always register virtual offsets groups' do
+          it 'expect #handle_before_schedule_consume to always register virtual offsets groups' do
             consumer.send(:handle_before_schedule_consume)
 
             expect(coordinator.virtual_offset_manager.groups).not_to be_empty
@@ -71,13 +71,13 @@ RSpec.describe_current do
           end
         end
 
-        it 'expect its #handle_before_schedule_consume to never register virtual offsets groups' do
+        it 'expect #handle_before_schedule_consume to never register virtual offsets groups' do
           consumer.send(:handle_before_schedule_consume)
 
           expect(coordinator.virtual_offset_manager).to be_nil
         end
 
-        it 'expect its #handle_before_schedule_consume to not fail without virtual_offset_manager' do
+        it 'expect #handle_before_schedule_consume to not fail without virtual_offset_manager' do
           expect { consumer.send(:handle_before_schedule_consume) }.not_to raise_error
         end
       end
@@ -98,7 +98,7 @@ RSpec.describe_current do
           allow(client).to receive(:pause)
         end
 
-        it 'expect its #handle_before_schedule_consume to invoke pause on a client' do
+        it 'expect #handle_before_schedule_consume to invoke pause on a client' do
           consumer.send(:handle_before_schedule_consume)
 
           expect(client).to have_received(:pause)
@@ -121,7 +121,7 @@ RSpec.describe_current do
           allow(client).to receive(:pause)
         end
 
-        it 'expect its #handle_before_schedule_consume to never invoke pause on a client' do
+        it 'expect #handle_before_schedule_consume to never invoke pause on a client' do
           consumer.send(:handle_before_schedule_consume)
 
           expect(client).not_to have_received(:pause)

--- a/spec/lib/karafka/pro/processing/strategies_spec.rb
+++ b/spec/lib/karafka/pro/processing/strategies_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe_current do
         context 'when using VPs and VPs virtual marking' do
           before { consumer.singleton_class.include(strategy) }
 
-          it 'expect its #handle_before_schedule to always register virtual offsets groups' do
-            consumer.send(:handle_before_schedule)
+          it 'expect its #handle_before_schedule_consume to always register virtual offsets groups' do
+            consumer.send(:handle_before_schedule_consume)
 
             expect(coordinator.virtual_offset_manager.groups).not_to be_empty
           end
@@ -71,14 +71,14 @@ RSpec.describe_current do
           end
         end
 
-        it 'expect its #handle_before_schedule to never register virtual offsets groups' do
-          consumer.send(:handle_before_schedule)
+        it 'expect its #handle_before_schedule_consume to never register virtual offsets groups' do
+          consumer.send(:handle_before_schedule_consume)
 
           expect(coordinator.virtual_offset_manager).to be_nil
         end
 
-        it 'expect its #handle_before_schedule to not fail without virtual_offset_manager' do
-          expect { consumer.send(:handle_before_schedule) }.not_to raise_error
+        it 'expect its #handle_before_schedule_consume to not fail without virtual_offset_manager' do
+          expect { consumer.send(:handle_before_schedule_consume) }.not_to raise_error
         end
       end
     end
@@ -98,8 +98,8 @@ RSpec.describe_current do
           allow(client).to receive(:pause)
         end
 
-        it 'expect its #handle_before_schedule to invoke pause on a client' do
-          consumer.send(:handle_before_schedule)
+        it 'expect its #handle_before_schedule_consume to invoke pause on a client' do
+          consumer.send(:handle_before_schedule_consume)
 
           expect(client).to have_received(:pause)
         end
@@ -121,8 +121,8 @@ RSpec.describe_current do
           allow(client).to receive(:pause)
         end
 
-        it 'expect its #handle_before_schedule to never invoke pause on a client' do
-          consumer.send(:handle_before_schedule)
+        it 'expect its #handle_before_schedule_consume to never invoke pause on a client' do
+          consumer.send(:handle_before_schedule_consume)
 
           expect(client).not_to have_received(:pause)
         end

--- a/spec/lib/karafka/processing/executor_spec.rb
+++ b/spec/lib/karafka/processing/executor_spec.rb
@@ -31,31 +31,31 @@ RSpec.describe_current do
     it { expect(executor.group_id).to eq(group_id) }
   end
 
-  describe '#before_schedule' do
-    before { allow(consumer).to receive(:on_before_schedule) }
+  describe '#before_schedule_consume' do
+    before { allow(consumer).to receive(:on_before_schedule_consume) }
 
     it do
-      expect { executor.before_schedule(messages) }.not_to raise_error
+      expect { executor.before_schedule_consume(messages) }.not_to raise_error
     end
 
     it 'expect to build appropriate messages batch' do
-      executor.before_schedule(messages)
+      executor.before_schedule_consume(messages)
       expect(consumer.messages.first.raw_payload).to eq(messages.first.raw_payload)
     end
 
     it 'expect to assign appropriate coordinator' do
-      executor.before_schedule(messages)
+      executor.before_schedule_consume(messages)
       expect(consumer.coordinator).to eq(coordinator)
     end
 
     it 'expect to build metadata with proper details' do
-      executor.before_schedule(messages)
+      executor.before_schedule_consume(messages)
       expect(consumer.messages.metadata.topic).to eq(topic.name)
     end
 
-    it 'expect to run consumer on_before_schedule' do
-      executor.before_schedule(messages)
-      expect(consumer).to have_received(:on_before_schedule).with(no_args)
+    it 'expect to run consumer on_before_schedule_consume' do
+      executor.before_schedule_consume(messages)
+      expect(consumer).to have_received(:on_before_schedule_consume).with(no_args)
     end
   end
 
@@ -78,6 +78,34 @@ RSpec.describe_current do
 
     it 'expect to run consumer' do
       expect(consumer).to have_received(:on_consume)
+    end
+  end
+
+  describe '#before_schedule_revoked' do
+    before { allow(consumer).to receive(:on_before_schedule_revoked) }
+
+    context 'when consumer is defined as it was in use' do
+      before { executor.send(:consumer) }
+
+      it do
+        expect { executor.before_schedule_revoked }.not_to raise_error
+      end
+
+      it 'expect to run consumer on_before_schedule' do
+        executor.before_schedule_revoked
+        expect(consumer).to have_received(:on_before_schedule_revoked).with(no_args)
+      end
+    end
+
+    context 'when consumer is not defined as it was not in use' do
+      it do
+        expect { executor.before_schedule_revoked }.not_to raise_error
+      end
+
+      it 'expect not to run consumer on_before_schedule' do
+        executor.before_schedule_revoked
+        expect(consumer).not_to have_received(:on_before_schedule_revoked)
+      end
     end
   end
 
@@ -118,6 +146,19 @@ RSpec.describe_current do
     end
   end
 
+  describe '#before_schedule_idle' do
+    before { allow(consumer).to receive(:on_before_schedule_idle) }
+
+    it do
+      expect { executor.before_schedule_idle }.not_to raise_error
+    end
+
+    it 'expect to run consumer on_before_schedule' do
+      executor.before_schedule_idle
+      expect(consumer).to have_received(:on_before_schedule_idle).with(no_args)
+    end
+  end
+
   describe '#idle' do
     before do
       allow(consumer).to receive(:on_idle)
@@ -126,6 +167,34 @@ RSpec.describe_current do
 
     it 'expect to run consumer on_idle' do
       expect(consumer).to have_received(:on_idle).with(no_args)
+    end
+  end
+
+  describe '#before_schedule_shutdown' do
+    before { allow(consumer).to receive(:on_before_schedule_shutdown) }
+
+    context 'when consumer is defined as it was in use' do
+      before { executor.send(:consumer) }
+
+      it do
+        expect { executor.before_schedule_shutdown }.not_to raise_error
+      end
+
+      it 'expect to run consumer on_before_schedule' do
+        executor.before_schedule_shutdown
+        expect(consumer).to have_received(:on_before_schedule_shutdown).with(no_args)
+      end
+    end
+
+    context 'when consumer is not defined as it was not in use' do
+      it do
+        expect { executor.before_schedule_shutdown }.not_to raise_error
+      end
+
+      it 'expect not to run consumer on_before_schedule' do
+        executor.before_schedule_shutdown
+        expect(consumer).not_to have_received(:on_before_schedule_shutdown)
+      end
     end
   end
 

--- a/spec/lib/karafka/processing/jobs/consume_spec.rb
+++ b/spec/lib/karafka/processing/jobs/consume_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe_current do
 
   describe '#before_schedule' do
     before do
-      allow(executor).to receive(:before_schedule)
+      allow(executor).to receive(:before_schedule_consume)
       job.before_schedule
     end
 
-    it 'expect to run before_schedule on the executor with time and messages' do
-      expect(executor).to have_received(:before_schedule).with(messages)
+    it 'expect to run before_schedule_consume on the executor with time and messages' do
+      expect(executor).to have_received(:before_schedule_consume).with(messages)
     end
   end
 

--- a/spec/lib/karafka/processing/jobs/idle_spec.rb
+++ b/spec/lib/karafka/processing/jobs/idle_spec.rb
@@ -17,4 +17,15 @@ RSpec.describe_current do
   it 'expect to run idle on the executor' do
     expect(executor).to have_received(:idle)
   end
+
+  describe '#before_schedule' do
+    before do
+      allow(executor).to receive(:before_schedule_idle)
+      job.before_schedule
+    end
+
+    it 'expect to run before_schedule_idle on the executor' do
+      expect(executor).to have_received(:before_schedule_idle)
+    end
+  end
 end

--- a/spec/lib/karafka/processing/jobs/revoked_spec.rb
+++ b/spec/lib/karafka/processing/jobs/revoked_spec.rb
@@ -17,4 +17,15 @@ RSpec.describe_current do
   it 'expect to run revoked on the executor' do
     expect(executor).to have_received(:revoked).with(no_args)
   end
+
+  describe '#before_schedule' do
+    before do
+      allow(executor).to receive(:before_schedule_revoked)
+      job.before_schedule
+    end
+
+    it 'expect to run before_schedule_revoked on the executor' do
+      expect(executor).to have_received(:before_schedule_revoked)
+    end
+  end
 end

--- a/spec/lib/karafka/processing/jobs/shutdown_spec.rb
+++ b/spec/lib/karafka/processing/jobs/shutdown_spec.rb
@@ -17,4 +17,15 @@ RSpec.describe_current do
   it 'expect to run shutdown on the executor' do
     expect(executor).to have_received(:shutdown).with(no_args)
   end
+
+  describe '#before_schedule' do
+    before do
+      allow(executor).to receive(:before_schedule_shutdown)
+      job.before_schedule
+    end
+
+    it 'expect to run before_schedule_shutdown on the executor' do
+      expect(executor).to have_received(:before_schedule_shutdown)
+    end
+  end
 end

--- a/spec/lib/karafka/processing/strategies/base_spec.rb
+++ b/spec/lib/karafka/processing/strategies/base_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe_current do
     klass.new
   end
 
-  describe '#handle_before_schedule' do
-    it { expect { runner.handle_before_schedule }.to raise_error(NotImplementedError) }
+  describe '#handle_before_schedule_consume' do
+    it { expect { runner.handle_before_schedule_consume }.to raise_error(NotImplementedError) }
   end
 
   describe '#handle_before_consume' do
@@ -23,11 +23,27 @@ RSpec.describe_current do
     it { expect { runner.handle_after_consume }.to raise_error(NotImplementedError) }
   end
 
+  describe '#handle_before_schedule_revoked' do
+    it { expect { runner.handle_before_schedule_revoked }.to raise_error(NotImplementedError) }
+  end
+
   describe '#handle_revoked' do
     it { expect { runner.handle_revoked }.to raise_error(NotImplementedError) }
   end
 
+  describe '#handle_before_schedule_shutdown' do
+    it { expect { runner.handle_before_schedule_shutdown }.to raise_error(NotImplementedError) }
+  end
+
   describe '#handle_shutdown' do
     it { expect { runner.handle_shutdown }.to raise_error(NotImplementedError) }
+  end
+
+  describe '#handle_before_schedule_idle' do
+    it { expect { runner.handle_before_schedule_idle }.to raise_error(NotImplementedError) }
+  end
+
+  describe '#handle_idle' do
+    it { expect { runner.handle_idle }.to raise_error(NotImplementedError) }
   end
 end


### PR DESCRIPTION
We used to have a generic `before_schedule` on the executor, but this is insufficient for job tracking with advanced schedulers. On top of this, it was not clear what would be the proper post-schedule flow. This PR replaces it with dedicated methods.

On top of that, I removed error catching for critical non-user-related places where errors should be considered critical and not silenced.

close https://github.com/karafka/karafka/issues/1752