### PR TITLE
ruby 3.3.0-rc1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '3.3.0-preview2'
+          - '3.3.0-rc1'
           - '3.2'
           # We run it against the oldest and the newest of a given major to make sure, that there
           # are no syntax-sugars that we would use that were introduced down the road
@@ -118,7 +118,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '3.3.0-preview2'
+          - '3.3.0-rc1'
           - '3.2'
           - '3.1'
           - '3.0'
@@ -170,7 +170,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '3.3.0-preview2'
+          - '3.3.0-rc1'
           - '3.2'
           - '3.1'
           - '3.0'


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2023/12/11/ruby-3-3-0-rc1-released/