### PR TITLE
Stabilize unstable spec

### DIFF
--- a/spec/integrations/consumption/strategies/dlq/with_rolling_error_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/with_rolling_error_spec.rb
@@ -9,6 +9,13 @@ end
 
 class Consumer < Karafka::BaseConsumer
   def consume
+    # Remove flow edge cases and always require at least 3 messages for the sake of consistency
+    if messages.size < 3
+      seek(messages.first.offset)
+
+      return
+    end
+
     DT[:ticks] << true
 
     @runs ||= -1


### PR DESCRIPTION
This fix makes sure that we always operate with at least 3 messages. While this is not always the case with Kafka, this check in spec ensures it is predictable.

close https://github.com/karafka/karafka/issues/1804