### PR TITLE
Direct assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka framework changelog
 
 ## 2.3.4 (Unreleased)
+- **[Feature]** Introduce ability to use direct assignments (Pro).
 - [Enhancement] Add a buffer to the supervisor supervision on shutdown to prevent a potential race condition when signal pass lags.
 - [Enhancement] Provide ability to automatically generate and validate fingerprints of encrypted payload.
 - [Fix] Fix a case where critically crashed supervisor would raise incorrect error.

--- a/config/locales/pro_errors.yml
+++ b/config/locales/pro_errors.yml
@@ -71,6 +71,7 @@ en:
       patterns_format: must be an array with hashes
       patterns_missing: needs to be present
       patterns_regexps_not_unique: 'must be unique within consumer group'
+      direct_assignments_homogenous: 'single consumer group cannot mix regular and direct assignments'
 
     pattern:
       regexp_format: must be a regular expression

--- a/config/locales/pro_errors.yml
+++ b/config/locales/pro_errors.yml
@@ -62,6 +62,11 @@ en:
       swarm.nodes_format: needs to be a range or an array of nodes ids
       swarm_nodes_with_non_existent_nodes: includes unreachable nodes ids
 
+      direct_assignments.active_missing: needs to be present
+      direct_assignments.active_format: 'needs to be boolean'
+      direct_assignments.partitions_missing: 'needs to be present'
+      direct_assignments.partitions_format: 'needs to be true or list of partitions'
+
     consumer_group:
       patterns_format: must be an array with hashes
       patterns_missing: needs to be present

--- a/config/locales/pro_errors.yml
+++ b/config/locales/pro_errors.yml
@@ -66,6 +66,7 @@ en:
       direct_assignments.active_format: 'needs to be boolean'
       direct_assignments.partitions_missing: 'needs to be present'
       direct_assignments.partitions_format: 'needs to be true or list of partitions'
+      direct_assignments_active_but_empty: 'cannot be empty and active at the same time'
 
     consumer_group:
       patterns_format: must be an array with hashes

--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -449,7 +449,6 @@ module Karafka
         ::Karafka::Core::Instrumentation.statistics_callbacks.delete(@subscription_group.id)
         ::Karafka::Core::Instrumentation.error_callbacks.delete(@subscription_group.id)
 
-        commit_offsets!
         kafka.close
         @kafka = nil
         @buffer.clear

--- a/lib/karafka/pro/iterator/expander.rb
+++ b/lib/karafka/pro/iterator/expander.rb
@@ -29,7 +29,8 @@ module Karafka
       # - { 'topic1' => 100 } - means we run all partitions from the offset 100
       # - { 'topic1' => Time.now - 60 } - we run all partitions from the message from 60s ago
       # - { 'topic1' => { 1 => Time.now - 60 } } - partition1 from message 60s ago
-      #
+      # - { 'topic1' => { 1 => true } } - will pick first offset not consumed on this CG for p 1
+      # - { 'topic1' => true } - will pick first offset not consumed on this CG for all p
       class Expander
         # Expands topics to which we want to subscribe with partitions information in case this
         # info is not provided.

