### PR TITLE
stabilize spec

### DIFF
--- a/spec/integrations/consumption/inline_insights/from_earliest_spec.rb
+++ b/spec/integrations/consumption/inline_insights/from_earliest_spec.rb
@@ -20,10 +20,9 @@ draw_routes do
   end
 end
 
-elements = DT.uuids(10)
-produce_many(DT.topic, elements)
-
 start_karafka_and_wait_until do
+  produce_many(DT.topic, DT.uuids(10))
+
   DT.key?(:stats) && DT[:stats_exist].include?(true) && !DT[:stats].last.empty?
 end
 


### PR DESCRIPTION
In case insights would appear later then the first batch, this spec would hang.