### PR TITLE
Alias `#produce_sync` and `#produce_async` in consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.2.15 (Unreleased)
 - **[Feature]** Provide `Karafka::Admin::Acl` for Kafka ACL management via the Admin APIs.
 - **[Feature]** Periodic Jobs (Pro)
+- [Enhancement] Alias producer operations in consumer to skip `#producer` reference.
 - [Enhancement] Provide an `:independent` configuration to DLQ allowing to reset pause count track on each marking as consumed when retrying.
 - [Change] Make `Kubernetes::LivenessListener` not start until Karafka app starts running.
 - [Fix] Fix a case where internal Idle job scheduling would go via the consumption flow.

--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -11,7 +11,7 @@ module Karafka
 
     def_delegators :@coordinator, :topic, :partition
 
-    def_delegators :producer, :produce_async, :produce_sync,:produce_many_async,
+    def_delegators :producer, :produce_async, :produce_sync, :produce_many_async,
                    :produce_many_sync
 
     # @return [String] id of the current consumer

--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -11,6 +11,9 @@ module Karafka
 
     def_delegators :@coordinator, :topic, :partition
 
+    def_delegators :producer, :produce_async, :produce_sync,:produce_many_async,
+                   :produce_many_sync
+
     # @return [String] id of the current consumer
     attr_reader :id
     # @return [Karafka::Routing::Topic] topic to which a given consumer is subscribed

--- a/spec/integrations/consumption/producing_with_aliases_spec.rb
+++ b/spec/integrations/consumption/producing_with_aliases_spec.rb
@@ -10,8 +10,8 @@ class Consumer < Karafka::BaseConsumer
 
     produce_async(topic: topic.name, payload: '1')
     produce_sync(topic: topic.name, payload: '2')
-    produce_many_async([{ topic: topic.name, payload: '2'}])
-    produce_many_sync([{ topic: topic.name, payload: '2'}])
+    produce_many_async([{ topic: topic.name, payload: '2' }])
+    produce_many_sync([{ topic: topic.name, payload: '2' }])
   end
 end
 

--- a/spec/integrations/consumption/producing_with_aliases_spec.rb
+++ b/spec/integrations/consumption/producing_with_aliases_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Karafka should be able to produce from consumers using the delegated aliased API
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[:done] = true
+
+    produce_async(topic: topic.name, payload: '1')
+    produce_sync(topic: topic.name, payload: '2')
+    produce_many_async([{ topic: topic.name, payload: '2'}])
+    produce_many_sync([{ topic: topic.name, payload: '2'}])
+  end
+end
+
+draw_routes(Consumer)
+
+produce_many(DT.topic, DT.uuids(1))
+
+start_karafka_and_wait_until do
+  DT.key?(:done)
+end
+
+# No checks needed. If aliases wouldn't work, will crash


### PR DESCRIPTION
close https://github.com/karafka/karafka/issues/1810