### PR TITLE
Move running status management to runner

### DIFF
--- a/lib/karafka/runner.rb
+++ b/lib/karafka/runner.rb
@@ -18,6 +18,10 @@ module Karafka
       workers = Processing::WorkersBatch.new(jobs_queue)
       listeners = Connection::ListenersBatch.new(jobs_queue)
 
+      # We mark it prior to delegating to the manager as manager will have to start at least one
+      # connection to Kafka, hence running
+      Karafka::App.run!
+
       # Register all the listeners so they can be started and managed
       @manager.register(listeners)
 

--- a/lib/karafka/server.rb
+++ b/lib/karafka/server.rb
@@ -61,10 +61,9 @@ module Karafka
       end
 
       # Starts Karafka with a supervision
-      # @note We don't need to sleep because Karafka::Fetcher is locking and waiting to
-      # finish loop (and it won't happen until we explicitly want to stop)
+      # @note We don't need to sleep because Karafka::Runner is locking and waiting to finish loop
+      # (and it won't happen until we explicitly want to stop)
       def start
-        Karafka::App.run!
         Karafka::Runner.new.call
       end
 

--- a/spec/lib/karafka/server_spec.rb
+++ b/spec/lib/karafka/server_spec.rb
@@ -105,14 +105,12 @@ RSpec.describe_current do
 
   describe '#start' do
     before do
-      allow(Karafka::App).to receive(:run!)
       allow(runner).to receive(:call)
 
       server_class.start
     end
 
     it 'expect to run' do
-      expect(Karafka::App).to have_received(:run!)
       expect(runner).to have_received(:call)
     end
   end


### PR DESCRIPTION
This PR moves run! status trigger to runner to be able to start it in forks once we have them, so the status is not switched until forking kicks in.