--- a/lib/karafka/pro/routing/features/direct_assignments.rb
+++ b/lib/karafka/pro/routing/features/direct_assignments.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Routing
+      module Features
+        # Allows for building direct assignments that bypass consumer group auto-assignments
+        # Useful for building complex pipelines that have explicit assignment requirements
+        class DirectAssignments < Base
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/routing/features/direct_assignments/config.rb
+++ b/lib/karafka/pro/routing/features/direct_assignments/config.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Routing
+      module Features
+        class DirectAssignments < Base
+          # Direct assignments feature configuration
+          Config = Struct.new(:active, :partitions, keyword_init: true) do
+            alias_method :active?, :active
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/routing/features/direct_assignments/contracts/consumer_group.rb
+++ b/lib/karafka/pro/routing/features/direct_assignments/contracts/consumer_group.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Routing
+      module Features
+        class DirectAssignments < Base
+          module Contracts
+            # Contract to validate configuration of the direct assignments feature
+            class ConsumerGroup < Karafka::Contracts::Base
+              configure do |config|
+                config.error_messages = YAML.safe_load(
+                  File.read(
+                    File.join(Karafka.gem_root, 'config', 'locales', 'pro_errors.yml')
+                  )
+                ).fetch('en').fetch('validations').fetch('consumer_group')
+
+                virtual do |data, errors|
+                  next unless errors.empty?
+
+                  active = []
+
+                  data[:topics].each do |topic|
+                    active << topic[:direct_assignments][:active]
+                  end
+
+                  # If none active we use standard subscriptions
+                  next if active.none?
+                  # If all topics from a given CG are using direct assignments that is expected
+                  # and allowed
+                  next if active.all?
+
+                  [[%i[direct_assignments], :homogenous]]
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/routing/features/direct_assignments/contracts/topic.rb
+++ b/lib/karafka/pro/routing/features/direct_assignments/contracts/topic.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Routing
+      module Features
+        class DirectAssignments < Base
+          # Namespace for direct assignments feature contracts
+          module Contracts
+            # Contract to validate configuration of the direct assignments topic feature
+            class Topic < Karafka::Contracts::Base
+              configure do |config|
+                config.error_messages = YAML.safe_load(
+                  File.read(
+                    File.join(Karafka.gem_root, 'config', 'locales', 'pro_errors.yml')
+                  )
+                ).fetch('en').fetch('validations').fetch('topic')
+              end
+
+              nested(:direct_assignments) do
+                required(:active) { |val| [true, false].include?(val) }
+
+                required(:partitions) do |val|
+                  next true if val == true
+                  next false unless val.is_a?(Hash)
+                  next false unless val.keys.all? { |part| part.is_a?(Integer) }
+                  next false unless val.values.all? { |flag| flag == true }
+
+                  true
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/routing/features/direct_assignments/contracts/topic.rb
+++ b/lib/karafka/pro/routing/features/direct_assignments/contracts/topic.rb
@@ -40,6 +40,19 @@ module Karafka
                   true
                 end
               end
+
+              virtual do |data, errors|
+                next unless errors.empty?
+
+                direct_assignments = data[:direct_assignments]
+                partitions = direct_assignments[:partitions]
+
+                next unless direct_assignments[:active]
+                next unless partitions.is_a?(Hash)
+                next unless partitions.empty?
+
+                [[%i[direct_assignments], :active_but_empty]]
+              end
             end
           end
         end

--- a/lib/karafka/pro/routing/features/direct_assignments/subscription_group.rb
+++ b/lib/karafka/pro/routing/features/direct_assignments/subscription_group.rb
@@ -15,9 +15,11 @@ module Karafka
   module Pro
     module Routing
       module Features
-        # Alterations to the direct assigments that allow us to do stable direct assignments
+        # Alterations to the direct assignments that allow us to do stable direct assignments
         # without working with consumer groups dynamic assignments
         class DirectAssignments < Base
+          # Extension allowing us to select correct subscriptions and assignments based on the
+          # expanded routing setup
           module SubscriptionGroup
             # @return [false, Array<String>] false if we do not have any subscriptions or array
             #   with all the subscriptions for given subscription group
@@ -29,6 +31,9 @@ module Karafka
                 .then { |subscriptions| subscriptions.empty? ? false : subscriptions }
             end
 
+            # @param consumer [Karafka::Connection::Proxy] consumer for expanding  the partition
+            #   knowledge in case of certain topics assignments
+            # @return [Rdkafka::Consumer::TopicPartitionList] final tpl for assignments
             def assignments(consumer)
               topics
                 .select(&:active?)

--- a/lib/karafka/pro/routing/features/direct_assignments/subscription_group.rb
+++ b/lib/karafka/pro/routing/features/direct_assignments/subscription_group.rb
@@ -15,6 +15,8 @@ module Karafka
   module Pro
     module Routing
       module Features
+        # Alterations to the direct assigments that allow us to do stable direct assignments
+        # without working with consumer groups dynamic assignments
         class DirectAssignments < Base
           module SubscriptionGroup
             # @return [false, Array<String>] false if we do not have any subscriptions or array

--- a/lib/karafka/pro/routing/features/direct_assignments/subscription_group.rb
+++ b/lib/karafka/pro/routing/features/direct_assignments/subscription_group.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Routing
+      module Features
+        class DirectAssignments < Base
+          module SubscriptionGroup
+            # @return [false, Array<String>] false if we do not have any subscriptions or array
+            #   with all the subscriptions for given subscription group
+            def subscriptions
+              topics
+                .select(&:active?)
+                .reject { |topic| topic.direct_assignments.active? }
+                .map(&:subscription_name)
+                .then { |subscriptions| subscriptions.empty? ? false : subscriptions }
+            end
+
+            def assignments(consumer)
+              topics
+                .select(&:active?)
+                .select { |topic| topic.direct_assignments.active? }
+                .map { |topic| [topic.subscription_name, topic.direct_assignments.partitions] }
+                .to_h
+                .tap { |topics| return false if topics.empty? }
+                .then { |topics| Iterator::Expander.new.call(topics) }
+                .then { |topics| Iterator::TplBuilder.new(consumer, topics).call }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/routing/features/direct_assignments/topic.rb
+++ b/lib/karafka/pro/routing/features/direct_assignments/topic.rb
@@ -23,18 +23,16 @@ module Karafka
             #   to use direct assignments instead of automatic for this topic. It also allows us
             #   to specify which partitions we're interested in or `true` if in all
             def direct_assignments(*partitions_or_all)
