### PR TITLE
introduce marking as consumed in the iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - [Enhancement] Add a buffer to the supervisor supervision on shutdown to prevent a potential race condition when signal pass lags.
 - [Enhancement] Provide ability to automatically generate and validate fingerprints of encrypted payload.
 - [Enhancement] Support `enable.partition.eof` fast yielding.
+- [Enhancement] Provide `#mark_as_consumed` and `#mark_as_consumed!` to the iterator.
+- [Enhancement] Introduce graceful `#stop` to the iterator instead of recommending of usage of `break`.
+- [Change] Do not create new proxy object to Rdkafka with certain low-level operations and re-use existing.
 - [Fix] Fix a case where critically crashed supervisor would raise incorrect error.
 - [Fix] Re-raise critical supervisor errors before shutdown.
 - [Fix] Fix a case when right-open (infinite) swarm matching would not pass validations.

--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -366,7 +366,7 @@ module Karafka
       #   even when no stored, because with sync commit, it refreshes the ownership state of the
       #   consumer in a sync way.
       def internal_commit_offsets(async: true)
-        @wrapped_kafka.commit(nil, async)
+        @wrapped_kafka.commit_offsets(async: async)
       end
 
       # Non-mutexed seek that should be used only internally. Outside we expose `#seek` that is

--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -344,7 +344,7 @@ module Karafka
       # @note It is recommended to use this only on rebalances to get positions with metadata
       #   when working with metadata as this is synchronous
       def committed(tpl = nil)
-        Proxy.new(kafka).committed(tpl)
+        @wrapped_kafka.committed(tpl)
       end
 
       private
@@ -356,13 +356,7 @@ module Karafka
       # @param metadata [String, nil] offset storage metadata or nil if none
       # @return [Boolean] true if we could store the offset (if we still own the partition)
       def internal_store_offset(message, metadata)
-        kafka.store_offset(message, metadata)
-        true
-      rescue Rdkafka::RdkafkaError => e
-        return false if e.code == :assignment_lost
-        return false if e.code == :state
-
-        raise e
+        @wrapped_kafka.store_offset(message, metadata)
       end
 
       # Non thread-safe message committing method
@@ -372,23 +366,7 @@ module Karafka
       #   even when no stored, because with sync commit, it refreshes the ownership state of the
       #   consumer in a sync way.
       def internal_commit_offsets(async: true)
-        kafka.commit(nil, async)
-
-        true
-      rescue Rdkafka::RdkafkaError => e
-        case e.code
-        when :assignment_lost
-          return false
-        when :unknown_member_id
-          return false
-        when :no_offset
-          return true
-        when :coordinator_load_in_progress
-          sleep(1)
-          retry
-        end
-
-        raise e
+        @wrapped_kafka.commit(nil, async)
       end
 
       # Non-mutexed seek that should be used only internally. Outside we expose `#seek` that is
@@ -409,12 +387,10 @@ module Karafka
             message.partition => message.offset
           )
 
-          proxy = Proxy.new(kafka)
-
           # Now we can overwrite the seek message offset with our resolved offset and we can
           # then seek to the appropriate message
           # We set the timeout to 2_000 to make sure that remote clusters handle this well
-          real_offsets = proxy.offsets_for_times(tpl)
+          real_offsets = @wrapped_kafka.offsets_for_times(tpl)
           detected_partition = real_offsets.to_h.dig(message.topic, message.partition)
 
           # There always needs to be an offset. In case we seek into the future, where there
@@ -451,6 +427,7 @@ module Karafka
 
         kafka.close
         @kafka = nil
+        @wrapped_kafka = nil
         @buffer.clear
         # @note We do not clear rebalance manager here as we may still have revocation info
         # here that we want to consider valid prior to running another reconnection
@@ -670,7 +647,11 @@ module Karafka
 
       # @return [Rdkafka::Consumer] librdkafka consumer instance
       def kafka
-        @kafka ||= build_consumer
+        return @kafka if @kafka
+
+        @kafka = build_consumer
+        @wrapped_kafka = Proxy.new(@kafka)
+        @kafka
       end
     end
   end

--- a/lib/karafka/pro/iterator.rb
+++ b/lib/karafka/pro/iterator.rb
@@ -151,7 +151,6 @@ module Karafka
       def mark_as_consumed!(message)
         mark_as_consumed(message)
         @current_consumer.commit_offsets(async: false)
-        @stored_offsets = true
       end
 
       private

