### PR TITLE
remove concurent ruby from the jobs queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka framework changelog
 
 ## 2.2.14 (Unreleased)
+- [Improvement] Limit usage of `concurrent-ruby` (plan to remove it as a dependency fully)
 - [Change] Replace single #before_schedule with appropriate methods and events for scheduling various types of work. This is needed as we may run different framework logic on those and, second, for accurate job tracking with advanced schedulers.
 - [Change] Rename `before_enqueue` to `before_schedule` to reflect what it does and when (internal).
 - [Change] Remove not needed error catchers for strategies code. This code if errors, should be considered critical and should not be silenced.

--- a/lib/karafka/connection/listener.rb
+++ b/lib/karafka/connection/listener.rb
@@ -45,6 +45,8 @@ module Karafka
         @messages_buffer = MessagesBuffer.new(subscription_group)
         @mutex = Mutex.new
         @stopped = false
+
+        @jobs_queue.register(@subscription_group.id)
       end
 
       # Runs the main listener fetch loop.

--- a/spec/lib/karafka/pro/processing/jobs_queue_spec.rb
+++ b/spec/lib/karafka/pro/processing/jobs_queue_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe_current do
   before do
     allow(Karafka::App.config).to receive(:concurrency).and_return(5)
     queue.instance_variable_set('@queue', internal_queue)
+    queue.register(job1.group_id)
+    queue.register(job2.group_id)
   end
 
   describe '#<<' do

--- a/spec/lib/karafka/processing/jobs_queue_spec.rb
+++ b/spec/lib/karafka/processing/jobs_queue_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe_current do
   before do
     allow(Karafka::App.config).to receive(:concurrency).and_return(5)
     queue.instance_variable_set('@queue', internal_queue)
+    queue.register(job1.group_id)
+    queue.register(job2.group_id)
   end
 
   describe '#<<' do


### PR DESCRIPTION
This PR removes concurreny ruby usage from the jobs queue. Part of retiring of https://github.com/karafka/karafka/issues/1741