### PR TITLE
improve dlq dispatch warranties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This release contains a **BREAKING** change. Make sure to read and apply upgrade
 - **[Feature]** Introduce ability to use direct assignments (Pro).
 - **[Feature]** Provide consumer piping API (Pro).
 - **[Feature]** Introduce `karafka topics plan` to describe changes that will be applied when migrating.
+- [Enhancement] Include number of attempts prior to DLQ message being dispatched including the dispatch one (Pro).
+- [Enhancement] Provide ability to decide how to dispatch from DLQ (sync / async).
+- [Enhancement] Provide ability to decide how to mark as consumed from DLQ (sync / async).
 - [Enhancement] Allow for usage of a custom Appsignal namespace when logging.
 - [Enhancement] Do not run periodic jobs when LRJ job is running despite polling (LRJ can still start when Periodic runs).
 - [Enhancement] Improve accuracy of periodic jobs and make sure they do not run too early after saturated work.

--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -107,6 +107,8 @@ en:
       dead_letter_queue.active_format: needs to be either true or false
       dead_letter_queue.independent_format: needs to be either true or false
       dead_letter_queue.transactional_format: needs to be either true or false
+      dead_letter_queue.dispatch_method_format: 'needs to be either #produce_sync or #produce_async'
+      dead_letter_queue.marking_method_format: 'needs to be either #mark_as_consumed or #mark_as_consumed!'
       active_format: needs to be either true or false
       declaratives.partitions_format: needs to be more or equal to 1
       declaratives.active_format: needs to be true

--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -217,7 +217,7 @@ module Karafka
         subscription_group: topic.subscription_group,
         offset: offset,
         timeout: coordinator.pause_tracker.current_timeout,
-        attempt: coordinator.pause_tracker.attempt
+        attempt: attempt
       )
     end
 
@@ -297,7 +297,7 @@ module Karafka
         partition: partition,
         offset: coordinator.seek_offset,
         timeout: coordinator.pause_tracker.current_timeout,
-        attempt: coordinator.pause_tracker.attempt
+        attempt: attempt
       )
     end
   end

--- a/lib/karafka/pro/processing/strategies/aj/dlq_ftr_lrj_mom.rb
+++ b/lib/karafka/pro/processing/strategies/aj/dlq_ftr_lrj_mom.rb
@@ -55,7 +55,7 @@ module Karafka
                   apply_dlq_flow do
                     skippable_message, = find_skippable_message
                     dispatch_to_dlq(skippable_message) if dispatch_to_dlq?
-                    mark_as_consumed(skippable_message)
+                    mark_dispatched_to_dlq(skippable_message)
                   end
                 end
               end

--- a/lib/karafka/pro/processing/strategies/aj/dlq_ftr_lrj_mom_vp.rb
+++ b/lib/karafka/pro/processing/strategies/aj/dlq_ftr_lrj_mom_vp.rb
@@ -61,7 +61,7 @@ module Karafka
                   apply_dlq_flow do
                     skippable_message, = find_skippable_message
                     dispatch_to_dlq(skippable_message) if dispatch_to_dlq?
-                    mark_as_consumed(skippable_message)
+                    mark_dispatched_to_dlq(skippable_message)
                   end
                 end
               end

--- a/lib/karafka/pro/processing/strategies/aj/dlq_ftr_mom.rb
+++ b/lib/karafka/pro/processing/strategies/aj/dlq_ftr_mom.rb
@@ -57,7 +57,7 @@ module Karafka
                     # We can commit the offset here because we know that we skip it "forever" and
                     # since AJ consumer commits the offset after each job, we also know that the
                     # previous job was successful
-                    mark_as_consumed(skippable_message)
+                    mark_dispatched_to_dlq(skippable_message)
                   end
                 end
               end

--- a/lib/karafka/pro/processing/strategies/aj/dlq_ftr_mom_vp.rb
+++ b/lib/karafka/pro/processing/strategies/aj/dlq_ftr_mom_vp.rb
@@ -55,7 +55,7 @@ module Karafka
                     # We can commit the offset here because we know that we skip it "forever" and
                     # since AJ consumer commits the offset after each job, we also know that the
                     # previous job was successful
-                    mark_as_consumed(skippable_message)
+                    mark_dispatched_to_dlq(skippable_message)
                   end
                 end
               end

--- a/lib/karafka/pro/processing/strategies/aj/dlq_lrj_mom.rb
+++ b/lib/karafka/pro/processing/strategies/aj/dlq_lrj_mom.rb
@@ -51,7 +51,7 @@ module Karafka
                   apply_dlq_flow do
                     skippable_message, = find_skippable_message
                     dispatch_to_dlq(skippable_message) if dispatch_to_dlq?
-                    mark_as_consumed(skippable_message)
+                    mark_dispatched_to_dlq(skippable_message)
                   end
                 end
               end