-              @direct_assignments ||= begin
-                if partitions_or_all == [true]
-                  Config.new(
-                    active: true,
-                    partitions: true
-                  )
-                else
-                  Config.new(
-                    active: !partitions_or_all.empty?,
-                    partitions: partitions_or_all.map { |partition| [partition, true] }.to_h
-                  )
-                end
+              @direct_assignments ||= if partitions_or_all == [true]
+                Config.new(
+                  active: true,
+                  partitions: true
+                )
+              else
+                Config.new(
+                  active: !partitions_or_all.empty?,
+                  partitions: partitions_or_all.map { |partition| [partition, true] }.to_h
+                )
               end
             end
 

--- a/lib/karafka/pro/routing/features/direct_assignments/topic.rb
+++ b/lib/karafka/pro/routing/features/direct_assignments/topic.rb
@@ -16,26 +16,29 @@ module Karafka
     module Routing
       module Features
         class DirectAssignments < Base
+          # Topic extensions for direct assignments
           module Topic
             # Allows for direct assignment of
-            def assign(*partitions_or_all)
-              @direct_assignments ||= if partitions_or_all == [true]
-                Config.new(
-                  active: true,
-                  partitions: true
-                )
-              else
-                Config.new(
-                  active: !partitions_or_all.empty?,
-                  partitions: partitions_or_all.map { |partition| [partition, true] }.to_h
-                )
+            # @param partitions_or_all [true, Array<Integer>, Range] informs Karafka that we want
+            #   to use direct assignments instead of automatic for this topic. It also allows us
+            #   to specify which partitions we're interested in or `true` if in all
+            def direct_assignments(*partitions_or_all)
+              @direct_assignments ||= begin
+                if partitions_or_all == [true]
+                  Config.new(
+                    active: true,
+                    partitions: true
+                  )
+                else
+                  Config.new(
+                    active: !partitions_or_all.empty?,
+                    partitions: partitions_or_all.map { |partition| [partition, true] }.to_h
+                  )
+                end
               end
             end
 
-            # @return [DirectAssignments::Config]
-            def direct_assignments
-              assign
-            end
+            alias assign direct_assignments
 
             # @return [Hash] topic with all its native configuration options plus direct
             #   assignments

--- a/lib/karafka/pro/routing/features/direct_assignments/topic.rb
+++ b/lib/karafka/pro/routing/features/direct_assignments/topic.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Routing
+      module Features
+        class DirectAssignments < Base
+          module Topic
+            # Allows for direct assignment of
+            def assign(*partitions_or_all)
+              @direct_assignments ||= if partitions_or_all == [true]
+                Config.new(
+                  active: true,
+                  partitions: true
+                )
+              else
+                Config.new(
+                  active: !partitions_or_all.empty?,
+                  partitions: partitions_or_all.map { |partition| [partition, true] }.to_h
+                )
+              end
+            end
+
+            # @return [DirectAssignments::Config]
+            def direct_assignments
+              assign
+            end
+
+            # @return [Hash] topic with all its native configuration options plus direct
+            #   assignments
+            def to_h
+              super.merge(
+                direct_assignments: direct_assignments.to_h
+              ).freeze
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/routing/features/direct_assignments/topic.rb
+++ b/lib/karafka/pro/routing/features/direct_assignments/topic.rb
@@ -19,7 +19,7 @@ module Karafka
           # Topic extensions for direct assignments
           module Topic
             # Allows for direct assignment of
-            # @param partitions_or_all [true, Array<Integer>, Range] informs Karafka that we want
+            # @param partitions_or_all [true, Array<Integer>] informs Karafka that we want
             #   to use direct assignments instead of automatic for this topic. It also allows us
             #   to specify which partitions we're interested in or `true` if in all
             def direct_assignments(*partitions_or_all)

--- a/lib/karafka/pro/routing/features/swarm/topic.rb
+++ b/lib/karafka/pro/routing/features/swarm/topic.rb
@@ -19,8 +19,8 @@ module Karafka
           # Topic swarm API extensions
           module Topic
             # Allows defining swarm routing topic settings
