### PR TITLE
Multiplexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Karafka framework changelog
 
 ## 2.2.15 (Unreleased)
+- **[Feature]** Provide ability to multiplex subscription groups (Pro)
 - **[Feature]** Provide `Karafka::Admin::Acl` for Kafka ACL management via the Admin APIs.
 - **[Feature]** Periodic Jobs (Pro)
+- [Enhancement] Allow for multiple connections to the same topic within same consumer group using separate subscription groups.
 - [Enhancement] Alias producer operations in consumer to skip `#producer` reference.
 - [Enhancement] Provide an `:independent` configuration to DLQ allowing to reset pause count track on each marking as consumed when retrying.
 - [Change] Make `Kubernetes::LivenessListener` not start until Karafka app starts running.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 - **[Feature]** Provide ability to multiplex subscription groups (Pro)
 - **[Feature]** Provide `Karafka::Admin::Acl` for Kafka ACL management via the Admin APIs.
 - **[Feature]** Periodic Jobs (Pro)
-- [Enhancement] Allow for multiple connections to the same topic within same consumer group using separate subscription groups.
 - [Enhancement] Alias producer operations in consumer to skip `#producer` reference.
 - [Enhancement] Provide an `:independent` configuration to DLQ allowing to reset pause count track on each marking as consumed when retrying.
 - [Change] Make `Kubernetes::LivenessListener` not start until Karafka app starts running.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ GEM
     karafka-core (2.2.7)
       concurrent-ruby (>= 1.1)
       karafka-rdkafka (>= 0.13.9, < 0.15.0)
-    karafka-rdkafka (0.14.3)
+    karafka-rdkafka (0.14.5)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)

--- a/lib/karafka/contracts/consumer_group.rb
+++ b/lib/karafka/contracts/consumer_group.rb
@@ -18,7 +18,7 @@ module Karafka
       virtual do |data, errors|
         next unless errors.empty?
 
-        names = data.fetch(:topics).map { |topic| topic[:name] }
+        names = data.fetch(:topics).map { |topic| topic_unique_key(topic) }
 
         next if names.size == names.uniq.size
 
@@ -50,6 +50,14 @@ module Karafka
         next unless error_occured
 
         [[%i[topics], :topics_namespaced_names_not_unique]]
+      end
+
+      class << self
+        # @param topic [Hash] topic config hash
+        # @return [String] topic unique key for validators
+        def topic_unique_key(topic)
+          topic[:name]
+        end
       end
     end
   end