--- a/lib/karafka/pro/iterator.rb
+++ b/lib/karafka/pro/iterator.rb
@@ -20,7 +20,9 @@ module Karafka
     # the end. It also allows for signaling, when a given message should be last out of certain
     # partition, but we still want to continue iterating in other messages.
     #
-    # It does **not** create a consumer group and does not have any offset management.
+    # It does **not** create a consumer group and does not have any offset management until first
+    # consumer offset marking happens. So can be use for quick seeks as well as iterative,
+    # repetitive data fetching from rake, etc.
     class Iterator
       # A simple API allowing to iterate over topic/partition data, without having to subscribe
       # and deal with rebalances. This API allows for multi-partition streaming and is optimized
@@ -92,6 +94,7 @@ module Karafka
             end
           end
 
+          @current_consumer.commit_offsets(async: false) if @stored_offsets
           @current_message = nil
           @current_consumer = nil
         end
@@ -127,6 +130,30 @@ module Karafka
         )
       end
 
+      # Stops all the iterating
+      # @note `break` can also be used but in such cases commits stored async will not be flushed
+      #   to Kafka. This is why `#stop` is the recommended method.
+      def stop
+        @stopped = true
+      end
+
+      # Marks given message as consumed.
+      #
+      # @param message [Karafka::Messages::Message] message that we want to mark as processed
+      def mark_as_consumed(message)
+        @current_consumer.store_offset(message, nil)
+        @stored_offsets = true
+      end
+
+      # Marks given message as consumed and commits offsets
+      #
+      # @param message [Karafka::Messages::Message] message that we want to mark as processed
+      def mark_as_consumed!(message)
+        mark_as_consumed(message)
+        @current_consumer.commit_offsets(async: false)
+        @stored_offsets = true
+      end
+
       private
 
       # @return [Rdkafka::Consumer::Message, nil] message or nil if nothing to do
@@ -158,7 +185,7 @@ module Karafka
       # Do we have all the data we wanted or did every topic partition has reached eof.
       # @return [Boolean]
       def done?
-        @stopped_partitions >= @total_partitions
+        (@stopped_partitions >= @total_partitions) || @stopped
       end
     end
   end

--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -137,7 +137,9 @@ module Karafka
           # involving a consumer instance
           'enable.auto.commit': false,
           # Make sure that topic metadata lookups do not create topics accidentally
-          'allow.auto.create.topics': false
+          'allow.auto.create.topics': false,
+          # Do not store offsets automatically in admin in any way
+          'enable.auto.offset.store': false
         }
 
         # option [String] default name for the admin consumer group. Please note, that this is a

--- a/spec/integrations/pro/iterator/stop_start_with_marking_spec.rb
+++ b/spec/integrations/pro/iterator/stop_start_with_marking_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# We should be able with proper settings
+
+setup_karafka
+
+draw_routes do
+  topic DT.topic do
+    active false
+  end
+end
+
+produce_many(DT.topic, DT.uuids(50))
+
+topics = { DT.topic => { 0 => true } }
+
+settings = {
+  # Setup a custom group that you want to use for offset storage
+  'group.id': SecureRandom.uuid,
+  # Start from beginning if needed
+  'auto.offset.reset': 'beginning'
+}
+
+iterator = Karafka::Pro::Iterator.new(topics, settings: settings)
+
+count = 0
+iterator.each do |message|
+  count += 1
+
+  DT[message.partition] << message.offset
+  iterator.mark_as_consumed(message)
+
+  iterator.stop if count >= 10
+end
+
+iterator = Karafka::Pro::Iterator.new(topics, settings: settings)
+
+count = 0
+iterator.each do |message|
+  count += 1
+
+  DT[message.partition] << message.offset
+  iterator.mark_as_consumed!(message)
+
+  iterator.stop if count >= 10
+end
+
+iterator = Karafka::Pro::Iterator.new(topics, settings: settings)
+
+count = 0
+iterator.each do |message|
+  count += 1
+
+  DT[message.partition] << message.offset
+  iterator.mark_as_consumed!(message)
+
+  iterator.stop if count >= 10
+end
+
+assert_equal DT[0], (0..29).to_a

--- a/spec/lib/karafka/connection/proxy_spec.rb
+++ b/spec/lib/karafka/connection/proxy_spec.rb
@@ -105,4 +105,156 @@ RSpec.describe_current do
       end
     end
   end