--- a/lib/karafka/pro/processing/strategies/aj/dlq_lrj_mom_vp.rb
+++ b/lib/karafka/pro/processing/strategies/aj/dlq_lrj_mom_vp.rb
@@ -55,7 +55,7 @@ module Karafka
                   apply_dlq_flow do
                     skippable_message, = find_skippable_message
                     dispatch_to_dlq(skippable_message) if dispatch_to_dlq?
-                    mark_as_consumed(skippable_message)
+                    mark_dispatched_to_dlq(skippable_message)
                   end
                 end
               end

--- a/lib/karafka/pro/processing/strategies/aj/dlq_mom.rb
+++ b/lib/karafka/pro/processing/strategies/aj/dlq_mom.rb
@@ -49,7 +49,7 @@ module Karafka
                     # We can commit the offset here because we know that we skip it "forever" and
                     # since AJ consumer commits the offset after each job, we also know that the
                     # previous job was successful
-                    mark_as_consumed(skippable_message)
+                    mark_dispatched_to_dlq(skippable_message)
                   end
                 end
               end

--- a/lib/karafka/pro/processing/strategies/aj/dlq_mom_vp.rb
+++ b/lib/karafka/pro/processing/strategies/aj/dlq_mom_vp.rb
@@ -54,7 +54,7 @@ module Karafka
                     # Aj::DlqMom
                     skippable_message, = find_skippable_message
                     dispatch_to_dlq(skippable_message) if dispatch_to_dlq?
-                    mark_as_consumed(skippable_message)
+                    mark_dispatched_to_dlq(skippable_message)
                   end
                 end
               end

--- a/lib/karafka/processing/strategies/aj_dlq_mom.rb
+++ b/lib/karafka/processing/strategies/aj_dlq_mom.rb
@@ -34,7 +34,7 @@ module Karafka
             # We can commit the offset here because we know that we skip it "forever" and
             # since AJ consumer commits the offset after each job, we also know that the
             # previous job was successful
-            mark_as_consumed(skippable_message)
+            mark_dispatched_to_dlq(skippable_message)
             pause(coordinator.seek_offset, nil, false)
           end
         end

--- a/lib/karafka/routing/features/dead_letter_queue/config.rb
+++ b/lib/karafka/routing/features/dead_letter_queue/config.rb
@@ -17,6 +17,11 @@ module Karafka
           :transactional,
           # Strategy to apply (if strategies supported)
           :strategy,
+          # Should we use `#produce_sync` or `#produce_async`
+          :dispatch_method,
+          # Should we use `#mark_as_consumed` or `#mark_as_consumed!` (in flows that mark)
+          :marking_method,
+          # Initialize with kwargs
           keyword_init: true
         ) do
           alias_method :active?, :active

--- a/lib/karafka/routing/features/dead_letter_queue/contracts/topic.rb
+++ b/lib/karafka/routing/features/dead_letter_queue/contracts/topic.rb
@@ -21,6 +21,14 @@ module Karafka
               required(:independent) { |val| [true, false].include?(val) }
               required(:max_retries) { |val| val.is_a?(Integer) && val >= 0 }
               required(:transactional) { |val| [true, false].include?(val) }
+
+              required(:dispatch_method) do |val|
+                %i[produce_async produce_sync].include?(val)
+              end
+
+              required(:marking_method) do |val|
+                %i[mark_as_consumed mark_as_consumed!].include?(val)
+              end
             end
 
             # Validate topic name only if dlq is active

--- a/lib/karafka/routing/features/dead_letter_queue/topic.rb
+++ b/lib/karafka/routing/features/dead_letter_queue/topic.rb
@@ -18,19 +18,27 @@ module Karafka
           #   in a retry flow to reset the errors counter
           # @param transactional [Boolean] if applicable, should transaction be used to move
           #   given message to the dead-letter topic and mark it as consumed.
+          # @param dispatch_method [Symbol] `:produce_async` or `:produce_sync`. Describes
+          #   whether dispatch on dlq should be sync or async (async by default)
+          # @param marking_method [Symbol] `:mark_as_consumed` or `:mark_as_consumed!`. Describes
+          #   whether marking on DLQ should be async or sync (async by default)
           # @return [Config] defined config
           def dead_letter_queue(
             max_retries: DEFAULT_MAX_RETRIES,
             topic: nil,
             independent: false,
-            transactional: true
+            transactional: true,
+            dispatch_method: :produce_async,
+            marking_method: :mark_as_consumed
           )
             @dead_letter_queue ||= Config.new(
               active: !topic.nil?,
               max_retries: max_retries,
               topic: topic,
               independent: independent,
-              transactional: transactional
+              transactional: transactional,
+              dispatch_method: dispatch_method,
+              marking_method: marking_method
             )
           end
 

