### PR TITLE
verify constraints of web

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gemspec
 # They are added here because they are part of the integration suite
 group :integrations do
   gem 'activejob'
-  gem 'karafka-web'
+  gem 'karafka-web', '>= 0.8.0.rc1'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,10 +45,10 @@ GEM
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
-    karafka-web (0.7.10)
+    karafka-web (0.8.0.rc1)
       erubi (~> 1.4)
-      karafka (>= 2.2.9, < 3.0.0)
-      karafka-core (>= 2.2.4, < 3.0.0)
+      karafka (>= 2.3.0.rc1, < 2.4.0)
+      karafka-core (>= 2.3.0.rc1, < 2.4.0)
       roda (~> 3.68, >= 3.69)
       tilt (~> 2.0)
     mini_portile2 (2.8.5)
@@ -95,7 +95,7 @@ DEPENDENCIES
   byebug
   factory_bot
   karafka!
-  karafka-web
+  karafka-web (>= 0.8.0.rc1)
   rspec
   simplecov
 

--- a/lib/karafka.rb
+++ b/lib/karafka.rb
@@ -143,3 +143,5 @@ end
 
 # Load railtie after everything else is ready so we know we can rely on it.
 require 'karafka/railtie'
+
+Karafka::Constraints.verify!

--- a/lib/karafka/constraints.rb
+++ b/lib/karafka/constraints.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Karafka
+  # Module used to check some constraints that cannot be easily defined by Bundler
+  # At the moment we use it to ensure, that if Karafka is used, it operates with the expected
+  # web ui version and that older versions of Web UI that would not be compatible with the API
+  # changes in karafka are not used.
+  #
+  # We can make Web UI require certain karafka version range, but at the moment we do not have a
+  # strict 1:1 release pattern matching those two.
+  module Constraints
+    class << self
+      # Verifies that optional requirements are met.
+      def verify!
+        # Skip verification if web is not used at all
+        return unless require_version('karafka/web')
+
+        # All good if version higher than 0.7.x because we expect 0.8.0 or higher
+        return if version(Karafka::Web::VERSION) >= version('0.7.100')
+
+        # If older web-ui used, we cannot allow it
+        raise(
+          Errors::DependencyConstraintsError,
+          'karafka-web < 0.8.0 is not compatible with this karafka version'
+        )
+      end
+
+      private
+
+      # Requires given version file from a gem location
+      # @param version_location [String]
+      # @return [Boolean] true if it was required or false if not reachable
+      def require_version(version_location)
+        require "#{version_location}/version"
+
+        true
+      rescue LoadError
+        false
+      end
+
+      # Builds a version object for comparing
+      # @param string [String]
+      # @return [::Gem::Version]
+      def version(string)
+        ::Gem::Version.new(string)
+      end
+    end
+  end
+end

--- a/lib/karafka/errors.rb
+++ b/lib/karafka/errors.rb
@@ -80,5 +80,12 @@ module Karafka
     # Raised in transactions when we attempt to store offset for a partition that we have lost
     # This does not affect producer only transactions, hence we raise it only on offset storage
     AssignmentLostError = Class.new(BaseError)
+
+    # Raised if optional dependencies like karafka-web are required in a version that is not
+    # supported by the current framework version.
+    #
+    # Because we do not want to require web out of the box and we do not want to lock web with
+    # karafka 1:1, we do such a sanity check
+    DependencyConstraintsError = Class.new(BaseError)
   end
 end

--- a/spec/integrations/web/incompatible_version_pristine/Gemfile
+++ b/spec/integrations/web/incompatible_version_pristine/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'activesupport', '7.1.3'
+gem 'karafka', path: ENV.fetch('KARAFKA_GEM_DIR'), require: true
+gem 'karafka-web', '0.7.10'
+gem 'railties', '7.1.3'

--- a/spec/integrations/web/incompatible_version_pristine/console_with_rails_spec.rb
+++ b/spec/integrations/web/incompatible_version_pristine/console_with_rails_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Karafka 2.3+ should not work with Web UI version 0.7.x
+
+require 'open3'
+
+InvalidExitCode = Class.new(StandardError)
+
+def system!(cmd, raise_error: true)
+  stdout, stderr, status = Open3.capture3(cmd)
+
+  return if status.success?
+
+  msg = "#{stdout}\n#{stderr}"
+
+  raise_error ? raise(InvalidExitCode, msg) : msg
+end
+
+system! <<~CMD
+  bundle exec rails new \
+    --skip-javascript \
+    --skip-bootsnap \
+    --skip-git \
+    --skip-active-storage \
+    --skip-active-job \
+    --skip-action-cable \
+    --api \
+    --skip-action-mailer \
+    --skip-active-record \
+    app
+CMD
+
+system!('cp Gemfile ./app/')
+system!('cd app && bundle install')
+msg = system!('cd app && bundle exec karafka install', raise_error: false)
+
+exit if msg.include?('karafka-web < 0.8.0 is not compatible with this karafka version')
+
+raise InvalidExitCode

--- a/spec/lib/karafka/constraints_spec.rb
+++ b/spec/lib/karafka/constraints_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  describe '#verify!' do
+    context 'when karafka/web is not used' do
+      before { allow(described_class).to receive(:require_version).and_return(false) }
+
+      it 'does not raise an error' do
+        expect { described_class.verify! }.not_to raise_error
+      end
+    end
+
+    context 'when karafka/web is used' do
+      before { allow(described_class).to receive(:require_version).and_return(true) }
+
+      context 'with version lower than 0.8.0' do
+        let(:expected_error) { Karafka::Errors::DependencyConstraintsError }
+
+        before { stub_const('Karafka::Web::VERSION', '0.7.99') }
+
+        it 'raises a DependencyConstraintsError' do
+          expect { described_class.verify! }.to raise_error(expected_error)
+        end
+      end
+
+      context 'with version 0.8.0 or higher' do
+        versions = %w[0.8.0 0.9.0 1.0.0]
+
+        versions.each do |version|
+          before { stub_const('Karafka::Web::VERSION', version) }
+
+          it "does not raise an error for version #{version}" do
+            expect { described_class.verify! }.not_to raise_error
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
since bundler does not support optional dependencies, we need to check web UI (if used) to make sure older than 0.7 is not used as long as we do not do direct 1:1 locks like rails.