--- a/lib/karafka/pro/routing/features/multiplexing.rb
+++ b/lib/karafka/pro/routing/features/multiplexing.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    # Namespace for Pro routing enhancements
+    module Routing
+      # Namespace for additional Pro features
+      module Features
+        # Multiplexing allows for creating multiple subscription groups for the same topic inside
+        # of the same subscription group allowing for better parallelism with limited number
+        # of processes
+        class Multiplexing < Base
+          class << self
+            # @param _config [Karafka::Core::Configurable::Node] app config node
+            def pre_setup(_config)
+              # Make sure we use proper unique validator for topics definitions
+              ::Karafka::Contracts::ConsumerGroup.singleton_class.prepend(
+                Patches::Contracts::ConsumerGroup
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/routing/features/multiplexing/consumer_group.rb
+++ b/lib/karafka/pro/routing/features/multiplexing/consumer_group.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Routing
+      module Features
+        class Multiplexing < Base
+          # Expansions of routing for multiplexing support
+          module ConsumerGroup
+            # Assigns the current subscription group id based on the defined one and allows for
+            # further topic definition
+            # @param name [String, Symbol] name of the current subscription group
+            # @param multiplex [Integer] how many subscription groups initialize out of this
+            #   definition
+            # @param block [Proc] block that may include topics definitions
+            def subscription_group=(name = SubscriptionGroup.id, multiplex: 1, &block)
+              multiplex.times do |i|
+                super(
+                  multiplex > 1 ? "#{name}-#{i}" : name.to_s,
+                  &block
+                )
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/routing/features/multiplexing/consumer_group.rb
+++ b/lib/karafka/pro/routing/features/multiplexing/consumer_group.rb
@@ -27,7 +27,7 @@ module Karafka
             def subscription_group=(name = SubscriptionGroup.id, multiplex: 1, &block)
               multiplex.times do |i|
                 super(
-                  multiplex > 1 ? "#{name}-#{i}" : name.to_s,
+                  multiplex > 1 ? "#{name}_multiplex_#{i}" : name.to_s,
                   &block
                 )
               end

--- a/lib/karafka/pro/routing/features/multiplexing/patches/contracts/consumer_group.rb
+++ b/lib/karafka/pro/routing/features/multiplexing/patches/contracts/consumer_group.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Routing
+      module Features
+        class Multiplexing < Base
+          # Patches to Karafka OSS
+          module Patches
+            # Contracts patches
+            module Contracts
+              # Consumer group contract patches
+              module ConsumerGroup
+                # Redefines the setup allowing for multiple sgs as long as with different names
+                #
+                # @param topic [Hash] topic config hash
+                # @return [Array] topic unique key for validators
+                def topic_unique_key(topic)
+                  [
+                    topic[:name],
+                    topic[:subscription_group_name]
+                  ]
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/routing/builder.rb
+++ b/lib/karafka/routing/builder.rb
@@ -109,10 +109,20 @@ module Karafka
       # subscription group customization
       # @param subscription_group_name [String, Symbol] subscription group id. When not provided,
       #   a random uuid will be used
+      # @param args [Array] any extra arguments accepted by the subscription group builder
       # @param block [Proc] further topics definitions
-      def subscription_group(subscription_group_name = SubscriptionGroup.id, &block)
+      def subscription_group(
+        subscription_group_name = SubscriptionGroup.id,
+        **args,
+        &block
+      )
         consumer_group('app') do
-          target.public_send(:subscription_group=, subscription_group_name.to_s, &block)
+          target.public_send(
+            :subscription_group=,
+            subscription_group_name.to_s,
+            **args,
+            &block
+          )
         end
       end
 

--- a/spec/integrations/pro/consumption/multiplexing/with_same_topic_in_multiple_subscription_groups_spec.rb
+++ b/spec/integrations/pro/consumption/multiplexing/with_same_topic_in_multiple_subscription_groups_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# When using separate subscription groups, each should have it's own underlying client and should
+# operate independently for data fetching and consumption
+
+setup_karafka do |config|
+  config.concurrency = 10
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[:clients] << client.object_id
+    DT[:consumers] << object_id
+  end
+end
+
+draw_routes do
+  subscription_group :sg, concurrency: 5 do
+    topic DT.topic do
+      config(partitions: 10)
+      consumer Consumer
+    end
+  end
+end
+
+start_karafka_and_wait_until do
+  10.times do |i|
+    produce_many(DT.topic, DT.uuids(10), partition: i)
+  end
+
+  sleep(1)
+
+  DT[:clients].uniq.count >= 5 && DT[:consumers].uniq.count >= 5
+end
+
+assert_equal 5, DT[:clients].uniq.size
+assert DT[:consumers].uniq.size >= 5

--- a/spec/integrations/pro/consumption/multiplexing/with_same_topic_in_multiple_subscription_groups_spec.rb
+++ b/spec/integrations/pro/consumption/multiplexing/with_same_topic_in_multiple_subscription_groups_spec.rb
@@ -15,7 +15,7 @@ class Consumer < Karafka::BaseConsumer
 end
 
 draw_routes do
-  subscription_group :sg, concurrency: 5 do
+  subscription_group :sg, multiplex: 5 do
     topic DT.topic do
       config(partitions: 10)
       consumer Consumer

--- a/spec/integrations/pro/routing/with_multiplexed_subscription_group_spec.rb
+++ b/spec/integrations/pro/routing/with_multiplexed_subscription_group_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Karafka should allow for multiplexing subscription group
+
+setup_karafka do |config|
+  config.strict_topics_namespacing = false
+end
+
+failed = false
+
+SG_UUID = SecureRandom.uuid
+
+begin
+  draw_routes(create_topics: false) do
+    subscription_group SG_UUID, multiplex: 5 do
+      topic 'namespace_collision' do
+        consumer Class.new
+      end
+    end
+  end
+rescue Karafka::Errors::InvalidConfigurationError
+  failed = true
+end
+
+assert_equal 5, Karafka::App.routes.first.subscription_groups.size
+
+Karafka::App.routes.first.subscription_groups.each_with_index do |sg, i|
+  assert sg.id.include?("#{SG_UUID}-#{i}_#{i}")
+  assert_equal sg.name, "#{SG_UUID}-#{i}"
+end
+
+assert !failed

--- a/spec/integrations/pro/routing/with_multiplexed_subscription_group_spec.rb
+++ b/spec/integrations/pro/routing/with_multiplexed_subscription_group_spec.rb
@@ -25,8 +25,8 @@ end
 assert_equal 5, Karafka::App.routes.first.subscription_groups.size
 
 Karafka::App.routes.first.subscription_groups.each_with_index do |sg, i|
-  assert sg.id.include?("#{SG_UUID}-#{i}_#{i}")
-  assert_equal sg.name, "#{SG_UUID}-#{i}"
+  assert sg.id.include?("#{SG_UUID}_multiplex_#{i}_#{i}")
+  assert_equal sg.name, "#{SG_UUID}_multiplex_#{i}"
 end
 
 assert !failed

--- a/spec/integrations/pro/routing/with_same_topic_in_multiple_same_subscription_groups_spec.rb
+++ b/spec/integrations/pro/routing/with_same_topic_in_multiple_same_subscription_groups_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Karafka should not allow for same topic to be present in multiple subscription groups in the same
+# consumer group with same subscription group name
+
+setup_karafka do |config|
+  config.strict_topics_namespacing = false
+end
+
+failed = false
+
+begin
+  draw_routes(create_topics: false) do
+    subscription_group :a do
+      topic 'namespace_collision' do
+        consumer Class.new
+      end
+    end
+
+    subscription_group :a do
+      topic 'namespace_collision' do
+        consumer Class.new
+      end
+    end
+  end
+rescue Karafka::Errors::InvalidConfigurationError
+  failed = true
+end
+
+assert failed

--- a/spec/integrations/pro/routing/with_same_topic_in_multiple_subscription_groups_spec.rb
+++ b/spec/integrations/pro/routing/with_same_topic_in_multiple_subscription_groups_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Karafka should allow for same topic to be present in multiple subscription groups in the same
+# consumer group as long as subscription groups have different names
+
+setup_karafka do |config|
+  config.strict_topics_namespacing = false
+end
+
+failed = false
+
+begin
+  draw_routes(create_topics: false) do
+    subscription_group :a do
+      topic 'namespace_collision' do
+        consumer Class.new
+      end
+    end
+
+    subscription_group :b do
+      topic 'namespace_collision' do
+        consumer Class.new
+      end
+    end
+  end
+rescue Karafka::Errors::InvalidConfigurationError
+  failed = true
+end
+
+assert !failed

--- a/spec/integrations/routing/with_same_topic_in_multiple_subscription_groups_spec.rb
+++ b/spec/integrations/routing/with_same_topic_in_multiple_subscription_groups_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Karafka should not allow for multiple subscriptions to the same topic in the same consumer group
+# even if subscription group names are different
+
+setup_karafka
+
+failed = false
+
+begin
+  draw_routes(create_topics: false) do
+    consumer_group :test do
+      subscription_group 'namespace_collision' do
+        topic :test do
+          consumer Class.new
+        end
+      end
+
+      subscription_group 'namespace_collision2' do
+        topic :test do
+          consumer Class.new
+        end
+      end
+    end
+  end
+rescue Karafka::Errors::InvalidConfigurationError
+  failed = true
+end
+
+assert failed

--- a/spec/lib/karafka/pro/routing/features/multiplexing/consumer_group_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/multiplexing/consumer_group_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:cg) { build(:routing_consumer_group) }
+
+  let(:adding_pattern) do
+    cg.public_send(:subscription_group=, :name, multiplex: multiplex) do
+      topic :test do
+        consumer Class.new
+      end
+    end
+  end
+
+  it { expect(cg.subscription_groups).to be_empty }
+
+  context 'when adding regular subscription group' do
+    let(:multiplex) { 1 }
+
+    before { adding_pattern }
+
+    it { expect(cg.subscription_groups.size).to eq(1) }
+  end
+
+  context 'when adding multiplexed subscription group' do
+    let(:multiplex) { 5 }
+
+    before { adding_pattern }
+
+    it { expect(cg.subscription_groups.size).to eq(5) }
+  end
+end

--- a/spec/lib/karafka/pro/routing/features/multiplexing/patches/contracts/consumer_group_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/multiplexing/patches/contracts/consumer_group_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:expanded) do
+    klass = described_class
+
+    Class.new do
+      extend klass
+    end
+  end
+
+  describe '#topic_unique_key' do
+    let(:topic) { { name: 'test', subscription_group_name: 'sg', other: 'na' } }
+
+    it { expect(expanded.topic_unique_key(topic)).to eq(%w[test sg]) }
+  end
+end

--- a/spec/lib/karafka/pro/routing/features/multiplexing_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/multiplexing_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  it { expect(described_class).to be < ::Karafka::Routing::Features::Base }
+end


### PR DESCRIPTION
This feature allows for running multiple parallel connections for data of the same topic from a single process.

It should allow for much better parallelism when lagging on topics that do not have as many processes as partitions and cannot use VPs due to the nature of their data.

close https://github.com/karafka/karafka/issues/1604