-            # @param nodes [Range, Array] range of nodes ids or array with nodes ids for which we
-            #   should run given topic
+            # @param nodes [Range, Array, Hash] range of nodes ids or array with nodes ids for
+            #   which we should run given topic
             def swarm(nodes: (0...Karafka::App.config.swarm.nodes))
               @swarm ||= Config.new(active: true, nodes: nodes)
             end

--- a/lib/karafka/routing/subscription_group.rb
+++ b/lib/karafka/routing/subscription_group.rb
@@ -76,13 +76,20 @@ module Karafka
         activity_manager.active?(:subscription_groups, name)
       end
 
-      # @return [Array<String>] names of topics to which we should subscribe.
+      # @return [false, Array<String>] names of topics to which we should subscribe or false when
+      #   operating only on direct assignments
       #
       # @note Most of the time it should not include inactive topics but in case of pattern
       #   matching the matcher topics become inactive down the road, hence we filter out so
       #   they are later removed.
       def subscriptions
         topics.select(&:active?).map(&:subscription_name)
+      end
+
+      # @return [false, Rdkafka::Consumer::TopicPartitionList] List of tpls for direct assignments
+      #   or false for the normal mode
+      def assignments
+        false
       end
 
       # @return [String] id of the subscription group

--- a/lib/karafka/routing/subscription_group.rb
+++ b/lib/karafka/routing/subscription_group.rb
@@ -86,9 +86,10 @@ module Karafka
         topics.select(&:active?).map(&:subscription_name)
       end
 
+      # @param _consumer [Karafka::Connection::Proxy]
       # @return [false, Rdkafka::Consumer::TopicPartitionList] List of tpls for direct assignments
       #   or false for the normal mode
-      def assignments
+      def assignments(_consumer)
         false
       end
 

--- a/spec/integrations/pro/consumption/direct_assignments/all_partitions_spec.rb
+++ b/spec/integrations/pro/consumption/direct_assignments/all_partitions_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# We should be able to assign to ourselves direct ownership of all partitions
+
+setup_karafka
+
+DT[:partitions] = Set.new
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[:partitions] << partition
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    config(partitions: 5)
+    assign(true)
+  end
+end
+
+5.times do |i|
+  produce_many(DT.topic, DT.uuids(2), partition: i)
+end
+
+start_karafka_and_wait_until do
+  DT[:partitions].size >= 5
+end

--- a/spec/integrations/pro/consumption/direct_assignments/beyond_poll_interval_spec.rb
+++ b/spec/integrations/pro/consumption/direct_assignments/beyond_poll_interval_spec.rb
@@ -12,9 +12,12 @@ DT[:partitions] = Set.new
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    return if DT[:goes].size >= 4
+    seen = DT[:partitions].include?(partition)
 
-    sleep(15)
+    return if DT[:goes].size >= 4 && seen
+
+    sleep(15) unless seen
+
     DT[:goes] << true
     DT[:partitions] << partition
   end
@@ -28,8 +31,10 @@ draw_routes do
   end
 end
 
-elements = DT.uuids(200)
-produce_many(DT.topic, elements)
+2.times do |i|
+  elements = DT.uuids(200)
+  produce_many(DT.topic, elements, partition: i)
+end
 
 start_karafka_and_wait_until do
   DT[:partitions].size >= 2 && DT[:goes].size >= 4

--- a/spec/integrations/pro/consumption/direct_assignments/beyond_poll_interval_spec.rb
+++ b/spec/integrations/pro/consumption/direct_assignments/beyond_poll_interval_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# When using direct assignments, we should be able to ignore max poll interval.
+
+setup_karafka do |config|
+  config.max_messages = 25
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+end
+
+DT[:partitions] = Set.new
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    return if DT[:goes].size >= 4
+
+    sleep(15)
+    DT[:goes] << true
+    DT[:partitions] << partition
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    config(partitions: 2)
+    assign(0, 1)
+  end
+end
+
+elements = DT.uuids(200)
+produce_many(DT.topic, elements)
+
+start_karafka_and_wait_until do
+  DT[:partitions].size >= 2 && DT[:goes].size >= 4
+end

--- a/spec/integrations/pro/consumption/direct_assignments/from_earliest_spec.rb
+++ b/spec/integrations/pro/consumption/direct_assignments/from_earliest_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# We should be able to get the insights and use them via the API when they are defined
-# In Pro despite extra option, should behave same as in OSS when no forced required
+# We should be able to assign to ourselves direct ownership of partitions we are interested in
 
 setup_karafka
 

