### PR TITLE
Remove rest of concurrent ruby from Karafka

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Karafka framework changelog
 
 ## 2.2.14 (Unreleased)
-- [Improvement] Limit usage of `concurrent-ruby` (plan to remove it as a dependency fully)
+- [Improvement] Remove all usage of concurrent-ruby from Karafka
 - [Change] Replace single #before_schedule with appropriate methods and events for scheduling various types of work. This is needed as we may run different framework logic on those and, second, for accurate job tracking with advanced schedulers.
 - [Change] Rename `before_enqueue` to `before_schedule` to reflect what it does and when (internal).
 - [Change] Remove not needed error catchers for strategies code. This code if errors, should be considered critical and should not be silenced.


### PR DESCRIPTION
This PR removes the rest of concurrent-ruby from karafka

all is left is the karafka-core pieces

ref https://github.com/karafka/karafka/issues/1741