--- a/spec/integrations/consumption/strategies/dlq/with_sync_dispatch_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/with_sync_dispatch_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# When using DLQ, it should work when dispatch in sync
+
+setup_karafka(allow_errors: %w[consumer.consume.error])
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      raise StandardError if message.offset == 0
+
+      DT[:offsets] << message.offset
+
+      mark_as_consumed message
+    end
+  end
+end
+
+class DlqConsumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[:broken] << message.offset
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    dead_letter_queue(
+      topic: DT.topics[1],
+      max_retries: 2,
+      dispatch_method: :produce_sync
+    )
+  end
+
+  topic DT.topics[1] do
+    consumer DlqConsumer
+  end
+end
+
+elements = DT.uuids(5)
+produce_many(DT.topic, elements)
+
+start_karafka_and_wait_until do
+  DT[:offsets].uniq.count > 1
+end
+
+assert_equal DT[:offsets], (1..4).to_a

--- a/spec/integrations/consumption/strategies/dlq/with_sync_marking_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/with_sync_marking_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# When using DLQ, it should work when marking as consumed sync
+
+setup_karafka(allow_errors: %w[consumer.consume.error])
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      raise StandardError if message.offset == 0
+
+      DT[:offsets] << message.offset
+
+      mark_as_consumed message
+    end
+  end
+end
+
+class DlqConsumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[:broken] << message.offset
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    dead_letter_queue(
+      topic: DT.topics[1],
+      max_retries: 2,
+      marking_method: :mark_as_consumed!
+    )
+  end
+
+  topic DT.topics[1] do
+    consumer DlqConsumer
+  end
+end
+
+elements = DT.uuids(5)
+produce_many(DT.topic, elements)
+
+start_karafka_and_wait_until do
+  DT[:offsets].uniq.count > 1
+end
+
+assert_equal DT[:offsets], (1..4).to_a

--- a/spec/integrations/pro/consumption/strategies/dlq/default/details_dispatch_transfer_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/details_dispatch_transfer_spec.rb
@@ -50,5 +50,6 @@ end
   assert_equal dlq_message.headers.fetch('original_topic'), DT.topic
   assert_equal dlq_message.headers.fetch('original_partition'), 0.to_s
   assert_equal dlq_message.headers.fetch('original_offset'), i.to_s
+  assert_equal dlq_message.headers.fetch('original_attempts'), '1'
   assert_equal dlq_message.headers.fetch('original_consumer_group'), cg
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/default/with_sync_dispatch_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/with_sync_dispatch_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# When using DLQ, it should work when dispatch in sync
+
+setup_karafka(allow_errors: %w[consumer.consume.error])
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      raise StandardError if message.offset == 0
+
+      DT[:offsets] << message.offset
+
+      mark_as_consumed message
+    end
+  end
+end
+
+class DlqConsumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[:broken] << message.offset
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    dead_letter_queue(
+      topic: DT.topics[1],
+      max_retries: 2,
+      dispatch_method: :produce_sync
+    )
+  end
+
+  topic DT.topics[1] do
+    consumer DlqConsumer
+  end
+end
+
+elements = DT.uuids(5)
+produce_many(DT.topic, elements)
+
+start_karafka_and_wait_until do
+  DT[:offsets].uniq.count > 1
+end
+
+assert_equal DT[:offsets], (1..4).to_a

--- a/spec/integrations/pro/consumption/strategies/dlq/default/with_sync_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/with_sync_marking_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# When using DLQ, it should work when marking as consumed sync
+
+setup_karafka(allow_errors: %w[consumer.consume.error])
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      raise StandardError if message.offset == 0
+
+      DT[:offsets] << message.offset
+
+      mark_as_consumed message
+    end
+  end
+end
+
+class DlqConsumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[:broken] << message.offset
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    dead_letter_queue(
+      topic: DT.topics[1],
+      max_retries: 2,
+      marking_method: :mark_as_consumed!
+    )
+  end
+
+  topic DT.topics[1] do
+    consumer DlqConsumer
+  end
+end
+
+elements = DT.uuids(5)
+produce_many(DT.topic, elements)
+
+start_karafka_and_wait_until do
+  DT[:offsets].uniq.count > 1
+end
+
+assert_equal DT[:offsets], (1..4).to_a

--- a/spec/lib/karafka/routing/features/dead_letter_queue/contracts/topic_spec.rb
+++ b/spec/lib/karafka/routing/features/dead_letter_queue/contracts/topic_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe_current do
         topic: 'deads',
         max_retries: 5,
         independent: false,
-        transactional: true
+        transactional: true,
+        dispatch_method: :produce_async,
+        marking_method: :mark_as_consumed
       }
     }
   end
@@ -53,6 +55,18 @@ RSpec.describe_current do
     before { config[:dead_letter_queue][:topic] = false }
 
     it { expect(check).to be_success }
+  end
+
+  context 'when dispatch_method is not any of methods' do
+    before { config[:dead_letter_queue][:dispatch_method] = false }
+
+    it { expect(check).not_to be_success }
+  end
+
+  context 'when marking_method is not any of methods' do
+    before { config[:dead_letter_queue][:marking_method] = false }
+
+    it { expect(check).not_to be_success }
   end
 
   context 'when max_retries is not an integer' do


### PR DESCRIPTION
this PR allows for selection whether we want to mark as consumed async or sync post dispatch on dlq and whether we want to dispatch sync or async (in transactions it is irrelevant)

close https://github.com/karafka/karafka/issues/1994