--- a/spec/integrations/pro/consumption/direct_assignments/from_earliest_spec.rb
+++ b/spec/integrations/pro/consumption/direct_assignments/from_earliest_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# We should be able to get the insights and use them via the API when they are defined
+# In Pro despite extra option, should behave same as in OSS when no forced required
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[:done] = true
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    config(partitions: 2)
+    assign(0, 1)
+  end
+end
+
+elements = DT.uuids(10)
+produce_many(DT.topic, elements)
+
+start_karafka_and_wait_until do
+  DT.key?(:done)
+end

--- a/spec/integrations/pro/consumption/direct_assignments/from_earliest_spec.rb
+++ b/spec/integrations/pro/consumption/direct_assignments/from_earliest_spec.rb
@@ -5,9 +5,11 @@
 
 setup_karafka
 
+DT[:partitions] = Set.new
+
 class Consumer < Karafka::BaseConsumer
   def consume
-    DT[:done] = true
+    DT[:partitions] << partition
   end
 end
 
@@ -19,9 +21,9 @@ draw_routes do
   end
 end
 
-elements = DT.uuids(10)
+elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT.key?(:done)
+  DT[:partitions].size >= 2
 end

--- a/spec/integrations/pro/consumption/direct_assignments/from_earliest_spec.rb
+++ b/spec/integrations/pro/consumption/direct_assignments/from_earliest_spec.rb
@@ -10,6 +10,10 @@ class Consumer < Karafka::BaseConsumer
   def consume
     DT[:partitions] << partition
   end
+
+  def shutdown
+    DT[:shutdowns] << true
+  end
 end
 
 draw_routes do
@@ -26,3 +30,5 @@ produce_many(DT.topic, elements)
 start_karafka_and_wait_until do
   DT[:partitions].size >= 2
 end
+
+assert_equal 2, DT[:shutdowns].count

--- a/spec/integrations/pro/consumption/direct_assignments/from_earliest_spec.rb
+++ b/spec/integrations/pro/consumption/direct_assignments/from_earliest_spec.rb
@@ -24,8 +24,11 @@ draw_routes do
   end
 end
 
-elements = DT.uuids(100)
-produce_many(DT.topic, elements)
+
+2.times do |i|
+  elements = DT.uuids(10)
+  produce_many(DT.topic, elements, partition: i)
+end
 
 start_karafka_and_wait_until do
   DT[:partitions].size >= 2

--- a/spec/integrations/pro/consumption/direct_assignments/from_earliest_spec.rb
+++ b/spec/integrations/pro/consumption/direct_assignments/from_earliest_spec.rb
@@ -24,7 +24,6 @@ draw_routes do
   end
 end
 
-
 2.times do |i|
   elements = DT.uuids(10)
   produce_many(DT.topic, elements, partition: i)

--- a/spec/integrations/pro/consumption/direct_assignments/marking_as_consumed_spec.rb
+++ b/spec/integrations/pro/consumption/direct_assignments/marking_as_consumed_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# We should be able to mark as consumed
+
+setup_karafka do |config|
+  config.max_messages = 10
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each { |message| mark_as_consumed(message) }
+
+    DT[:done] = true
+
+    sleep(2)
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    assign(true)
+  end
+end
+
+elements = DT.uuids(100)
+produce_many(DT.topic, elements)
+
+start_karafka_and_wait_until do
+  DT.key?(:done)
+end
+
+assert fetch_first_offset >= 10

--- a/spec/integrations/pro/consumption/direct_assignments/multi_topic_in_one_cg_spec.rb
+++ b/spec/integrations/pro/consumption/direct_assignments/multi_topic_in_one_cg_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# We should be able to assign to ourselves multiple topics in one CG
+
+setup_karafka
+
+class Consumer1 < Karafka::BaseConsumer
+  def consume
+    DT[:t1] = true
+  end
+end
+
+class Consumer2 < Karafka::BaseConsumer
+  def consume
+    DT[:t2] = true
+  end
+end
+
+draw_routes do
+  topic DT.topics.first do
+    consumer Consumer1
+    assign(true)
+  end
+
+  topic DT.topics.last do
+    consumer Consumer2
+    assign(true)
+  end
+end
+
+produce_many(DT.topics.first, DT.uuids(1))
+produce_many(DT.topics.last, DT.uuids(1))
+
+start_karafka_and_wait_until do
+  DT.key?(:t1) && DT.key?(:t2)
+end

