### PR TITLE
Improved Periodics

### DIFF
--- a/config/locales/pro_errors.yml
+++ b/config/locales/pro_errors.yml
@@ -36,6 +36,9 @@ en:
       periodic_job.active_format: 'needs to be boolean'
       periodic_job.interval_missing: 'needs to be present'
       periodic_job.interval_format: 'needs to be an integer equal or more than 100'
+      periodic_job.during_pause_format: 'needs to be boolean'
+      periodic_job.during_retry_format: 'needs to be boolean'
+      periodic_job.materialized_format: 'needs to be boolean'
 
       inline_insights.active_format: 'needs to be boolean'
       inline_insights.required_format: 'needs to be boolean'

--- a/lib/karafka/connection/listener.rb
+++ b/lib/karafka/connection/listener.rb
@@ -358,10 +358,19 @@ module Karafka
             # Skip if we were operating on a given topic partition recently
             next if @usage_tracker.active?(topic_name, partition, interval)
 
+            coordinator = @coordinators.find_or_create(topic_name, partition)
+
+            # Do not tick if we do not want to tick during pauses
+            next if coordinator.paused? && !topic.periodic_job.during_pause?
+
+            # If we do not want to run periodics during retry flows, we should not
+            # Since this counter is incremented before processing here it is always -1 from what
+            # we see in the consumer flow. THat is why attempt 0 means that we will have first
+            # run (ok) but attempt 1 means, there was an error
+            next if coordinator.attempt.positive? && !topic.periodic_job.during_retry?
+
             # Track so we do not run periodic job again too soon
             @usage_tracker.track(topic_name, partition)
-
-            coordinator = @coordinators.find_or_create(topic_name, partition)
 
             @executors.find_all_or_create(topic_name, partition, coordinator).each do |executor|
               jobs << @jobs_builder.periodic(executor)

--- a/lib/karafka/pro/routing/features/periodic_job/config.rb
+++ b/lib/karafka/pro/routing/features/periodic_job/config.rb
@@ -19,9 +19,17 @@ module Karafka
           # Config for periodics topics feature
           Config = Struct.new(
             :active,
+            :during_pause,
+            :during_retry,
             :interval,
+            :materialized,
             keyword_init: true
-          ) { alias_method :active?, :active }
+          ) do
+            alias_method :active?, :active
+            alias_method :during_pause?, :during_pause
+            alias_method :during_retry?, :during_retry
+            alias_method :materialized?, :materialized
+          end
         end
       end
     end

--- a/lib/karafka/pro/routing/features/periodic_job/contracts/topic.rb
+++ b/lib/karafka/pro/routing/features/periodic_job/contracts/topic.rb
@@ -31,6 +31,9 @@ module Karafka
               nested(:periodic_job) do
                 required(:active) { |val| [true, false].include?(val) }
                 required(:interval) { |val| val.is_a?(Integer) && val >= 100 }
+                required(:during_pause) { |val| [true, false].include?(val) }
+                required(:during_retry) { |val| [true, false].include?(val) }
+                required(:materialized) { |val| [true, false].include?(val) }
               end
             end
           end

--- a/lib/karafka/pro/routing/features/periodic_job/topic.rb
+++ b/lib/karafka/pro/routing/features/periodic_job/topic.rb
@@ -22,15 +22,53 @@ module Karafka
             # poll where messages were not received.
             # @param active [Boolean] should ticking happen for this topic assignments.
             # @param interval [Integer] minimum interval to run periodic jobs on given topic.
-            def periodic_job(active = false, interval: nil)
+            # @param during_pause [Boolean] Should periodic jobs run when partition is paused. It
+            #   is true by default but can be set to false if we do not want to run it when pausing
+            #   occurs
+            # @param during_retry [Boolean] Should we run when there was an error and we are in
+            #   a retry flow. Please not that for this to work, `during_pause` also needs to be
+            #   set to true as on errors retry happens after pause.
+            def periodic_job(
+              active = false,
+              interval: nil,
+              during_pause: nil,
+              during_retry: nil
+            )
               @periodic_job ||= begin
                 # If only interval defined, it means we want to use so set to active
-                active = true if interval.is_a?(Integer)
+                active = true unless interval.nil?
+                active = true unless during_pause.nil?
+                active = true unless during_retry.nil?
+                during_retry = false if during_retry.nil?
+
                 # If no interval, use default
                 interval ||= ::Karafka::App.config.internal.tick_interval
 
