### PR TITLE
optimize admin and expose `topic_info` admin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This release contains a **BREAKING** change. Make sure to read and apply upgrade
 - [Enhancement] Introduce graceful `#stop` to the iterator instead of recommending of usage of `break`.
 - [Enhancement] Do not run jobs schedulers and other interval based operations on each job queue unlock.
 - [Enhancement] Publish listeners status lifecycle events.
+- [Enhancement] Use proxy wrapper for Admin metadata requests.
+- [Enhancement] Use limited scope topic info data when operating on direct topics instead of full cluster queries.
 - [Change] Do not create new proxy object to Rdkafka with certain low-level operations and re-use existing.
 - [Change] Update `karafka.erb` template with a placeholder for waterdrop and karafka error instrumentation.
 - [Fix] Pro Swarm liveness listener can report incorrect failure when dynamic multiplexing scales down.

--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -58,6 +58,9 @@ en:
       internal.connection.proxy.committed.wait_time_format: needs to be an integer bigger than 0
       internal.connection.proxy.commit.max_attempts_format: needs to be an integer bigger than 0
       internal.connection.proxy.commit.wait_time_format: needs to be an integer bigger than 0
+      internal.connection.proxy.metadata.timeout_format: needs to be an integer bigger than 0
+      internal.connection.proxy.metadata.max_attempts_format: needs to be an integer bigger than 0
+      internal.connection.proxy.metadata.wait_time_format: needs to be an integer bigger than 0
 
       internal.swarm.manager_format: cannot be nil
       internal.swarm.orphaned_exit_code_format: needs to be an integer bigger or equal to 0

--- a/lib/karafka/connection/proxy.rb
+++ b/lib/karafka/connection/proxy.rb
@@ -158,6 +158,21 @@ module Karafka
         end
       end
 
+      # @param topic_name [String, nil] Name of the topic we're interested in or nil if we want to
+      #   get info on all topics
+      # @return [Rdkafka::Metadata] rdkafka metadata object with the requested details
+      def metadata(topic_name = nil)
+        m_config = @config.metadata
+
+        with_broker_errors_retry(
+          # required to be in seconds, not ms
+          wait_time: m_config.wait_time / 1_000.to_f,
+          max_attempts: m_config.max_attempts
+        ) do
+          @wrapped.metadata(topic_name, m_config.timeout)
+        end
+      end
+
       private
 
       # Runs expected block of code with few retries on all_brokers_down

--- a/lib/karafka/contracts/config.rb
+++ b/lib/karafka/contracts/config.rb
@@ -85,6 +85,7 @@ module Karafka
               query_watermark_offsets
               offsets_for_times
               committed
+              metadata
             ].each do |scope|
               nested(scope) do
                 required(:timeout) { |val| val.is_a?(Integer) && val.positive? }

--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -276,6 +276,16 @@ module Karafka
               # How long should we wait before next attempt in case of a failure
               setting :wait_time, default: 1_000
             end
+
+            # Settings for metadata request
+            setting :metadata do
+              # timeout for this request. For busy or remote clusters, this should be high enough
+              setting :timeout, default: 10_000
+              # How many times should we try to run this call before raising an error
+              setting :max_attempts, default: 3
+              # How long should we wait before next attempt in case of a failure
+              setting :wait_time, default: 1_000
+            end
           end
         end
 

--- a/spec/lib/karafka/admin_spec.rb
+++ b/spec/lib/karafka/admin_spec.rb
@@ -387,6 +387,24 @@ RSpec.describe_current do
     end
   end
 
+  describe '#topic_info' do
+    let(:name) { SecureRandom.uuid }
+
+    context 'when given topic does not exist' do
+      it { expect { described_class.topic_info(name) }.to raise_error(Rdkafka::RdkafkaError) }
+    end
+
+    context 'when given topic exists' do
+      before { described_class.create_topic(name, 2, 1) }
+
+      it do
+        info = described_class.topic_info(name)
+        expect(info[:partition_count]).to eq(2)
+        expect(info[:topic_name]).to eq(name)
+      end
+    end
+  end
+
   describe '#read_watermark_offsets' do
     subject(:offsets) { described_class.read_watermark_offsets(name, partition) }
 

--- a/spec/lib/karafka/contracts/config_spec.rb
+++ b/spec/lib/karafka/contracts/config_spec.rb
@@ -68,6 +68,11 @@ RSpec.describe_current do
             commit: {
               max_attempts: 5,
               wait_time: 1_000
+            },
+            metadata: {
+              timeout: 100,
+              max_attempts: 5,
+              wait_time: 1_000
             }
           }
         },
@@ -550,6 +555,7 @@ RSpec.describe_current do
       offsets_for_times
       committed
       commit
+      metadata
     ].each do |scope|
       context "when proxy #{scope} is missing" do
         before { config[:internal][:connection][:proxy].delete(scope) }


### PR DESCRIPTION
This PR improves admin by using a limited queries for per-topic operations (much faster on large clusters) + exposes `#topic_info` similar to `#cluster_info` that will be used in web-ui.

It also wraps metadata request with the proxy for granular timeout control
