### PR TITLE
initialize k8s on running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.2.15 (Unreleased)
 - **[Feature]** Periodic Jobs (Pro)
 - [Enhancement] Provide an `:independent` configuration to DLQ allowing to reset pause count track on each marking as consumed when retrying.
+- [Change] Make `Kubernetes::LivenessListener` not start until Karafka app starts running.
 - [Fix] Fix a case where internal Idle job scheduling would go via the consumption flow.
 
 ## 2.2.14 (2023-12-07)

--- a/spec/integrations/instrumentation/vendors/kubernetes/consuming_liveness_parallel_regular_flow_spec.rb
+++ b/spec/integrations/instrumentation/vendors/kubernetes/consuming_liveness_parallel_regular_flow_spec.rb
@@ -30,6 +30,9 @@ end
 Karafka.monitor.subscribe(listener)
 
 Thread.new do
+  sleep(0.1) until Karafka::App.running?
+  sleep(0.5) # Give a bit of time for the tcp server to start after the app starts running
+
   until Karafka::App.stopping?
     sleep(0.1)
     uri = URI.parse("http://127.0.0.1:#{port}/")

--- a/spec/integrations/instrumentation/vendors/kubernetes/consuming_liveness_parallel_regular_flow_spec.rb
+++ b/spec/integrations/instrumentation/vendors/kubernetes/consuming_liveness_parallel_regular_flow_spec.rb
@@ -16,16 +16,11 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-begin
-  port = rand(3000..5000)
-  listener = ::Karafka::Instrumentation::Vendors::Kubernetes::LivenessListener.new(
-    hostname: '127.0.0.1',
-    port: port,
-    consuming_ttl: 2_000
-  )
-rescue Errno::EADDRINUSE
-  retry
-end
+listener = ::Karafka::Instrumentation::Vendors::Kubernetes::LivenessListener.new(
+  hostname: '127.0.0.1',
+  port: 9000,
+  consuming_ttl: 2_000
+)
 
 Karafka.monitor.subscribe(listener)
 
@@ -35,7 +30,7 @@ Thread.new do
 
   until Karafka::App.stopping?
     sleep(0.1)
-    uri = URI.parse("http://127.0.0.1:#{port}/")
+    uri = URI.parse('http://127.0.0.1:9000/')
     response = Net::HTTP.get_response(uri)
     DT[:probing] << response.code
   end

--- a/spec/integrations/instrumentation/vendors/kubernetes/consuming_liveness_parallel_timeout_flow_spec.rb
+++ b/spec/integrations/instrumentation/vendors/kubernetes/consuming_liveness_parallel_timeout_flow_spec.rb
@@ -20,16 +20,11 @@ class SlowConsumer < Karafka::BaseConsumer
   end
 end
 
-begin
-  port = rand(3000..5000)
-  listener = ::Karafka::Instrumentation::Vendors::Kubernetes::LivenessListener.new(
-    hostname: '127.0.0.1',
-    port: port,
-    consuming_ttl: 2_000
-  )
-rescue Errno::EADDRINUSE
-  retry
-end
+listener = ::Karafka::Instrumentation::Vendors::Kubernetes::LivenessListener.new(
+  hostname: '127.0.0.1',
+  port: 9001,
+  consuming_ttl: 2_000
+)
 
 Karafka.monitor.subscribe(listener)
 
@@ -39,7 +34,7 @@ Thread.new do
 
   until Karafka::App.stopping?
     sleep(0.1)
-    uri = URI.parse("http://127.0.0.1:#{port}/")
+    uri = URI.parse('http://127.0.0.1:9001/')
     response = Net::HTTP.get_response(uri)
     DT[:probing] << response.code
   end

--- a/spec/integrations/instrumentation/vendors/kubernetes/consuming_liveness_parallel_timeout_flow_spec.rb
+++ b/spec/integrations/instrumentation/vendors/kubernetes/consuming_liveness_parallel_timeout_flow_spec.rb
@@ -34,6 +34,9 @@ end
 Karafka.monitor.subscribe(listener)
 
 Thread.new do
