### PR TITLE
prevent eos from kicking in when assignment is lost

### DIFF
--- a/lib/karafka/errors.rb
+++ b/lib/karafka/errors.rb
@@ -76,5 +76,9 @@ module Karafka
 
     # Raised when we want to un-pause listener that was not paused
     InvalidListenerPauseError = Class.new(BaseError)
+
+    # Raised in transactions when we attempt to store offset for a partition that we have lost
+    # This does not affect producer only transactions, hence we raise it only on offset storage
+    AssignmentLostError = Class.new(BaseError)
   end
 end

--- a/lib/karafka/pro/processing/strategies/default.rb
+++ b/lib/karafka/pro/processing/strategies/default.rb
@@ -134,6 +134,7 @@ module Karafka
           #   transaction state synchronization usage as within transaction it is always sync)
           def mark_in_transaction(message, offset_metadata, async)
             raise Errors::TransactionRequiredError unless @_in_transaction
+            raise Errors::AssignmentLostError if revoked?
 
             producer.transaction_mark_as_consumed(
               client,

--- a/lib/karafka/pro/processing/strategies/vp/default.rb
+++ b/lib/karafka/pro/processing/strategies/vp/default.rb
@@ -93,6 +93,8 @@ module Karafka
             #   transaction state synchronization usage as within transaction it is always sync)
             def mark_in_transaction(message, offset_metadata, async)
               raise Errors::TransactionRequiredError unless @_in_transaction
+              # Prevent from attempts of offset storage when we no longer own the assignment
+              raise Errors::AssignmentLostError if revoked?
 
               return super if collapsed?
 

--- a/spec/integrations/pro/consumption/transactions/lost_assignment_with_offset_storage_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/lost_assignment_with_offset_storage_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# We should NOT be able to mark as consumed within a transaction on a lost partition because the
+# transaction is expected to fail.
+
+setup_karafka(allow_errors: true) do |config|
+  config.kafka[:'transactional.id'] = SecureRandom.uuid
+  config.max_messages = 2
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    return if DT.key?(:done)
+
+    DT[:done] = true
+
+    sleep(0.1) until revoked?
+
+    begin
+      transaction do
+        produce_async(topic: topic.name, payload: '1')
+        mark_as_consumed(messages.last)
+      end
+    rescue Karafka::Errors::AssignmentLostError => e
+      DT[:error] = e
+    end
+  end
+end
+
+draw_routes(Consumer)
+
+produce_many(DT.topic, DT.uuids(1))
+
+start_karafka_and_wait_until do
+  DT.key?(:done)
+end
+
+assert DT.key?(:error)

--- a/spec/integrations/pro/consumption/transactions/lost_assignment_without_offset_storage_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/lost_assignment_without_offset_storage_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# We should be able to use producer-only transactions even after we have lost the assignment
+
+setup_karafka(allow_errors: true) do |config|
+  config.kafka[:'transactional.id'] = SecureRandom.uuid
+  config.max_messages = 2
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    return if DT.key?(:done)
+
+    DT[:done] = true
+
+    sleep(0.1) until revoked?
+
+    begin
+      transaction do
+        produce_async(topic: topic.name, payload: '1')
+      end
+    rescue StandardError
+      exit 1
+    end
+  end
+end
+
+draw_routes(Consumer)
+
+produce_many(DT.topic, DT.uuids(1))
+
+start_karafka_and_wait_until do
+  DT.key?(:done)
+end

--- a/spec/integrations/pro/consumption/transactions/vps/lost_assignment_with_offset_storage_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/lost_assignment_with_offset_storage_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# We should NOT be able to mark as consumed within a transaction on a lost partition because the
+# transaction is expected to fail.
+
+setup_karafka(allow_errors: true) do |config|
+  config.kafka[:'transactional.id'] = SecureRandom.uuid
+  config.max_messages = 100
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    return if DT.key?(:done)
+
+    DT[:instances] << object_id
+
+    sleep(0.1) until revoked?
+
+    DT[:done] = true
+
+    begin
+      transaction do
+        produce_async(topic: topic.name, payload: '1')
+        mark_as_consumed(messages.last)
+      end
+    rescue Karafka::Errors::AssignmentLostError => e
+      DT[:errors] << e
+    end
+  end
+end
+
+DT[:iterator] = (0..9).cycle
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    filter VpStabilizer
+    virtual_partitions(
+      partitioner: ->(_msg) { DT[:iterator].next }
+    )
+    manual_offset_management true
+  end
+end
+
+produce_many(DT.topic, DT.uuids(100))
+
+start_karafka_and_wait_until do
+  DT.key?(:done)
+end
+
+assert_equal DT[:errors].size, DT[:instances].size
+assert !DT[:errors].empty?

--- a/spec/integrations/pro/consumption/transactions/vps/lost_assignment_without_offset_storage_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/lost_assignment_without_offset_storage_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# We should be able to use producer-only transactions even after we have lost the assignment
+
+setup_karafka(allow_errors: true) do |config|
+  config.kafka[:'transactional.id'] = SecureRandom.uuid
+  config.max_messages = 100
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    return if DT.key?(:done)
+
+    sleep(0.1) until revoked?
+
+    DT[:done] << partition
+
+    begin
+      transaction do
+        produce_async(topic: topic.name, payload: '1')
+      end
+    rescue StandardError
+      exit 1
+    end
+  end
+end
+
+DT[:iterator] = (0..9).cycle
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    filter VpStabilizer
+    virtual_partitions(
+      partitioner: ->(_msg) { DT[:iterator].next }
+    )
+    manual_offset_management true
+  end
+end
+
+produce_many(DT.topic, DT.uuids(100))
+
+start_karafka_and_wait_until do
+  DT.key?(:done)
+end


### PR DESCRIPTION
This PR makes sure we raise an exception if we want to store offset inside a transaction that will not finish successfully anyhow.
