### PR TITLE
Improve shutdown when using long polling setup (high `max_wait_time`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This release contains a **BREAKING** change. Make sure to read and apply upgrade
 
 - **[Breaking]** Drop the concept of consumer group mapping.
 - **[Feature]** Introduce ability to use direct assignments (Pro).
+- [Enhancement] Improve shutdown when using long polling setup (high `max_wait_time`).
 - [Enhancement] Provide `Karafka::Admin#read_lags` for ability to query lags of a given CG.
 - [Enhancement] Allow direct assignments granular distribution in the Swarm (Pro).
 - [Enhancement] Add a buffer to the supervisor supervision on shutdown to prevent a potential race condition when signal pass lags.

--- a/lib/karafka/connection/listener.rb
+++ b/lib/karafka/connection/listener.rb
@@ -36,7 +36,7 @@ module Karafka
         @subscription_group = subscription_group
         @jobs_queue = jobs_queue
         @coordinators = Processing::CoordinatorsBuffer.new(subscription_group.topics)
-        @client = Client.new(@subscription_group)
+        @client = Client.new(@subscription_group, -> { running? })
         @executors = Processing::ExecutorsBuffer.new(@client, subscription_group)
         @jobs_builder = proc_config.jobs_builder
         @partitioner = proc_config.partitioner_class.new(subscription_group)

--- a/spec/integrations/instrumentation/statistics_publishing_on_long_poll_spec.rb
+++ b/spec/integrations/instrumentation/statistics_publishing_on_long_poll_spec.rb
@@ -34,7 +34,7 @@ Karafka::App.monitor.subscribe('connection.listener.fetch_loop.received') do |ev
 end
 
 start_karafka_and_wait_until do
-  sleep(10)
+  sleep(30)
   true
 end
 

--- a/spec/integrations/shutdown/fast_shutdown_on_long_polling_spec.rb
+++ b/spec/integrations/shutdown/fast_shutdown_on_long_polling_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Karafka should not wait full long polling cycle when shutdown is issued due to fast circuit
+# breaker flow. No assertions are needed as it will just wait forever if not working correctly
+
+setup_karafka do |config|
+  config.max_messages = 1
+  config.shutdown_timeout = 150_000_000
+  config.max_wait_time = 100_000_000
+  config.internal.swarm.node_report_timeout = 200_000_000
+end
+
+2.times { produce(DT.topic, '1') }
+
+Karafka.monitor.subscribe('connection.listener.fetch_loop') do
+  DT[:runs] << true
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[0] << true
+  end
+end
+
+draw_routes(Consumer)
+
+start_karafka_and_wait_until do
+  if DT[0].size >= 2
+    sleep(2)
+    true
+  else
+    false
+  end
+end

--- a/spec/lib/karafka/connection/client_spec.rb
+++ b/spec/lib/karafka/connection/client_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe_current do
-  subject(:client) { described_class.new(subscription_group) }
+  subject(:client) { described_class.new(subscription_group, -> { true }) }
 
   let(:subscription_group) { build(:routing_subscription_group) }
 

--- a/spec/lib/karafka/connection/listener_spec.rb
+++ b/spec/lib/karafka/connection/listener_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe_current do
   let(:subscription_group) { build(:routing_subscription_group, topics: [routing_topic]) }
   let(:jobs_queue) { Karafka::Processing::JobsQueue.new }
   let(:scheduler) { Karafka::Processing::Schedulers::Default.new(jobs_queue) }
-  let(:client) { Karafka::Connection::Client.new(subscription_group) }
+  let(:client) { Karafka::Connection::Client.new(subscription_group, -> { true }) }
   let(:routing_topic) { build(:routing_topic) }
   let(:status) { Karafka::Connection::Status.new }
 


### PR DESCRIPTION
close https://github.com/karafka/karafka-web/issues/285
close https://github.com/karafka/karafka/issues/1957
