### PR TITLE
alias lrj as non blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **[Feature]** Provide ability to multiplex subscription groups (Pro)
 - **[Feature]** Provide `Karafka::Admin::Acl` for Kafka ACL management via the Admin APIs.
 - **[Feature]** Periodic Jobs (Pro)
+- [Enhancement] Introduce `non_blocking` routing API that aliases LRJ to indicate a different use-case for LRJ flow approach.
 - [Enhancement] Allow to reset offset when seeking backwards by using the `reset_offset` keyword attribute set to `true`.
 - [Enhancement] Alias producer operations in consumer to skip `#producer` reference.
 - [Enhancement] Provide an `:independent` configuration to DLQ allowing to reset pause count track on each marking as consumed when retrying.

--- a/lib/karafka/pro/routing/features/non_blocking_job.rb
+++ b/lib/karafka/pro/routing/features/non_blocking_job.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    # Namespace for Pro routing enhancements
+    module Routing
+      # Namespace for additional Pro features
+      module Features
+        # Non Blocking Job is just an alias for LRJ.
+        #
+        # We however have it as a separate feature because its use-case may vary from LRJ.
+        #
+        # While LRJ is used mainly for long-running jobs that would take more than max poll
+        # interval time, non-blocking can be applied to make sure that we do not wait with polling
+        # of different partitions and topics that are subscribed together.
+        #
+        # This effectively allows for better resources utilization
+        #
+        # All the underlying code is the same but use-case is different and this should be
+        # reflected in the routing, hence this "virtual" feature.
+        class NonBlockingJob < Base
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/routing/features/non_blocking_job/topic.rb
+++ b/lib/karafka/pro/routing/features/non_blocking_job/topic.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Routing
+      module Features
+        class NonBlockingJob < Base
+          # Non-Blocking Jobs topic API extensions
+          module Topic
+            # @param args [Array] anything accepted by the `#long_running_job` API
+            def non_blocking_job(*args)
+              long_running_job(*args)
+            end
+
+            alias non_blocking non_blocking_job
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/integrations/pro/consumption/strategies/lrj/default/fast_non_blocking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/default/fast_non_blocking_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Fast jobs should also not have any problems (though not recommended) when running as lrj
+# It should work ok also when used via `non_blocking` API.
+
+setup_karafka do |config|
+  config.max_messages = 1
+  # We set it here that way not too wait too long on stuff
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[0] << messages.first.raw_payload
+  end
+end
+
+draw_routes do
+  consumer_group DT.consumer_group do
+    topic DT.topic do
+      consumer Consumer
+      non_blocking true
+    end
+  end
+end
+
+payloads = DT.uuids(20)
+produce_many(DT.topic, payloads)
+
+start_karafka_and_wait_until do
+  DT[0].size >= 20
+end
+
+assert_equal payloads, DT[0]

--- a/spec/integrations/pro/consumption/strategies/lrj/default/processing_via_non_blocking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/default/processing_via_non_blocking_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# When a job is marked as lrj, it should keep running longer than max poll interval and all
+# should be good. It should continue processing after resume and should pick up next messages
+# Marking as LRJ should also work via `non_blocking` alias.
+
+setup_karafka do |config|
+  config.max_messages = 1
+  # We set it here that way not too wait too long on stuff
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    # Ensure we exceed max poll interval, if that happens and this would not work async we would
+    # be kicked out of the group
+    sleep(15)
+
+    DT[0] << messages.first.raw_payload
+  end
+end
+
+draw_routes do
+  consumer_group DT.consumer_group do
+    topic DT.topic do
+      consumer Consumer
+      non_blocking_job true
+    end
+  end
+end
+
+payloads = DT.uuids(2)
+produce_many(DT.topic, payloads)
+
+start_karafka_and_wait_until do
+  DT[0].size >= 2
+end
+
+assert_equal payloads, DT[0]

--- a/spec/lib/karafka/pro/routing/features/non_blocking_job/topic_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/non_blocking_job/topic_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:topic) { build(:routing_topic) }
+
+  describe '#non_blocking_job' do
+    context 'when we use non_blocking_job without any arguments' do
+      it 'expect to initialize with defaults' do
+        expect(topic.long_running_job.active?).to eq(false)
+      end
+    end
+
+    context 'when we use non_blocking_job with active status' do
+      it 'expect to use proper active status' do
+        topic.non_blocking_job(true)
+        expect(topic.long_running_job.active?).to eq(true)
+      end
+    end
+
+    context 'when we use non_blocking_job multiple times with different values' do
+      it 'expect to use proper active status' do
+        topic.non_blocking_job(true)
+        topic.non_blocking_job(false)
+        expect(topic.long_running_job.active?).to eq(true)
+      end
+    end
+  end
+
+  describe '#long_running_job?' do
+    context 'when active' do
+      before { topic.non_blocking_job(true) }
+
+      it { expect(topic.long_running_job?).to eq(true) }
+    end
+
+    context 'when not active' do
+      before { topic.non_blocking_job(false) }
+
+      it { expect(topic.long_running_job?).to eq(false) }
+    end
+  end
+
+  describe '#to_h' do
+    it { expect(topic.to_h[:long_running_job]).to eq(topic.non_blocking_job.to_h) }
+  end
+end

--- a/spec/lib/karafka/pro/routing/features/non_blocking_job_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/non_blocking_job_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  it { expect(described_class).to be < ::Karafka::Pro::Routing::Features::Base }
+end


### PR DESCRIPTION
This PR aliases LRJ via `non_blocking` to allow for indication in routing that LRJ is set to avoid blocking and not to run LRJ.

While conceptually it uses the same code, the expression "non blocking" and "long-running" have different indication