+  sleep(0.1) until Karafka::App.running?
+  sleep(0.5) # Give a bit of time for the tcp server to start after the app starts running
+
   until Karafka::App.stopping?
     sleep(0.1)
     uri = URI.parse("http://127.0.0.1:#{port}/")

--- a/spec/integrations/instrumentation/vendors/kubernetes/consuming_liveness_timeout_flow_spec.rb
+++ b/spec/integrations/instrumentation/vendors/kubernetes/consuming_liveness_timeout_flow_spec.rb
@@ -30,6 +30,9 @@ Karafka.monitor.subscribe(listener)
 raw_flows = +''
 
 Thread.new do
+  sleep(0.1) until Karafka::App.running?
+  sleep(0.5) # Give a bit of time for the tcp server to start after the app starts running
+
   until Karafka::App.stopping?
     req = Net::HTTP::Get.new('/')
     client = Net::HTTP.new('127.0.0.1', port)

--- a/spec/integrations/instrumentation/vendors/kubernetes/consuming_liveness_timeout_flow_spec.rb
+++ b/spec/integrations/instrumentation/vendors/kubernetes/consuming_liveness_timeout_flow_spec.rb
@@ -14,16 +14,11 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-begin
-  port = rand(3000..5000)
-  listener = ::Karafka::Instrumentation::Vendors::Kubernetes::LivenessListener.new(
-    hostname: '127.0.0.1',
-    port: port,
-    consuming_ttl: 1_000
-  )
-rescue Errno::EADDRINUSE
-  retry
-end
+listener = ::Karafka::Instrumentation::Vendors::Kubernetes::LivenessListener.new(
+  hostname: '127.0.0.1',
+  port: 9002,
+  consuming_ttl: 1_000
+)
 
 Karafka.monitor.subscribe(listener)
 
@@ -35,7 +30,7 @@ Thread.new do
 
   until Karafka::App.stopping?
     req = Net::HTTP::Get.new('/')
-    client = Net::HTTP.new('127.0.0.1', port)
+    client = Net::HTTP.new('127.0.0.1', 9002)
     client.set_debug_output(raw_flows)
     response = client.request(req)
 

--- a/spec/integrations/instrumentation/vendors/kubernetes/liveness_all_good_spec.rb
+++ b/spec/integrations/instrumentation/vendors/kubernetes/liveness_all_good_spec.rb
@@ -19,15 +19,10 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-begin
-  port = rand(3000..5000)
-  listener = ::Karafka::Instrumentation::Vendors::Kubernetes::LivenessListener.new(
-    hostname: '127.0.0.1',
-    port: port
-  )
-rescue Errno::EADDRINUSE
-  retry
-end
+listener = ::Karafka::Instrumentation::Vendors::Kubernetes::LivenessListener.new(
+  hostname: '127.0.0.1',
+  port: 9003
+)
 
 Karafka.monitor.subscribe(listener)
 
@@ -41,7 +36,7 @@ Thread.new do
     sleep(0.1)
 
     req = Net::HTTP::Get.new('/')
-    client = Net::HTTP.new('127.0.0.1', port)
+    client = Net::HTTP.new('127.0.0.1', 9003)
     client.set_debug_output(raw_flows)
     response = client.request(req)
 

--- a/spec/integrations/instrumentation/vendors/kubernetes/liveness_all_good_spec.rb
+++ b/spec/integrations/instrumentation/vendors/kubernetes/liveness_all_good_spec.rb
@@ -34,6 +34,9 @@ Karafka.monitor.subscribe(listener)
 raw_flows = +''
 
 Thread.new do
+  sleep(0.1) until Karafka::App.running?
+  sleep(0.5) # Give a bit of time for the tcp server to start after the app starts running
+
   until Karafka::App.stopping?
     sleep(0.1)
 

--- a/spec/integrations/instrumentation/vendors/kubernetes/non_existing_until_running_spec.rb
+++ b/spec/integrations/instrumentation/vendors/kubernetes/non_existing_until_running_spec.rb
@@ -11,15 +11,10 @@ class Consumer < Karafka::BaseConsumer
   def consume; end
 end
 
