### PR TITLE
support time sensitive auto-unlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This release contains a **BREAKING** change. Make sure to read and apply upgrade
 - [Enhancement] Support `enable.partition.eof` fast yielding.
 - [Enhancement] Provide `#mark_as_consumed` and `#mark_as_consumed!` to the iterator.
 - [Enhancement] Introduce graceful `#stop` to the iterator instead of recommending of usage of `break`.
+- [Enhancement] Do not run jobs schedulers and other interval based operations on each job queue unlock.
 - [Change] Do not create new proxy object to Rdkafka with certain low-level operations and re-use existing.
 - [Change] Update `karafka.erb` template with a placeholder for waterdrop and karafka error instrumentation.
 - [Fix] Fix an issue where coordinator running jobs would not count periodic jobs and revocations.

--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -45,7 +45,7 @@ module Karafka
         @rebalance_manager = RebalanceManager.new(@subscription_group.id)
         @rebalance_callback = Instrumentation::Callbacks::Rebalance.new(@subscription_group)
 
-        @events_poller = Helpers::IntervalRunner.new do
+        @interval_runner = Helpers::IntervalRunner.new do
           events_poll
           # events poller returns nil when not running often enough, hence we don't use the
           # boolean to be explicit
@@ -109,7 +109,7 @@ module Karafka
           end
 
           # If we were signaled from the outside to break the loop, we should
-          break if @events_poller.call == :stop
+          break if @interval_runner.call == :stop
 
           # Track time spent on all of the processing and polling
           time_poll.checkpoint
@@ -306,7 +306,7 @@ module Karafka
         ) do
           close
 
-          @events_poller.reset
+          @interval_runner.reset
           @closed = false
           @paused_tpls.clear
         end

--- a/lib/karafka/processing/jobs_queue.rb
+++ b/lib/karafka/processing/jobs_queue.rb
@@ -158,12 +158,14 @@ module Karafka
       #   the work to be finished.
       # @note This method is blocking.
       def wait(group_id)
+        interval_in_seconds = tick_interval / 1_000.0
+
         # Go doing other things while we cannot process and wait for anyone to finish their work
         # and re-check the wait status
         while wait?(group_id)
           yield if block_given?
 
-          @semaphores.fetch(group_id).pop(timeout: tick_interval / 1_000.0)
+          @semaphores.fetch(group_id).pop(timeout: interval_in_seconds)
         end
       end
 

--- a/spec/integrations/pro/consumption/fast_non_blocking_unlock_spec.rb
+++ b/spec/integrations/pro/consumption/fast_non_blocking_unlock_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Because when we set time based locks that can bypass default ticking, we should be able to jump
+# over ticking faster that the ticking interval
+#
+# We do not not instrument wait unlocks on the queue but since listener events are published, we
+# can use next poll start to notice that it unlocks faster than the tick interval but slower than
+# post-job immediate unlock
+
+setup_karafka do |config|
+  config.max_messages = 1
+  config.concurrency = 1
+  # If unlock is not working, this will make things hang
+  config.internal.tick_interval = 1_000_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[:ticks] << Time.now.to_f
+
+    # Triggers the job queue state flow switch to the one that supports immediate timeouts
+    unless @first_pause
+      subscription_groups_coordinator.pause(topic.subscription_group, timeout: 0)
+      @first_pause = true
+
+      return
+    end
+
+    # Unlock fast
+    subscription_groups_coordinator.pause(topic.subscription_group, timeout: 1_000)
+  end
+end
+
+draw_routes do
+  subscription_group :a do
+    topic DT.topics[0] do
+      consumer Consumer
+    end
+  end
+end
+
+produce_many(DT.topics[0], DT.uuids(50))
+
+start_karafka_and_wait_until do
+  DT[:ticks].size >= 10
+end
+
+previous = nil
+
+DT[:ticks].each_with_index do |tick, index|
+  if previous.nil? || index < 2
+    previous = tick
+    next
+  end
+
+  tick_distance = tick - previous
+
+  assert tick_distance > 1
+  assert tick_distance < 2
+
+  previous = tick
+end

--- a/spec/lib/karafka/pro/processing/jobs_queue_spec.rb
+++ b/spec/lib/karafka/pro/processing/jobs_queue_spec.rb
@@ -131,6 +131,8 @@ RSpec.describe_current do
     let(:subscription_group_id) { SecureRandom.uuid }
     let(:id) { SecureRandom.uuid }
 
+    before { queue.register(subscription_group_id) }
+
     context 'when we lock' do
       before { queue.lock_async(subscription_group_id, id) }
 
@@ -370,6 +372,8 @@ RSpec.describe_current do
 
   describe '#empty?' do
     let(:job) { OpenStruct.new(group_id: 1, id: 1, call: true) }
+
+    before { queue.register(1) }
 
     context 'when there are no jobs at all' do
       it { expect(queue.empty?(1)).to eq(true) }


### PR DESCRIPTION
close https://github.com/karafka/karafka/issues/1965

This PR supports job queue auto-unlock on the async locked timeouts for millisecond precision unlocking in between subscription groups.

It also fixes a case where the periodic jobs scheduler would kick in too often because of jobs being finished and causing re-wait check