-                Config.new(active: active, interval: interval)
+                Config.new(
+                  active: active,
+                  interval: interval,
+                  during_pause: during_pause,
+                  during_retry: during_retry,
+                  # This is internal setting for state management, not part of the configuration
+                  # Do not overwrite.
+                  # If during_pause is explicit, we do not select it based on LRJ setup and we
+                  # consider if fully ready out of the box
+                  materialized: !during_pause.nil?
+                )
               end
+
+              return @periodic_job if @periodic_job.materialized?
+              return @periodic_job unless @long_running_job
+
+              # If not configured in any way, we want not to process during pause for LRJ.
+              # LRJ pauses by default when processing and during this time we do not want to
+              # tick at all. This prevents us from running periodic jobs while LRJ jobs are
+              # running. This of course has a side effect of not running when paused for any
+              # other reason but it is a compromise in the default settings
+              @periodic_job.during_pause = !long_running_job?
+              @periodic_job.materialized = true
+
+              @periodic_job
             end
 
             alias periodic periodic_job

--- a/lib/karafka/processing/coordinator.rb
+++ b/lib/karafka/processing/coordinator.rb
@@ -141,6 +141,16 @@ module Karafka
         @marked
       end
 
+      # @return [Boolean] true if paused, false otherwise
+      def paused?
+        @pause_tracker.paused?
+      end
+
+      # @return [Integer] attempt we're in when processing given batch
+      def attempt
+        @pause_tracker.attempt
+      end
+
       # Store in the coordinator info, that this pause was done manually by the end user and not
       # by the system itself
       def manual_pause

--- a/spec/integrations/pro/consumption/periodic_jobs/during_error_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/during_error_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# By default ticking should not happen if we are in a recovery flow
+
+setup_karafka(allow_errors: true) do |config|
+  config.pause_timeout = 1_000
+  config.pause_max_timeout = 1_500
+  config.max_wait_time = 100
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[:started] << Time.now.to_f
+
+    raise
+  end
+
+  def tick
+    DT[:ticks] << Time.now.to_f
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    periodic interval: 100
+  end
+end
+
+produce_many(DT.topic, DT.uuids(1))
+
+start_karafka_and_wait_until do
+  sleep(10)
+end
+
+DT[:ticks].each do |tick|
+  assert tick < DT[:started].min
+end

--- a/spec/integrations/pro/consumption/periodic_jobs/during_error_with_recovery_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/during_error_with_recovery_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# If we explicitely want to tick during recovery, it should be possible
+
+setup_karafka(allow_errors: true) do |config|
+  config.pause_timeout = 1_000
+  config.pause_max_timeout = 1_500
+  config.max_wait_time = 100
+  config.max_messages = 1
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    if DT[:errored].size < 5
+      DT[:errored] << Time.now.to_f
+      raise
+    end
+
+    DT[:post_error] << Time.now.to_f
+  end
+
+  def tick
+    DT[:ticks] << Time.now.to_f
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    periodic interval: 100, during_retry: true
+  end
+end
+
+produce_many(DT.topic, DT.uuids(20))
+
+start_karafka_and_wait_until do
+  DT[:post_error].size >= 2
+end
+
+assert DT[:ticks].any? do |tick|
+  (tick > DT[:errored].min) && (tick < DT[:post_error].min)
+end

--- a/spec/integrations/pro/consumption/periodic_jobs/long_running_jobs/no_parallel_ticking_when_not_during_pause_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/long_running_jobs/no_parallel_ticking_when_not_during_pause_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# When running on LRJ, ticking should not happen alongside long processing when it is not turned
+# on (default is off).
+# Note that LRJ consume can start when tick is running. Only the other way around is not allowed
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    start = Time.now.to_f
+    sleep(10)
+    DT[:consume] << (start..Time.now.to_f)
+  end
+
+  def tick
+    produce_many(DT.topic, DT.uuids(1))
+    DT[:ticks] << Time.now.to_f
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    periodic true
+    long_running_job true
+  end
+end
+
+start_karafka_and_wait_until do
+  DT[:ticks].count >= 5
+end
+
+# There should be at least one tick parallel to consumption
+assert DT[:consume].all? do |time_range|
+  DT[:ticks].none? do |tick_time|
+    time_range.include?(tick_time)
+  end
+end

--- a/spec/integrations/pro/consumption/periodic_jobs/long_running_jobs/parallel_ticking_when_during_pause_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/long_running_jobs/parallel_ticking_when_during_pause_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # When running on LRJ, ticking should happen alongside long processing because it is non blocking
-# on proper periods
+# on proper periods when `during_pause` is set to true.
 
 setup_karafka
 
