### PR TITLE
make #enqueue_all output compatible with ActiveJob.perform_all_later

### DIFF
--- a/lib/active_job/queue_adapters/karafka_adapter.rb
+++ b/lib/active_job/queue_adapters/karafka_adapter.rb
@@ -18,6 +18,7 @@ module ActiveJob
       # @param jobs [Array<Object>] jobs that we want to enqueue
       def enqueue_all(jobs)
         ::Karafka::App.config.internal.active_job.dispatcher.dispatch_many(jobs)
+        jobs.size
       end
 
       # Raises info, that Karafka backend does not support scheduling jobs

--- a/spec/lib/active_job/queue_adapters/karafka_adapter_spec.rb
+++ b/spec/lib/active_job/queue_adapters/karafka_adapter_spec.rb
@@ -34,5 +34,9 @@ RSpec.describe_current do
       adapter.enqueue_all(jobs)
       expect(dispatcher).to have_received(:dispatch_many).with(jobs)
     end
+
+    it 'expect to return total count of enqueued jobs' do
+      expect(adapter.enqueue_all(jobs)).to eql jobs.size
+    end
   end
 end


### PR DESCRIPTION
For any ActiveJob adapter, `#enqueue_all` method should return the total number of jobs enqueued.

So that `enqueued_count` set by `instrument_enqueue_all` is as expected: 
https://github.com/rails/rails/blob/main/activejob/lib/active_job/enqueuing.rb#L17
https://github.com/rails/rails/blob/main/activejob/lib/active_job/instrumentation.rb#L10

Otherwise, it fails here: https://github.com/rails/rails/blob/main/activejob/lib/active_job/log_subscriber.rb#L68