### PR TITLE
Add `use_distributions` setting to Datadog::MetricsListener

### DIFF
--- a/lib/karafka/instrumentation/vendors/datadog/metrics_listener.rb
+++ b/lib/karafka/instrumentation/vendors/datadog/metrics_listener.rb
@@ -14,7 +14,8 @@ module Karafka
           include ::Karafka::Core::Configurable
           extend Forwardable
 
-          def_delegators :config, :client, :rd_kafka_metrics, :namespace, :default_tags, :use_distributions
+          def_delegators :config, :client, :rd_kafka_metrics, :namespace,
+                         :default_tags, :use_distributions
 
           # Value object for storing a single rdkafka metric publishing details
           RdKafkaMetric = Struct.new(:type, :scope, :name, :key_location)
@@ -113,8 +114,18 @@ module Karafka
             extra_tags = ["consumer_group:#{consumer_group_id}"]
 
             bucket_metric_type = use_distributions ? 'distribution' : 'histogram'
-            public_send(bucket_metric_type, 'listener.polling.time_taken', time_taken, tags: default_tags + extra_tags)
-            public_send(bucket_metric_type, 'listener.polling.messages', messages_count, tags: default_tags + extra_tags)
+            public_send(
+              bucket_metric_type,
+              'listener.polling.time_taken',
+              time_taken,
+              tags: default_tags + extra_tags
+            )
+            public_send(
+              bucket_metric_type,
+              'listener.polling.messages',
+              messages_count,
+              tags: default_tags + extra_tags
+            )
           end
 
           # Here we report majority of things related to processing as we have access to the
@@ -131,10 +142,30 @@ module Karafka
             count('consumer.batches', 1, tags: tags)
             gauge('consumer.offset', metadata.last_offset, tags: tags)
             bucket_metric_type = use_distributions ? 'distribution' : 'histogram'
-            public_send(bucket_metric_type, 'consumer.consumed.time_taken', event[:time], tags: tags)
-            public_send(bucket_metric_type, 'consumer.batch_size', messages.count, tags: tags)
-            public_send(bucket_metric_type, 'consumer.processing_lag', metadata.processing_lag, tags: tags)
-            public_send(bucket_metric_type, 'consumer.consumption_lag', metadata.consumption_lag, tags: tags)
+            public_send(
+              bucket_metric_type,
+              'consumer.consumed.time_taken',
+              event[:time],
+              tags: tags
+            )
+            public_send(
+              bucket_metric_type,
+              'consumer.batch_size',
+              messages.count,
+              tags: tags
+            )
+            public_send(
+              bucket_metric_type,
+              'consumer.processing_lag',
+              metadata.processing_lag,
+              tags: tags
+            )
+            public_send(
+              bucket_metric_type,
+              'consumer.consumption_lag',
+              metadata.consumption_lag,
+              tags: tags
+            )
           end
 
           {
@@ -161,8 +192,18 @@ module Karafka
 
             gauge('worker.total_threads', Karafka::App.config.concurrency, tags: default_tags)
             bucket_metric_type = use_distributions ? 'distribution' : 'histogram'
-            public_send(bucket_metric_type, 'worker.processing', jq_stats[:busy], tags: default_tags)
-            public_send(bucket_metric_type, 'worker.enqueued_jobs', jq_stats[:enqueued], tags: default_tags)
+            public_send(
+              bucket_metric_type,
+              'worker.processing',
+              jq_stats[:busy],
+              tags: default_tags
+            )
+            public_send(
+              bucket_metric_type,
+              'worker.enqueued_jobs',
+              jq_stats[:enqueued],
+              tags: default_tags
+            )
           end
 
           # We report this metric before and after processing for higher accuracy
@@ -172,7 +213,12 @@ module Karafka
             jq_stats = event[:jobs_queue].statistics
 
             bucket_metric_type = use_distributions ? 'distribution' : 'histogram'
-            public_send(bucket_metric_type, 'worker.processing', jq_stats[:busy], tags: default_tags)
+            public_send(
+              bucket_metric_type,
+              'worker.processing',
+              jq_stats[:busy],
+              tags: default_tags
+            )
           end
 
           private

--- a/spec/integrations/instrumentation/vendors/datadog/metrics_flow_with_distributions_spec.rb
+++ b/spec/integrations/instrumentation/vendors/datadog/metrics_flow_with_distributions_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Here we subscribe to our listener and make sure nothing breaks during the notifications
+# We use a dummy client that will intercept calls that should go to DataDog and check basic
+# metrics presence.
+# Listener is instantiated with `use_distributions` set to `true`, replacing all histogram
+# metrics with distribution metrics.
+require 'karafka/instrumentation/vendors/datadog/metrics_listener'
+require Karafka.gem_root.join('spec/support/vendors/datadog/statsd_dummy_client')
+
+# We allow errors to raise one to make sure things are published as expected
+setup_karafka(allow_errors: true)
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    unless @raised
+      @raised = true
+      raise StandardError
+    end
+
+    messages.each do |message|
+      DT[message.metadata.partition] << message.raw_payload
+    end
+  end
+end
+
+statsd_dummy = Vendors::Datadog::StatsdDummyClient.new
+
+listener = ::Karafka::Instrumentation::Vendors::Datadog::MetricsListener.new do |config|
+  config.client = statsd_dummy
+  # Publish host as a tag alongside the rest of tags
+  config.default_tags = ["host:#{Socket.gethostname}"]
+  # Use distributions instead of histograms
+  config.use_distributions = true
+end
+
+Karafka.monitor.subscribe(listener)
+
+draw_routes(Consumer)
+
+produce_many(DT.topic, DT.uuids(100))
+
+start_karafka_and_wait_until do
+  # This sleeps make karafka run a bit longer for more metrics to kick in
+  DT[0].size >= 100 && sleep(5)
+end
+
+%w[
+  karafka.worker.processing
+  karafka.worker.enqueued_jobs
+  karafka.consumer.consumed.time_taken
+  karafka.consumer.batch_size
+  karafka.consumer.processing_lag
+  karafka.consumer.consumption_lag
+].each do |hist_key|
+  assert_equal true, statsd_dummy.buffer[:distribution].key?(hist_key), "#{hist_key} missing"
+end

--- a/spec/integrations/instrumentation/vendors/datadog/metrics_flow_with_distributions_spec.rb
+++ b/spec/integrations/instrumentation/vendors/datadog/metrics_flow_with_distributions_spec.rb
@@ -31,7 +31,7 @@ listener = ::Karafka::Instrumentation::Vendors::Datadog::MetricsListener.new do 
   # Publish host as a tag alongside the rest of tags
   config.default_tags = ["host:#{Socket.gethostname}"]
   # Use distributions instead of histograms
-  config.use_distributions = true
+  config.distribution_mode = :distribution
 end
 
 Karafka.monitor.subscribe(listener)

--- a/spec/support/vendors/datadog/statsd_dummy_client.rb
+++ b/spec/support/vendors/datadog/statsd_dummy_client.rb
@@ -24,6 +24,7 @@ module Vendors
         gauge
         increment
         decrement
+        distribution
       ].each do |method_name|
         define_method method_name do |metric, value = nil, details = {}|
           @buffer[method_name][metric] << [value, details]


### PR DESCRIPTION
Currently, histogram metrics are emitted as histograms in the Datadog listener.
This PR introduces an option to emit these metrics as distributions instead. This makes the calculated percentiles more accurate in case there are multiple consumers running on different hosts (or rather when multiple DD agents are being used).
More info can be found in the [DD documentation](https://docs.datadoghq.com/metrics/types/?tab=distribution#metric-types).