--- a/spec/integrations/pro/consumption/direct_assignments/transactions_support_spec.rb
+++ b/spec/integrations/pro/consumption/direct_assignments/transactions_support_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# We should be able to assign what we want and mark offsets in a transation
+
+setup_karafka do |config|
+  config.kafka[:'transactional.id'] = SecureRandom.uuid
+  config.max_messages = 10
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    transaction do
+      messages.each { |message| mark_as_consumed(message) }
+      produce_async(topic: DT.topic, payload: '1')
+    end
+
+    DT[:done] = true
+
+    sleep(2)
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    assign(true)
+  end
+end
+
+elements = DT.uuids(100)
+produce_many(DT.topic, elements)
+
+start_karafka_and_wait_until do
+  DT.key?(:done)
+end
+
+assert fetch_first_offset >= 10

--- a/spec/integrations/pro/consumption/direct_assignments/transactions_support_spec.rb
+++ b/spec/integrations/pro/consumption/direct_assignments/transactions_support_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# We should be able to assign what we want and mark offsets in a transation
+# We should be able to assign what we want and mark offsets in a transaction
 
 setup_karafka do |config|
   config.kafka[:'transactional.id'] = SecureRandom.uuid

--- a/spec/integrations/pro/encryption/consumption/with_key_mismatch_spec.rb
+++ b/spec/integrations/pro/encryption/consumption/with_key_mismatch_spec.rb
@@ -47,4 +47,3 @@ if DT[:errors].empty?
 else
   assert DT[:errors].first.payload[:error].is_a?(OpenSSL::PKey::PKeyError)
 end
-

--- a/spec/integrations/pro/routing/direct_assignments/with_mixed_group_spec.rb
+++ b/spec/integrations/pro/routing/direct_assignments/with_mixed_group_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# We should not be allowed to mix automatic and direct assignments
+
+setup_karafka
+
+failed = false
+
+begin
+  draw_routes(create_topics: false) do
+    topic :a do
+      consumer Class.new
+      assign(0)
+    end
+
+    topic :b do
+      consumer Class.new
+    end
+  end
+rescue Karafka::Errors::InvalidConfigurationError
+  failed = true
+end
+
+assert failed
+
+Karafka::App.routes.clear
+
+failed = false
+
+begin
+  draw_routes(create_topics: false) do
+    consumer_group :a do
+      topic :a do
+        consumer Class.new
+        assign(0)
+      end
+    end
+
+    topic :b do
+      consumer Class.new
+    end
+  end
+rescue Karafka::Errors::InvalidConfigurationError
+  failed = true
+end
+
+# Should be ok when separate CGs
+assert !failed
+
+Karafka::App.routes.clear
+
+failed = false
+
+begin
+  draw_routes(create_topics: false) do
+    subscription_group :a do
+      topic :a do
+        consumer Class.new
+        assign(0)
+      end
+    end
+
+    topic :b do
+      consumer Class.new
+    end
+  end
+rescue Karafka::Errors::InvalidConfigurationError
+  failed = true
+end
+
+# Should not be ok when separate SGs in a CG
+assert failed

--- a/spec/lib/karafka/pro/routing/features/direct_assignments/config_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/direct_assignments/config_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  pending
+end

--- a/spec/lib/karafka/pro/routing/features/direct_assignments/config_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/direct_assignments/config_spec.rb
@@ -1,5 +1,30 @@
 # frozen_string_literal: true
 
 RSpec.describe_current do
-  pending
+  subject(:config) { described_class.new(active: active, partitions: partitions) }
+
+  let(:active) { true }
+  let(:partitions) { [1, 2, 3] }
+
+  describe '#active?' do
+    context 'when active' do
+      it 'returns true' do
+        expect(config.active?).to be true
+      end
+    end
+
+    context 'when not active' do
+      let(:active) { false }
+
+      it 'returns false' do
+        expect(config.active?).to be false
+      end
+    end
+  end
+
+  describe '#to_h' do
+    it 'returns a hash representation with active and partitions keys' do
+      expect(config.to_h).to eq({ active: active, partitions: partitions })
+    end
+  end
 end

--- a/spec/lib/karafka/pro/routing/features/direct_assignments/contracts/consumer_group_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/direct_assignments/contracts/consumer_group_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  pending
+end

--- a/spec/lib/karafka/pro/routing/features/direct_assignments/contracts/consumer_group_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/direct_assignments/contracts/consumer_group_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe_current do
   end
 
   context 'with a single topic' do
