### PR TITLE
replace define method with class eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [Enhancement] Alias producer operations in consumer to skip `#producer` reference.
 - [Enhancement] Provide an `:independent` configuration to DLQ allowing to reset pause count track on each marking as consumed when retrying.
 - [Change] Make `Kubernetes::LivenessListener` not start until Karafka app starts running.
+- [Refactor] Replace `define_method` with `class_eval` in some locations.
 - [Fix] Fix a case where internal Idle job scheduling would go via the consumption flow.
 
 ## 2.2.14 (2023-12-07)

--- a/lib/karafka/app.rb
+++ b/lib/karafka/app.rb
@@ -75,9 +75,11 @@ module Karafka
         monitor
         pro?
       ].each do |delegated|
-        define_method(delegated) do
-          Karafka.send(delegated)
-        end
+        class_eval <<~RUBY, __FILE__, __LINE__ + 1
+          def #{delegated}
+            Karafka.#{delegated}
+          end
+        RUBY
       end
     end
   end

--- a/lib/karafka/process.rb
+++ b/lib/karafka/process.rb
@@ -25,9 +25,11 @@ module Karafka
       #     Karafka.logger.info('Log something here')
       #     exit
       #   end
-      define_method :"on_#{signal.to_s.downcase}" do |&block|
-        @callbacks[signal] << block
-      end
+      class_eval <<~RUBY, __FILE__, __LINE__ + 1
+        def on_#{signal.to_s.downcase}(&block)
+          @callbacks[:#{signal}] << block
+        end
+      RUBY
     end
 
     # Creates an instance of process and creates empty hash for callbacks

--- a/lib/karafka/routing/topic.rb
+++ b/lib/karafka/routing/topic.rb
@@ -46,15 +46,13 @@ module Karafka
       INHERITABLE_ATTRIBUTES.each do |attribute|
         attr_writer attribute
 
-        define_method attribute do
-          current_value = instance_variable_get(:"@#{attribute}")
+        class_eval <<~RUBY, __FILE__, __LINE__ + 1
+          def #{attribute}
+            return @#{attribute} unless @#{attribute}.nil?
 
-          return current_value unless current_value.nil?
-
-          value = Karafka::App.config.send(attribute)
-
-          instance_variable_set(:"@#{attribute}", value)
-        end
+            @#{attribute} = Karafka::App.config.send(:#{attribute})
+          end
+        RUBY
       end
 
       # @return [String] name of subscription that will go to librdkafka


### PR DESCRIPTION
Since class eval methods do not have closures, it should be slightly better on the memory side and less risky on the scope. Plus it is a bit faster in general.