-begin
-  port = rand(3000..5000)
-  listener = ::Karafka::Instrumentation::Vendors::Kubernetes::LivenessListener.new(
-    hostname: '127.0.0.1',
-    port: port
-  )
-rescue Errno::EADDRINUSE
-  retry
-end
+listener = ::Karafka::Instrumentation::Vendors::Kubernetes::LivenessListener.new(
+  hostname: '127.0.0.1',
+  port: 9004
+)
 
 Karafka.monitor.subscribe(listener)
 
@@ -31,7 +26,7 @@ not_available = false
 
 begin
   req = Net::HTTP::Get.new('/')
-  client = Net::HTTP.new('127.0.0.1', port)
+  client = Net::HTTP.new('127.0.0.1', 9004)
   client.request(req)
 rescue Errno::ECONNREFUSED
   not_available = true

--- a/spec/integrations/instrumentation/vendors/kubernetes/non_existing_until_running_spec.rb
+++ b/spec/integrations/instrumentation/vendors/kubernetes/non_existing_until_running_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# If Karafka is configured but not started, the liveness probing should not work
+
+require 'net/http'
+require 'karafka/instrumentation/vendors/kubernetes/liveness_listener'
+
+setup_karafka(allow_errors: true)
+
+class Consumer < Karafka::BaseConsumer
+  def consume; end
+end
+
+begin
+  port = rand(3000..5000)
+  listener = ::Karafka::Instrumentation::Vendors::Kubernetes::LivenessListener.new(
+    hostname: '127.0.0.1',
+    port: port
+  )
+rescue Errno::EADDRINUSE
+  retry
+end
+
+Karafka.monitor.subscribe(listener)
+
+draw_routes(Consumer)
+
+sleep(1)
+
+not_available = false
+
+begin
+  req = Net::HTTP::Get.new('/')
+  client = Net::HTTP.new('127.0.0.1', port)
+  client.request(req)
+rescue Errno::ECONNREFUSED
+  not_available = true
+end
+
+assert not_available

--- a/spec/integrations/instrumentation/vendors/kubernetes/polling_liveness_timeout_flow_spec.rb
+++ b/spec/integrations/instrumentation/vendors/kubernetes/polling_liveness_timeout_flow_spec.rb
@@ -29,6 +29,9 @@ end
 Karafka.monitor.subscribe(listener)
 
 Thread.new do
+  sleep(0.1) until Karafka::App.running?
+  sleep(0.5) # Give a bit of time for the tcp server to start after the app starts running
+
   until Karafka::App.stopping?
     sleep(0.1)
     uri = URI.parse("http://127.0.0.1:#{port}/")

--- a/spec/integrations/instrumentation/vendors/kubernetes/polling_liveness_timeout_flow_spec.rb
+++ b/spec/integrations/instrumentation/vendors/kubernetes/polling_liveness_timeout_flow_spec.rb
@@ -15,16 +15,11 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-begin
-  port = rand(3000..5000)
-  listener = ::Karafka::Instrumentation::Vendors::Kubernetes::LivenessListener.new(
-    hostname: '127.0.0.1',
-    port: port,
-    polling_ttl: 1_000
-  )
-rescue Errno::EADDRINUSE
-  retry
-end
+listener = ::Karafka::Instrumentation::Vendors::Kubernetes::LivenessListener.new(
+  hostname: '127.0.0.1',
+  port: 9005,
+  polling_ttl: 1_000
+)
 
 Karafka.monitor.subscribe(listener)
 
@@ -34,7 +29,7 @@ Thread.new do
 
   until Karafka::App.stopping?
     sleep(0.1)
-    uri = URI.parse("http://127.0.0.1:#{port}/")
+    uri = URI.parse('http://127.0.0.1:9005/')
     response = Net::HTTP.get_response(uri)
     DT[:probing] << response.code
   end

