### PR TITLE
replace lags with lags with offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This release contains **BREAKING** changes. Make sure to read and apply upgrade 
 - [Enhancement] Improve accuracy of periodic jobs and make sure they do not run too early after saturated work.
 - [Enhancement] Introduce ability to async lock other subscription groups polling.
 - [Enhancement] Improve shutdown when using long polling setup (high `max_wait_time`).
-- [Enhancement] Provide `Karafka::Admin#read_lags` for ability to query lags of a given CG.
+- [Enhancement] Provide `Karafka::Admin#read_lags_with_offsets` for ability to query lags and offsets of a given CG.
 - [Enhancement] Allow direct assignments granular distribution in the Swarm (Pro).
 - [Enhancement] Add a buffer to the supervisor supervision on shutdown to prevent a potential race condition when signal pass lags.
 - [Enhancement] Provide ability to automatically generate and validate fingerprints of encrypted payload.

--- a/lib/karafka/admin.rb
+++ b/lib/karafka/admin.rb
@@ -244,13 +244,15 @@ module Karafka
         end
       end
 
-      # Reads lags for given topics in the context of consumer groups defined in the routing
+      # Reads lags and offsets for given topics in the context of consumer groups defined in the
+      #   routing
       # @param consumer_groups_with_topics [Hash<String, Array<String>>] hash with consumer groups
       #   names with array of topics to query per consumer group inside
       # @param active_topics_only [Boolean] if set to false, when we use routing topics, will
       #   select also topics that are marked as inactive in routing
-      # @return [Hash<String, Hash<Integer, Integer>>] hash where the top level keys are the
-      #   consumer groups and values are hashes with topics and inside partitions with lags
+      # @return [Hash<String, Hash<Integer, <Hash<Integer>>>>] hash where the top level keys are
+      #   the consumer groups and values are hashes with topics and inside partitions with lags
+      #   and offsets
       #
       # @note For topics that do not exist, topic details will be set to an empty hash
       #
@@ -259,7 +261,7 @@ module Karafka
       #
       # @note This lag reporting is for committed lags and is "Kafka-centric", meaning that this
       #   represents lags from Kafka perspective and not the consumer. They may differ.
-      def read_lags(consumer_groups_with_topics = {}, active_topics_only: true)
+      def read_lags_with_offsets(consumer_groups_with_topics = {}, active_topics_only: true)
         # We first fetch all the topics with partitions count that exist in the cluster so we
         # do not query for topics that do not exist and so we can get partitions count for all
         # the topics we may need. The non-existent and not consumed will be filled at the end
@@ -290,6 +292,7 @@ module Karafka
         end
 
         groups_lags = Hash.new { |h, k| h[k] = {} }
+        groups_offs = Hash.new { |h, k| h[k] = {} }
 
         cgs_with_topics.each do |cg, topics|
           # Do not add to tpl topics that do not exist
@@ -300,7 +303,18 @@ module Karafka
           with_consumer('group.id': cg) do |consumer|
             topics.each { |topic| tpl.add_topic(topic, existing_topics[topic]) }
 
-            consumer.lag(consumer.committed(tpl)).each do |topic, partitions_lags|
+            commit_offsets = consumer.committed(tpl)
+
+            commit_offsets.to_h.each do |topic, partitions|
+              groups_offs[cg][topic] = {}
+
+              partitions.each do |partition|
+                # -1 when no offset is stored
+                groups_offs[cg][topic][partition.partition] = partition.offset || -1
+              end
+            end
+
+            consumer.lag(commit_offsets).each do |topic, partitions_lags|
               groups_lags[cg][topic] = partitions_lags
             end
           end
@@ -322,7 +336,22 @@ module Karafka
           end
         end
 
-        groups_lags
+        merged = Hash.new { |h, k| h[k] = {} }
+
+        groups_lags.each do |cg, topics|
+          topics.each do |topic, partitions|
+            merged[cg][topic] = {}
+
+            partitions.each do |partition, lag|
+              merged[cg][topic][partition] = {
+                offset: groups_offs.fetch(cg).fetch(topic).fetch(partition),
+                lag: lag
+              }
+            end
+          end
+        end
+
+        merged
       end
 
       # @return [Rdkafka::Metadata] cluster metadata info

--- a/spec/lib/karafka/admin_spec.rb
+++ b/spec/lib/karafka/admin_spec.rb
@@ -495,13 +495,13 @@ RSpec.describe_current do
   end
 
   # More coverage of this feature is in integration suite
-  describe '#read_lag' do
-    subject(:lags) { Karafka::Admin.read_lags(cgs_t) }
+  describe '#read_lags_with_offsets' do
+    subject(:results) { Karafka::Admin.read_lags_with_offsets(cgs_t) }
 
     context 'when we query for a non-existent topic with a non-existing CG' do
       let(:cgs_t) { { 'doesnotexist' => ['doesnotexisttopic'] } }
 
-      it { expect(lags).to eq('doesnotexist' => { 'doesnotexisttopic' => {} }) }
+      it { expect(results).to eq('doesnotexist' => { 'doesnotexisttopic' => {} }) }
     end
 
     context 'when querying existing topic with a CG that never consumed it' do
@@ -509,7 +509,7 @@ RSpec.describe_current do
 
       let(:cgs_t) { { 'doesnotexist' => [name] } }
 
-      it { expect(lags).to eq('doesnotexist' => { name => { 0 => -1 } }) }
+      it { expect(results).to eq('doesnotexist' => { name => { 0 => { lag: -1, offset: -1 } } }) }
     end
   end
 end


### PR DESCRIPTION
This PR replaces `#read_lags` with more comprehensive `#read_lags_with_offsets` since when reading lags we already do have offsets.

It is not a breaking change because we did not yet release this and we only need to update web-ui in one place.