-    context 'using direct assignments' do
+    context 'when using direct assignments' do
       let(:config) do
         {
           topics: [
@@ -63,7 +63,7 @@ RSpec.describe_current do
       end
     end
 
-    context 'not using direct assignments' do
+    context 'when not using direct assignments' do
       let(:config) do
         {
           topics: [

--- a/spec/lib/karafka/pro/routing/features/direct_assignments/contracts/consumer_group_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/direct_assignments/contracts/consumer_group_spec.rb
@@ -1,5 +1,80 @@
 # frozen_string_literal: true
 
 RSpec.describe_current do
-  pending
+  subject(:validation_result) { described_class.new.call(config) }
+
+  context 'with all topics using direct assignments' do
+    let(:config) do
+      {
+        topics: [
+          { direct_assignments: { active: true } },
+          { direct_assignments: { active: true } }
+        ]
+      }
+    end
+
+    it 'is expected to be successful' do
+      expect(validation_result).to be_success
+    end
+  end
+
+  context 'with no topics using direct assignments' do
+    let(:config) do
+      {
+        topics: [
+          { direct_assignments: { active: false } },
+          { direct_assignments: { active: false } }
+        ]
+      }
+    end
+
+    it 'is expected to be successful' do
+      expect(validation_result).to be_success
+    end
+  end
+
+  context 'with a mix of topics using and not using direct assignments' do
+    let(:config) do
+      {
+        topics: [
+          { direct_assignments: { active: true } },
+          { direct_assignments: { active: false } }
+        ]
+      }
+    end
+
+    it 'is expected to fail' do
+      expect(validation_result).not_to be_success
+    end
+  end
+
+  context 'with a single topic' do
+    context 'using direct assignments' do
+      let(:config) do
+        {
+          topics: [
+            { direct_assignments: { active: true } }
+          ]
+        }
+      end
+
+      it 'is expected to be successful' do
+        expect(validation_result).to be_success
+      end
+    end
+
+    context 'not using direct assignments' do
+      let(:config) do
+        {
+          topics: [
+            { direct_assignments: { active: false } }
+          ]
+        }
+      end
+
+      it 'is expected to be successful' do
+        expect(validation_result).to be_success
+      end
+    end
+  end
 end

--- a/spec/lib/karafka/pro/routing/features/direct_assignments/contracts/topic_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/direct_assignments/contracts/topic_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  pending
+end

--- a/spec/lib/karafka/pro/routing/features/direct_assignments/contracts/topic_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/direct_assignments/contracts/topic_spec.rb
@@ -1,5 +1,80 @@
 # frozen_string_literal: true
 
 RSpec.describe_current do
-  pending
+  subject(:validation_result) { described_class.new.call(config) }
+
+  context 'with valid configurations' do
+    let(:config) do
+      {
+        direct_assignments: {
+          active: true,
+          partitions: { 1 => true, 2 => true }
+        }
+      }
+    end
+
+    it 'is expected to be successful' do
+      expect(validation_result).to be_success
+    end
+  end
+
+  context 'when active is not a boolean' do
+    let(:config) do
+      {
+        direct_assignments: {
+          active: 'true', # Invalid type
+          partitions: { 1 => true }
+        }
+      }
+    end
+
+    it 'is expected to fail' do
+      expect(validation_result).not_to be_success
+    end
+  end
+
+  context 'when partitions are not exclusively integers mapping to true' do
+    let(:config) do
+      {
+        direct_assignments: {
+          active: true,
+          partitions: { '1' => true, 2 => false } # Invalid key type and value
+        }
+      }
+    end
+
+    it 'is expected to fail' do
+      expect(validation_result).not_to be_success
+    end
+  end
+
+  context 'when partitions are set to true' do
+    let(:config) do
+      {
+        direct_assignments: {
+          active: true,
+          partitions: true
+        }
+      }
+    end
+
+    it 'is expected to be successful' do
+      expect(validation_result).to be_success
+    end
+  end
+
+  context 'when partitions is an empty hash' do
+    let(:config) do
+      {
+        direct_assignments: {
+          active: true,
+          partitions: {} # Empty hash is not valid
+        }
+      }
+    end
+
+    it 'is expected to fail' do
+      expect(validation_result).not_to be_success
+    end
+  end
 end

--- a/spec/lib/karafka/pro/routing/features/direct_assignments/subscription_group_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/direct_assignments/subscription_group_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  pending
+end

--- a/spec/lib/karafka/pro/routing/features/direct_assignments/subscription_group_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/direct_assignments/subscription_group_spec.rb
@@ -1,5 +1,73 @@
 # frozen_string_literal: true
 
 RSpec.describe_current do
-  pending
+  subject(:subscription_group) { class_spy('SubscriptionGroup').extend(described_class) }
+
+  let(:active_topic) do
+    instance_spy(
+      'Karafka::Routing::Topic',
+      active?: true,
+      direct_assignments: instance_spy('DirectAssignments', active?: false),
+      subscription_name: 'active_topic'
+    )
+  end
+
+  let(:inactive_topic) { instance_spy('Karafka::Routing::Topic', active?: false) }
+
+  let(:direct_assignment_active_topic) do
+    instance_spy(
+      'Karafka::Routing::Topic',
+      active?: true,
+      direct_assignments: instance_spy('DirectAssignments', active?: true, partitions: [1, 2, 3]),
+      subscription_name: 'direct_topic'
+    )
+  end
+
+  let(:topics) { [active_topic, inactive_topic, direct_assignment_active_topic] }
+
+  before { allow(subscription_group).to receive(:topics).and_return(topics) }
+
+  describe '#subscriptions' do
+    context 'when there are active topics without direct assignments' do
+      it 'returns an array of subscription names' do
+        expect(subscription_group.subscriptions).to eq(['active_topic'])
+      end
+    end
+
+    context 'when all active topics have direct assignments' do
+      let(:topics) { [direct_assignment_active_topic] }
+
+      it 'returns false indicating no subscriptions' do
+        expect(subscription_group.subscriptions).to be false
+      end
+    end
+  end
+
+  describe '#assignments' do
+    let(:consumer) { instance_spy('Karafka::Connection::Proxy') }
+    let(:iterator_expander) { instance_spy('Karafka::Pro::Iterator::Expander') }
+    let(:tpl_builder) { instance_spy('Karafka::Pro::Iterator::TplBuilder') }
+    let(:topic_partition_list) { instance_spy('Rdkafka::Consumer::TopicPartitionList') }
+
+    before do
+      allow(Karafka::Pro::Iterator::Expander).to receive(:new).and_return(iterator_expander)
+      allow(iterator_expander).to receive(:call).with(any_args).and_return(topics)
+      allow(Karafka::Pro::Iterator::TplBuilder).to receive(:new).and_return(tpl_builder)
+      allow(tpl_builder).to receive(:call).and_return(topic_partition_list)
+    end
+
+    context 'when there are active topics with direct assignments' do
+      it 'returns a topic partition list for assignments' do
+        expect(subscription_group.assignments(consumer)).to eq(topic_partition_list)
+      end
+    end
+
+    context 'when there are no active topics with direct assignments' do
+      let(:topics) { [active_topic, inactive_topic] } # No topics with active direct assignments
+
+      it 'returns false indicating no assignments' do
+        expect(subscription_group.assignments(consumer)).to be false
+      end
+    end
+  end
 end

--- a/spec/lib/karafka/pro/routing/features/direct_assignments/topic_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/direct_assignments/topic_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  pending
+end

--- a/spec/lib/karafka/pro/routing/features/direct_assignments/topic_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/direct_assignments/topic_spec.rb
@@ -1,5 +1,45 @@
 # frozen_string_literal: true
 
 RSpec.describe_current do
-  pending
+  subject(:topic) { build(:routing_topic) }
+
+  describe '#direct_assignments' do
+    context 'when initialized without arguments' do
+      it 'expect to initialize with defaults' do
+        expect(topic.direct_assignments.active).to eq(false)
+      end
+    end
+
+    context 'when initialized with specific partitions' do
+      let(:partitions) { [1, 2, 3] }
+
+      it 'expect to mark as active and use given partitions' do
+        topic.direct_assignments(*partitions)
+        expect(topic.direct_assignments.active).to eq(true)
+        expect(topic.direct_assignments.partitions).to eq(partitions.map { |p| [p, true] }.to_h)
+      end
+    end
+
+    context 'when initialized with true' do
+      it 'expect to use all partitions' do
+        topic.direct_assignments(true)
+        expect(topic.direct_assignments.active).to eq(true)
+        expect(topic.direct_assignments.partitions).to eq(true)
+      end
+    end
+  end
+
+  describe '#to_h' do
+    context 'when direct assignments are active' do
+      before { topic.direct_assignments(1, 2, 3) }
+
+      it { expect(topic.to_h[:direct_assignments]).to eq(topic.direct_assignments.to_h) }
+    end
+
+    context 'when direct assignments are not active' do
+      before { topic.direct_assignments }
+
+      it { expect(topic.to_h[:direct_assignments]).to eq(topic.direct_assignments.to_h) }
+    end
+  end
 end

--- a/spec/lib/karafka/pro/routing/features/direct_assignments_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/direct_assignments_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  it { expect(described_class).to be < ::Karafka::Routing::Features::Base }
+end


### PR DESCRIPTION
This PR provides ability do assign direct ownership over topics and partitions bypassing the automatic group management from kafka. This can be used for stream merging, window processing, and other advanced features.