### PR TITLE
ensure parallel executions of async are ok

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka framework changelog
 
+## 2.3.1 (Unreleased)
+- [Refactor] Ensure that `Karafka::Helpers::Async#async_call` can run from multiple threads.
+
 ## 2.3.0 (2024-01-26)
 - **[Feature]** Introduce Exactly-Once Semantics within consumers `#transaction` block (Pro)
 - **[Feature]** Provide ability to multiplex subscription groups (Pro)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka (2.3.0)
+    karafka (2.3.1)
       karafka-core (>= 2.3.0, < 2.4.0)
       waterdrop (>= 2.6.12, < 3.0.0)
       zeitwerk (~> 2.3)

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '2.3.0'
+  VERSION = '2.3.1'
 end


### PR DESCRIPTION
this PR ensures, that in case we run `#async_call` few times in parallel, it is safe.

This is not a bug or anything ATM but we need to alter this behaviour for forks.