+
+  describe '#store_offset' do
+    let(:message) { instance_double('Karafka::Messages::Message') }
+    let(:metadata) { 'metadata' }
+
+    context 'when storing the offset is successful' do
+      before do
+        allow(wrapped_object).to receive(:store_offset).with(message, metadata).and_return(true)
+      end
+
+      it 'returns true' do
+        expect(proxy.store_offset(message, metadata)).to be true
+      end
+    end
+
+    context 'when an assignment_lost error occurs' do
+      # Simulate assignment lost error code
+      let(:assignment_lost_error) { Rdkafka::RdkafkaError.new(-142) }
+
+      before do
+        allow(wrapped_object)
+          .to receive(:store_offset)
+          .with(message, metadata).and_raise(assignment_lost_error)
+      end
+
+      it 'returns false' do
+        expect(proxy.store_offset(message, metadata)).to be false
+      end
+    end
+
+    context 'when a state error occurs' do
+      # Simulate state error code
+      let(:state_error) { Rdkafka::RdkafkaError.new(-172) }
+
+      before do
+        allow(wrapped_object)
+          .to receive(:store_offset)
+          .with(message, metadata)
+          .and_raise(state_error)
+      end
+
+      it 'returns false' do
+        expect(proxy.store_offset(message, metadata)).to be false
+      end
+    end
+
+    context 'when another RdkafkaError occurs' do
+      # Simulate an unspecified error code
+      let(:other_error) { Rdkafka::RdkafkaError.new(-1) }
+
+      before do
+        allow(wrapped_object)
+          .to receive(:store_offset)
+          .with(message, metadata)
+          .and_raise(other_error)
+      end
+
+      it 'raises the error' do
+        expect { proxy.store_offset(message, metadata) }.to raise_error(Rdkafka::RdkafkaError)
+      end
+    end
+  end
+
+  describe '#commit_offsets' do
+    context 'when committing offsets asynchronously' do
+      before do
+        allow(wrapped_object).to receive(:commit).with(nil, true).and_return(true)
+      end
+
+      it 'returns true' do
+        expect(proxy.commit_offsets).to be true
+      end
+    end
+
+    context 'when committing offsets synchronously' do
+      before do
+        allow(wrapped_object).to receive(:commit).with(nil, false).and_return(true)
+      end
+
+      it 'returns true' do
+        expect(proxy.commit_offsets(async: false)).to be true
+      end
+    end
+
+    context 'when an assignment_lost error occurs' do
+      let(:error) { Rdkafka::RdkafkaError.new(-142) }
+
+      before do
+        allow(wrapped_object).to receive(:commit).and_raise(error)
+      end
+
+      it 'returns false' do
+        expect(proxy.commit_offsets).to be false
+      end
+    end
+
+    context 'when an unknown_member_id error occurs' do
+      let(:error) { Rdkafka::RdkafkaError.new(25) }
+
+      before do
+        allow(wrapped_object).to receive(:commit).and_raise(error)
+      end
+
+      it 'returns false' do
+        expect(proxy.commit_offsets).to be false
+      end
+    end
+
+    context 'when a no_offset error occurs' do
+      let(:error) { Rdkafka::RdkafkaError.new(-168) }
+
+      before do
+        allow(wrapped_object).to receive(:commit).and_raise(error)
+      end
+
+      it 'returns true' do
+        expect(proxy.commit_offsets).to be true
+      end
+    end
+
+    context 'when a coordinator_load_in_progress error occurs' do
+      let(:error) { Rdkafka::RdkafkaError.new(14) }
+
+      before do
+        attempts = 0
+        allow(wrapped_object).to receive(:commit) do
+          attempts += 1
+
+          raise error if attempts == 1
+
+          true # Simulates success on retry
+        end
+      end
+
+      it 'retries once and then succeeds' do
+        expect(proxy.commit_offsets).to be true
+        expect(wrapped_object).to have_received(:commit).twice
+      end
+    end
+
+    context 'when another RdkafkaError occurs' do
+      let(:other_error) { Rdkafka::RdkafkaError.new(13) }
+
+      before do
+        allow(wrapped_object).to receive(:commit).and_raise(other_error)
+      end
+
+      it 'raises the error' do
+        expect { proxy.commit_offsets }.to raise_error(Rdkafka::RdkafkaError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
close https://github.com/karafka/karafka/issues/1809

this PR also moves some of the generic abstraction to rdkafka proxy and caches the proxy wrapper not to create it when not needed.