--- a/spec/integrations/rails/rails71_pristine/with_kubernetes_listener_in_the_console/Gemfile
+++ b/spec/integrations/rails/rails71_pristine/with_kubernetes_listener_in_the_console/Gemfile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'activerecord', '7.1.1'
+gem 'activesupport', '7.1.1'
+gem 'karafka', path: ENV.fetch('KARAFKA_GEM_DIR'), require: true
+gem 'railties', '7.1.1'
+gem 'rspec-rails'

--- a/spec/integrations/rails/rails71_pristine/with_kubernetes_listener_in_the_console/console_with_rails_spec.rb
+++ b/spec/integrations/rails/rails71_pristine/with_kubernetes_listener_in_the_console/console_with_rails_spec.rb
@@ -49,7 +49,7 @@ File.open('karafka.rb', 'a') do |file|
   LISTENER
 end
 
-Thread::abort_on_exception = true
+Thread.abort_on_exception = true
 
 thread = Thread.new do
   # Make sure Rails console can start
@@ -67,7 +67,7 @@ begin
   req = Net::HTTP::Get.new('/')
   client = Net::HTTP.new('127.0.0.1', 9006)
   client.request(req)
-rescue Errno::ECONNREFUSED => e
+rescue Errno::ECONNREFUSED
   not_available = true
 end
 

--- a/spec/integrations/rails/rails71_pristine/with_kubernetes_listener_in_the_console/console_with_rails_spec.rb
+++ b/spec/integrations/rails/rails71_pristine/with_kubernetes_listener_in_the_console/console_with_rails_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# Karafka should work with Rails 7.1 and Karafka console should not crash
+# Additionally when we use the Kubernetes Liveness Probing, it should not activate itself as
+# Karafka does not start the liveness probing until it boots and it should NOT boot in the console
+
+require 'net/http'
+require 'open3'
+
+InvalidExitCode = Class.new(StandardError)
+
+def system!(cmd)
+  stdout, stderr, status = Open3.capture3(cmd)
+
+  return if status.success?
+
+  raise(
+    InvalidExitCode,
+    "#{stdout}\n#{stderr}"
+  )
+end
+
+system! <<~CMD
+  bundle exec rails new \
+    --skip-javascript \
+    --skip-bootsnap \
+    --skip-git \
+    --skip-active-storage \
+    --skip-active-job \
+    --skip-action-cable \
+    --api \
+    --skip-action-mailer \
+    --skip-active-record \
+    app
+CMD
+
+system!('cp Gemfile ./app/')
+system!('cd app && bundle install')
+system!('cd app && bundle exec karafka install')
+system!('cd app && mv consumers app/')
+
+File.open('karafka.rb', 'a') do |file|
+  file.puts <<~LISTENER
+    require 'karafka/instrumentation/vendors/kubernetes/liveness_listener'
+
+    listener = ::Karafka::Instrumentation::Vendors::Kubernetes::LivenessListener.new(port: 9006)
+
+    Karafka.monitor.subscribe(listener)
+  LISTENER
+end
+
+Thread::abort_on_exception = true
+
+thread = Thread.new do
+  # Make sure Rails console can start
+  timeout = 'timeout --preserve-status --verbose 10'
+
+  system!("cd app && #{timeout} bundle exec rails console")
+  system!("cd app && #{timeout} bundle exec karafka console")
+end
+
+sleep(2)
+
+not_available = false
+
+begin
+  req = Net::HTTP::Get.new('/')
+  client = Net::HTTP.new('127.0.0.1', 9006)
+  client.request(req)
+rescue Errno::ECONNREFUSED => e
+  not_available = true
+end
+
+assert not_available
+
+thread.join


### PR DESCRIPTION
This PR changes when we initialize the TCP listener for k8s liveness.

Instead of subscribing on initialization, we subscribe ONLY on running. This can now be done since while ago we reworked how embedded mode changes statuses.

This will also allow us to simplify the docs and remove the:

```ruby
if ENV['KARAFKA_LIVENESS'] == true
  listener = ::Karafka::Instrumentation::Vendors::Kubernetes::LivenessListener.new(
    # config goes here...
  )
  
  Karafka.monitor.subscribe(listener)
end
```

recommendation.