@@ -21,7 +21,7 @@ end
 draw_routes do
   topic DT.topic do
     consumer Consumer
-    periodic true
+    periodic(during_pause: true)
     long_running_job true
   end
 end

--- a/spec/integrations/pro/consumption/periodic_jobs/long_running_jobs/ticking_overlaping_consuming_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/long_running_jobs/ticking_overlaping_consuming_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# When running LRJ and ticking, ticking is not synchronized with LRJ
+# (unless synchronized via mutex). This means, that it should be possible to have a long living
+# ticking that started when nothing was happening but meanwhile things started.
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[:consume] << Time.now.to_f
+  end
+
+  def tick
+    start = Time.now.to_f
+    produce_many(DT.topic, DT.uuids(1))
+    sleep(10)
+    DT[:ticks] << (start..Time.now.to_f)
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    periodic true
+    long_running_job true
+  end
+end
+
+start_karafka_and_wait_until do
+  DT.key?(:ticks)
+end
+
+# There should be at least one tick parallel to consumption
+assert DT[:ticks].any? do |time_range|
+  DT[:consume].any? do |tick_time|
+    time_range.include?(tick_time)
+  end
+end

--- a/spec/integrations/pro/consumption/periodic_jobs/not_during_error_with_recovery_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/not_during_error_with_recovery_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Ticking should work before and after the recovery but not during in the default setup.
+
+setup_karafka(allow_errors: true) do |config|
+  config.pause_timeout = 1_000
+  config.pause_max_timeout = 1_500
+  config.max_wait_time = 100
+  config.max_messages = 1
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    if DT[:errored].size < 5
+      DT[:errored] << Time.now.to_f
+      raise
+    end
+
+    DT[:post_error] << Time.now.to_f
+  end
+
+  def tick
+    DT[:ticks] << Time.now.to_f
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    periodic interval: 100
+  end
+end
+
+produce_many(DT.topic, DT.uuids(20))
+
+start_karafka_and_wait_until do
+  DT[:post_error].size >= 2
+end
+
+DT[:ticks].each do |tick|
+  assert (tick < DT[:errored].min) || (tick > DT[:post_error].min)
+end

--- a/spec/integrations/pro/consumption/periodic_jobs/without_ticking_on_pause_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/without_ticking_on_pause_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# When periodic jobs are configured not to tick when partition is paused we should not tick then
+# Keep in mind, LRJ always pauses so you won't have ticking on it if this is set like this
+
+setup_karafka do |config|
+  config.max_wait_time = 100
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[:iterations] << true
+
+    if DT[:iterations].size >= 5
+      pause(messages.first.offset, 100_000_000)
+      DT[:started] = Time.now.to_f
+    end
+  end
+
+  def tick
+    DT[:ticks] << Time.now.to_f
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    periodic(
+      interval: 100,
+      during_pause: false
+    )
+  end
+end
+
+start_karafka_and_wait_until do
+  if DT[:iterations].size < 5
+    produce_many(DT.topic, DT.uuids(1))
+    sleep(1)
+  end
+
+  DT[:iterations].size >= 5 && DT.key?(:started) && sleep(5)
+end
+
+DT[:ticks].each do |tick|
+  assert tick <= DT[:started]
+end

--- a/spec/lib/karafka/pro/routing/features/periodic_job/contracts/topic_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/periodic_job/contracts/topic_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe_current do
     {
       periodic_job: {
         active: true,
-        interval: 2_500
+        interval: 2_500,
+        during_pause: true,
+        during_retry: true
       }
     }
   end
@@ -18,6 +20,18 @@ RSpec.describe_current do
 
   context 'when active flag is not boolean' do
     before { config[:periodic_job][:active] = rand }
+
+    it { expect(check).not_to be_success }
+  end
+
+  context 'when during_pause flag is not boolean' do
+    before { config[:periodic_job][:during_pause] = rand }
+
+    it { expect(check).not_to be_success }
+  end
+
+  context 'when during_retry flag is not boolean' do
+    before { config[:periodic_job][:during_retry] = rand }
 
     it { expect(check).not_to be_success }
   end


### PR DESCRIPTION
I noticed that periodics, by default, would run when the partition is paused and on errors. I introduced two new settings to them that allow for configuration of it. The defaults are as follows:

- on recovery (retry flows) periodics will NOT run
- on pause periodics WILL run unless it is LRJ because for LRJ pause is applied during processing. This provides an "out of the box" way of ensuring that LRJ jobs won't run with periodics unless explicitly requested.
- 