### PR TITLE
replace subscribe best offset position with admin api

### DIFF
--- a/spec/integrations/admin/consumer_groups/delete_existing_spec.rb
+++ b/spec/integrations/admin/consumer_groups/delete_existing_spec.rb
@@ -32,9 +32,9 @@ end
 # Produce one more so we can get the new offset for checking
 produce_many(DT.topic, DT.uuids(1))
 
-assert_equal 10, fetch_first_offset
+assert_equal 10, fetch_next_offset
 
 Karafka::Admin.delete_consumer_group(DT.consumer_group)
 
 # Should start from beginning as it was removed
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/admin/consumer_groups/seek_consumer_group_time_spec.rb
+++ b/spec/integrations/admin/consumer_groups/seek_consumer_group_time_spec.rb
@@ -28,4 +28,4 @@ Karafka::Admin.seek_consumer_group(
   { DT.topic => { 0 => time_ref } }
 )
 
-assert_equal 4, fetch_first_offset
+assert_equal 4, fetch_next_offset

--- a/spec/integrations/admin/consumer_groups/seek_consumer_group_time_total_future_spec.rb
+++ b/spec/integrations/admin/consumer_groups/seek_consumer_group_time_total_future_spec.rb
@@ -29,6 +29,4 @@ Karafka::Admin.seek_consumer_group(
   { DT.topic => { 0 => Time.now + 60 * 60 } }
 )
 
-# false will be returned when we cannot fetch message because offset is in the future and we do
-# not have more messages. This is expected here.
-assert_equal false, fetch_first_offset
+assert_equal 10, fetch_next_offset

--- a/spec/integrations/admin/consumer_groups/seek_consumer_group_time_total_past_spec.rb
+++ b/spec/integrations/admin/consumer_groups/seek_consumer_group_time_total_past_spec.rb
@@ -28,4 +28,4 @@ Karafka::Admin.seek_consumer_group(
   { DT.topic => { 0 => Time.now - 60 * 60 } }
 )
 
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/admin/consumer_groups/seek_consumer_group_topic_spec.rb
+++ b/spec/integrations/admin/consumer_groups/seek_consumer_group_topic_spec.rb
@@ -32,11 +32,11 @@ end
 # Produce one more so we can get the new offset for checking
 produce_many(DT.topic, DT.uuids(1))
 
-assert_equal 10, fetch_first_offset
+assert_equal 10, fetch_next_offset
 
 Karafka::Admin.seek_consumer_group(
   DT.consumer_group,
   { DT.topic => 5 }
 )
 
-assert_equal 5, fetch_first_offset
+assert_equal 5, fetch_next_offset

--- a/spec/integrations/admin/consumer_groups/seek_consumer_group_topic_time_total_past_spec.rb
+++ b/spec/integrations/admin/consumer_groups/seek_consumer_group_topic_time_total_past_spec.rb
@@ -29,4 +29,4 @@ Karafka::Admin.seek_consumer_group(
   { DT.topic => Time.now - 60 * 60 }
 )
 
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/consumption/strategies/aj_mom/offset_marking_on_long_running_stop_spec.rb
+++ b/spec/integrations/consumption/strategies/aj_mom/offset_marking_on_long_running_stop_spec.rb
@@ -30,5 +30,4 @@ start_karafka_and_wait_until do
   DT[0].size >= 2
 end
 
-# No test needed, if it commits last offset, this will hang forever
-fetch_first_offset
+assert_equal 2, fetch_next_offset

--- a/spec/integrations/consumption/strategies/aj_mom_dlq/offset_marking_on_long_running_stop_spec.rb
+++ b/spec/integrations/consumption/strategies/aj_mom_dlq/offset_marking_on_long_running_stop_spec.rb
@@ -32,5 +32,4 @@ start_karafka_and_wait_until do
   DT[0].size >= 2
 end
 
-# No test needed, if it commits last offset, this will hang forever
-fetch_first_offset
+assert_equal 2, fetch_next_offset

--- a/spec/integrations/consumption/strategies/aj_mom_dlq/offset_skip_on_non_recoverable_error_spec.rb
+++ b/spec/integrations/consumption/strategies/aj_mom_dlq/offset_skip_on_non_recoverable_error_spec.rb
@@ -36,6 +36,6 @@ end
 
 producer.produce_async(topic: DT.topics[0], payload: '{}')
 
-assert_equal 1, fetch_first_offset
+assert_equal 1, fetch_next_offset
 
 producer.close

--- a/spec/integrations/consumption/strategies/default/from_earliest_spec.rb
+++ b/spec/integrations/consumption/strategies/default/from_earliest_spec.rb
@@ -26,4 +26,5 @@ end
 assert_equal elements, DT[0]
 assert_equal 2, DT.data.size
 assert_equal [true], DT[:uses].uniq
-assert !fetch_first_offset
+
+assert_equal 100, fetch_next_offset

--- a/spec/integrations/consumption/strategies/default/with_failed_transactions_spec.rb
+++ b/spec/integrations/consumption/strategies/default/with_failed_transactions_spec.rb
@@ -36,4 +36,4 @@ start_karafka_and_wait_until do
 end
 
 assert_equal DT[0], (202..301).to_a
-assert !fetch_first_offset
+assert_equal 302, fetch_next_offset

--- a/spec/integrations/consumption/strategies/default/with_offset_moved_backwards_directly_spec.rb
+++ b/spec/integrations/consumption/strategies/default/with_offset_moved_backwards_directly_spec.rb
@@ -36,4 +36,4 @@ start_karafka_and_wait_until do
   DT.key?(:done)
 end
 
-assert_equal 3, fetch_first_offset
+assert_equal 3, fetch_next_offset

--- a/spec/integrations/consumption/strategies/dlq/without_any_errors_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/without_any_errors_spec.rb
@@ -55,4 +55,4 @@ assert_equal (0..99).to_a, DT[:offsets]
 # No broken messages
 assert_equal 0, DT[:broken].size
 
-assert !fetch_first_offset
+assert_equal 100, fetch_next_offset

--- a/spec/integrations/consumption/strategies/dlq_mom/without_intermediate_marking_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/without_intermediate_marking_spec.rb
@@ -52,4 +52,4 @@ start_karafka_and_wait_until do
 end
 
 # None of the offsets should have been committed
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/consumption/strategies/mom/with_offset_moved_backwards_directly_spec.rb
+++ b/spec/integrations/consumption/strategies/mom/with_offset_moved_backwards_directly_spec.rb
@@ -41,4 +41,4 @@ start_karafka_and_wait_until do
   DT.key?(:done)
 end
 
-assert_equal 3, fetch_first_offset
+assert_equal 3, fetch_next_offset

--- a/spec/integrations/pausing/pause_prior_to_automatic_offset_and_mark_spec.rb
+++ b/spec/integrations/pausing/pause_prior_to_automatic_offset_and_mark_spec.rb
@@ -32,4 +32,4 @@ start_karafka_and_wait_until do
   DT[:paused].size >= 3
 end
 
-assert_equal fetch_first_offset, DT[:last].max + 1
+assert_equal fetch_next_offset, DT[:last].max + 1

--- a/spec/integrations/pausing/pause_prior_to_automatic_offset_spec.rb
+++ b/spec/integrations/pausing/pause_prior_to_automatic_offset_spec.rb
@@ -33,4 +33,4 @@ start_karafka_and_wait_until do
   DT[:paused].size >= 3
 end
 
-assert_equal fetch_first_offset, DT[:paused].last
+assert_equal fetch_next_offset, DT[:paused].last

--- a/spec/integrations/pro/consumption/direct_assignments/marking_as_consumed_spec.rb
+++ b/spec/integrations/pro/consumption/direct_assignments/marking_as_consumed_spec.rb
@@ -30,4 +30,4 @@ start_karafka_and_wait_until do
   DT.key?(:done)
 end
 
-assert fetch_first_offset >= 10
+assert fetch_next_offset >= 10

--- a/spec/integrations/pro/consumption/direct_assignments/transactions_support_spec.rb
+++ b/spec/integrations/pro/consumption/direct_assignments/transactions_support_spec.rb
@@ -34,4 +34,4 @@ start_karafka_and_wait_until do
   DT.key?(:done)
 end
 
-assert fetch_first_offset >= 10
+assert fetch_next_offset >= 10

--- a/spec/integrations/pro/consumption/from_earliest_spec.rb
+++ b/spec/integrations/pro/consumption/from_earliest_spec.rb
@@ -24,4 +24,4 @@ end
 
 assert_equal elements, DT[0]
 assert_equal 1, DT.data.size
-assert !fetch_first_offset
+assert_equal 100, fetch_next_offset

--- a/spec/integrations/pro/consumption/periodic_jobs/marking_from_ticking_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/marking_from_ticking_spec.rb
@@ -32,4 +32,4 @@ start_karafka_and_wait_until do
   DT[:ticks].count >= 2
 end
 
-assert_equal fetch_first_offset - 1, DT[:marked].last
+assert_equal fetch_next_offset - 1, DT[:marked].last

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_lrj_mom/offset_marking_on_long_running_stop_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_lrj_mom/offset_marking_on_long_running_stop_spec.rb
@@ -34,5 +34,4 @@ start_karafka_and_wait_until do
   DT[0].size >= 2
 end
 
-# No test needed, if it commits last offset, this will hang forever
-fetch_first_offset
+assert_equal 2, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_mom/offset_marking_on_long_running_stop_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_mom/offset_marking_on_long_running_stop_spec.rb
@@ -33,5 +33,4 @@ start_karafka_and_wait_until do
   DT[0].size >= 2
 end
 
-# No test needed, if it commits last offset, this will hang forever
-fetch_first_offset
+assert_equal 2, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_lrj_mom/offset_marking_on_long_running_stop_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_lrj_mom/offset_marking_on_long_running_stop_spec.rb
@@ -33,5 +33,4 @@ start_karafka_and_wait_until do
   DT[0].size >= 2
 end
 
-# No test needed, if it commits last offset, this will hang forever
-fetch_first_offset
+assert_equal 2, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_mom/offset_marking_on_long_running_stop_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_mom/offset_marking_on_long_running_stop_spec.rb
@@ -32,5 +32,4 @@ start_karafka_and_wait_until do
   DT[0].size >= 2
 end
 
-# No test needed, if it commits last offset, this will hang forever
-fetch_first_offset
+assert_equal 2, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/aj/ftr_lrj_mom/offset_marking_on_long_running_stop_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/ftr_lrj_mom/offset_marking_on_long_running_stop_spec.rb
@@ -33,5 +33,4 @@ start_karafka_and_wait_until do
   DT[0].size >= 2
 end
 
-# No test needed, if it commits last offset, this will hang forever
-fetch_first_offset
+assert_equal 2, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/aj/ftr_mom/offset_marking_on_long_running_stop_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/ftr_mom/offset_marking_on_long_running_stop_spec.rb
@@ -32,5 +32,4 @@ start_karafka_and_wait_until do
   DT[0].size >= 2
 end
 
-# No test needed, if it commits last offset, this will hang forever
-fetch_first_offset
+assert_equal 2, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/dlq/default/pause_prior_to_automatic_offset_and_mark_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/pause_prior_to_automatic_offset_and_mark_spec.rb
@@ -33,4 +33,4 @@ start_karafka_and_wait_until do
   DT[:paused].size >= 3
 end
 
-assert_equal fetch_first_offset, DT[:last].max + 1
+assert_equal fetch_next_offset, DT[:last].max + 1

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj/with_long_manual_pause_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj/with_long_manual_pause_spec.rb
@@ -32,4 +32,4 @@ start_karafka_and_wait_until do
   DT[:paused].size >= 3
 end
 
-assert_equal fetch_first_offset, DT[:paused].last
+assert_equal fetch_next_offset, DT[:paused].last

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_mom/occasional_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_mom/occasional_marking_spec.rb
@@ -50,4 +50,4 @@ DT[0].each do |offset|
 end
 
 # We should start from the only offset marked as consumed + 1
-assert_equal DT[:marked].first + 1, fetch_first_offset
+assert_equal DT[:marked].first + 1, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_mom/with_non_recoverable_slow_no_marking_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_mom/with_non_recoverable_slow_no_marking_error_spec.rb
@@ -58,4 +58,4 @@ end
 
 assert_equal [0, 1], DT[1].uniq
 assert DT[1].size >= 1
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_mom/without_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_mom/without_marking_spec.rb
@@ -43,4 +43,4 @@ DT[0].each do |offset|
   previous = offset
 end
 
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_vp/with_long_manual_pause_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_vp/with_long_manual_pause_spec.rb
@@ -36,4 +36,4 @@ start_karafka_and_wait_until do
   DT[:paused].size >= 3
 end
 
-assert DT[:paused].include?(fetch_first_offset)
+assert DT[:paused].include?(fetch_next_offset)

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_vp/without_intermediate_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_vp/without_intermediate_marking_spec.rb
@@ -35,6 +35,4 @@ start_karafka_and_wait_until do
   DT[0].size >= 1000
 end
 
-# All should be consumed.
-# If anything with message marking would be off, it would return an offset value
-assert !fetch_first_offset
+assert_equal 1000, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/time_limit_check_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/time_limit_check_spec.rb
@@ -33,4 +33,4 @@ end
 assert_equal elements[0..1], DT[0]
 
 # None of the offsets should have been committed
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/without_intermediate_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/without_intermediate_marking_spec.rb
@@ -54,4 +54,4 @@ start_karafka_and_wait_until do
 end
 
 # None of the offsets should have been committed
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom_vp/time_limit_check_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom_vp/time_limit_check_spec.rb
@@ -37,4 +37,4 @@ start_karafka_and_wait_until do
 end
 
 assert_equal elements[0..1].sort, DT[0].sort
-assert fetch_first_offset.zero?
+assert fetch_next_offset.zero?

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom_vp/with_hitting_limits_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom_vp/with_hitting_limits_spec.rb
@@ -52,4 +52,4 @@ DT[:times].each_with_index do |slot, index|
   assert_equal(5 * (index + 1), DT[:messages_times].count { |time| time < slot })
 end
 
-assert fetch_first_offset.zero?
+assert fetch_next_offset.zero?

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom_vp/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom_vp/with_non_recoverable_error_with_retries_spec.rb
@@ -64,4 +64,4 @@ assert_equal (0..99).to_a.sort - [3], DT[:offsets].sort.uniq
 
 assert_equal DT[:broken].last.last, elements[3]
 
-assert fetch_first_offset.zero?
+assert fetch_next_offset.zero?

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom_vp/with_one_partition_throttled_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom_vp/with_one_partition_throttled_spec.rb
@@ -59,4 +59,4 @@ start_karafka_and_wait_until do
 end
 
 assert DT[0].size < 3
-assert fetch_first_offset.zero?
+assert fetch_next_offset.zero?

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom_vp/with_recoverable_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom_vp/with_recoverable_error_spec.rb
@@ -56,4 +56,4 @@ end
 
 assert DT[:dlqed].empty?
 assert((DT[0].count { |offset| offset == 7 }) >= 2)
-assert fetch_first_offset.zero?
+assert fetch_next_offset.zero?

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom_vp/with_work_exceeding_throttle_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom_vp/with_work_exceeding_throttle_spec.rb
@@ -46,4 +46,4 @@ end
 # All messages should be received and seek should work correctly
 # Order may be not as expected due to random VPs
 assert_equal DT[0].sort, (0...DT[0].size).to_a.sort
-assert fetch_first_offset.zero?
+assert fetch_next_offset.zero?

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom_vp/without_hitting_limits_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom_vp/without_hitting_limits_spec.rb
@@ -43,4 +43,4 @@ end
 # VPed, so not in order
 assert_equal elements.sort, DT[0].sort
 assert_equal 1, DT.data.size
-assert fetch_first_offset.zero?
+assert fetch_next_offset.zero?

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_vp/marking_without_intermediate_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_vp/marking_without_intermediate_marking_spec.rb
@@ -34,6 +34,4 @@ start_karafka_and_wait_until do
   DT[0].size >= 1000
 end
 
-# All should be consumed.
-# If anything with message marking would be off, it would return an offset value
-assert !fetch_first_offset
+assert_equal 1000, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_vp/time_limit_check_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_vp/time_limit_check_spec.rb
@@ -38,4 +38,4 @@ end
 assert_equal elements[0..1].sort, DT[0].sort
 
 # Offset after first batch should be committed
-assert fetch_first_offset.positive?
+assert fetch_next_offset.positive?

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj/with_long_manual_pause_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj/with_long_manual_pause_spec.rb
@@ -31,4 +31,4 @@ start_karafka_and_wait_until do
   DT[:paused].size >= 3
 end
 
-assert_equal fetch_first_offset, DT[:paused].last
+assert_equal fetch_next_offset, DT[:paused].last

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/occasional_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/occasional_marking_spec.rb
@@ -49,4 +49,4 @@ DT[0].each do |offset|
 end
 
 # We should start from the only offset marked as consumed + 1
-assert_equal DT[:marked].first + 1, fetch_first_offset
+assert_equal DT[:marked].first + 1, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/with_non_recoverable_slow_no_marking_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/with_non_recoverable_slow_no_marking_error_spec.rb
@@ -59,4 +59,4 @@ end
 
 assert_equal [0, 1], DT[1].uniq
 assert DT[1].size >= 1
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/without_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/without_marking_spec.rb
@@ -42,4 +42,4 @@ DT[0].each do |offset|
   previous = offset
 end
 
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj_mom_vp/last_marking_without_intermediate_on_vp_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj_mom_vp/last_marking_without_intermediate_on_vp_spec.rb
@@ -42,4 +42,4 @@ start_karafka_and_wait_until do
   DT[0].sum >= 50
 end
 
-assert fetch_first_offset < 49
+assert fetch_next_offset < 49

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj_vp/without_intermediate_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj_vp/without_intermediate_marking_spec.rb
@@ -31,6 +31,4 @@ start_karafka_and_wait_until do
   DT[0].size >= 1000
 end
 
-# All should be consumed.
-# If anything with message marking would be off, it would return an offset value
-assert !fetch_first_offset
+assert_equal 1000, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/without_intermediate_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/without_intermediate_marking_spec.rb
@@ -52,4 +52,4 @@ start_karafka_and_wait_until do
 end
 
 # None of the offsets should have been committed
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/dlq/vp/marking_without_intermediate_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/vp/marking_without_intermediate_marking_spec.rb
@@ -30,6 +30,4 @@ start_karafka_and_wait_until do
   DT[0].size >= 1000
 end
 
-# All should be consumed.
-# If anything with message marking would be off, it would return an offset value
-assert !fetch_first_offset
+assert_equal 1000, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/default/saturated_before_revocation_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/default/saturated_before_revocation_spec.rb
@@ -40,10 +40,31 @@ end
 produce(DT.topic, '1', partition: 0)
 produce(DT.topic, '1', partition: 1)
 
+def trigger_rebalance
+  consumer = setup_rdkafka_consumer
+  consumer.subscribe(DT.topic)
+
+  first = false
+
+  10.times do
+    message = consumer.poll(1_000)
+
+    next unless message
+
+    first = message.offset
+
+    break
+  end
+
+  consumer.close
+
+  first
+end
+
 start_karafka_and_wait_until do
   sleep(0.1) while DT[:any].uniq.size < 2
 
-  fetch_first_offset
+  trigger_rebalance
 
   DT[:done] << true
 

--- a/spec/integrations/pro/consumption/strategies/lrj/default/with_auto_offset_management_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/default/with_auto_offset_management_spec.rb
@@ -29,4 +29,4 @@ start_karafka_and_wait_until do
   DT.key?(0)
 end
 
-assert_equal DT[0].last + 1, fetch_first_offset
+assert_equal DT[0].last + 1, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/default/with_long_manual_pause_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/default/with_long_manual_pause_spec.rb
@@ -33,4 +33,4 @@ start_karafka_and_wait_until do
   DT[:paused].size >= 3
 end
 
-assert_equal fetch_first_offset, DT[:paused].last
+assert_equal fetch_next_offset, DT[:paused].last

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr/with_auto_offset_management_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr/with_auto_offset_management_spec.rb
@@ -31,4 +31,4 @@ start_karafka_and_wait_until do
   DT[0].size > 1
 end
 
-assert_equal DT[0].last + 1, fetch_first_offset
+assert_equal DT[0].last + 1, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr/with_long_manual_pause_when_throttled_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr/with_long_manual_pause_when_throttled_spec.rb
@@ -35,4 +35,4 @@ start_karafka_and_wait_until do
   DT[:paused].size >= 3
 end
 
-assert_equal fetch_first_offset, DT[:paused].last
+assert_equal fetch_next_offset, DT[:paused].last

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/attempts_tracking_with_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/attempts_tracking_with_errors_spec.rb
@@ -46,4 +46,4 @@ DT[:attempts].each_slice(2) do |slice|
   assert_equal 2, slice[1]
 end
 
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/attempts_tracking_with_non_recoverable_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/attempts_tracking_with_non_recoverable_errors_spec.rb
@@ -32,4 +32,4 @@ start_karafka_and_wait_until do
 end
 
 assert (DT[:attempts] - (1..15).to_a).empty?, DT[:attempts]
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/attempts_tracking_without_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/attempts_tracking_without_errors_spec.rb
@@ -33,4 +33,4 @@ end
 
 DT[:attempts].each { |attempt| assert_equal 1, attempt, DT[:attempts] }
 
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/fast_non_throttled_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/fast_non_throttled_spec.rb
@@ -36,4 +36,4 @@ start_karafka_and_wait_until do
 end
 
 assert_equal payloads, DT[0]
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/occasional_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/occasional_marking_spec.rb
@@ -49,4 +49,4 @@ DT[0].each do |offset|
 end
 
 # We should start from the only offset marked as consumed + 1
-assert_equal DT[:marked].first + 1, fetch_first_offset
+assert_equal DT[:marked].first + 1, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/parallel_non_lrj_with_lrj_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/parallel_non_lrj_with_lrj_spec.rb
@@ -45,4 +45,4 @@ start_karafka_and_wait_until do
 end
 
 assert DT[:regular_time][0] < DT[:done_time][0]
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/processing_with_expired_throttling_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/processing_with_expired_throttling_spec.rb
@@ -40,4 +40,4 @@ start_karafka_and_wait_until do
 end
 
 assert_equal payloads, DT[0]
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/regular_processing_one_by_one_without_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/regular_processing_one_by_one_without_errors_spec.rb
@@ -29,4 +29,4 @@ start_karafka_and_wait_until do
 end
 
 assert DT[0].size >= 5
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/shutdown_order_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/shutdown_order_spec.rb
@@ -38,4 +38,4 @@ start_karafka_and_wait_until do
 end
 
 assert DT[0].last < DT[1].last
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/with_continuous_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/with_continuous_error_spec.rb
@@ -45,4 +45,4 @@ start_karafka_and_wait_until do
 end
 
 assert DT[0].count(0) > 1
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/with_long_manual_pause_when_throttled_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/with_long_manual_pause_when_throttled_spec.rb
@@ -41,4 +41,4 @@ start_karafka_and_wait_until do
 end
 
 assert_equal 1, DT[:paused].uniq.count
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/with_never_ending_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/with_never_ending_error_spec.rb
@@ -32,4 +32,4 @@ start_karafka_and_wait_until do
 end
 
 assert_equal [], (1..20).to_a - DT[:attempts], DT[:attempts]
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/with_throttle_and_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/with_throttle_and_error_spec.rb
@@ -50,4 +50,4 @@ assert_equal StandardError, DT[:errors].first[:error].class
 assert_equal 'consumer.consume.error', DT[:errors].first[:type]
 assert_equal 'error.occurred', DT[:errors].first.id
 assert_equal 5, DT[0].uniq.size
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/without_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/without_marking_spec.rb
@@ -42,4 +42,4 @@ DT[0].each do |offset|
   previous = offset
 end
 
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/attempts_tracking_with_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/attempts_tracking_with_errors_spec.rb
@@ -40,4 +40,4 @@ start_karafka_and_wait_until do
 end
 
 assert DT[:attempts].size >= 2, DT[:attempts]
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/attempts_tracking_with_non_recoverable_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/attempts_tracking_with_non_recoverable_errors_spec.rb
@@ -36,4 +36,4 @@ end
 
 assert (DT[:attempts] - (1..15).to_a).empty?, DT[:attempts]
 
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/attempts_tracking_without_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/attempts_tracking_without_errors_spec.rb
@@ -36,4 +36,4 @@ end
 
 DT[:attempts].each { |attempt| assert_equal 1, attempt, DT[:attempts] }
 
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/fast_non_throttled_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/fast_non_throttled_spec.rb
@@ -40,4 +40,4 @@ end
 
 # Not deterministic due to VPs
 assert_equal payloads.sort, DT[0].sort
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/occasional_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/occasional_marking_spec.rb
@@ -52,4 +52,4 @@ DT[0].each do |offset|
 end
 
 # We should start from the only offset marked as consumed + 1
-assert_equal DT[:marked].last + 1, fetch_first_offset
+assert_equal DT[:marked].last + 1, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/parallel_non_lrj_with_lrj_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/parallel_non_lrj_with_lrj_spec.rb
@@ -48,4 +48,4 @@ start_karafka_and_wait_until do
 end
 
 assert DT[:regular_time][0] < DT[:done_time][0]
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/processing_with_expired_throttling_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/processing_with_expired_throttling_spec.rb
@@ -43,4 +43,4 @@ start_karafka_and_wait_until do
 end
 
 assert_equal payloads, DT[0]
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/regular_processing_one_by_one_without_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/regular_processing_one_by_one_without_errors_spec.rb
@@ -32,4 +32,4 @@ start_karafka_and_wait_until do
 end
 
 assert DT[0].size >= 5
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/shutdown_order_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/shutdown_order_spec.rb
@@ -42,4 +42,4 @@ start_karafka_and_wait_until do
 end
 
 assert DT[0].last < DT[1].last
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/with_continuous_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/with_continuous_error_spec.rb
@@ -51,4 +51,4 @@ end
 
 assert DT[0].count(0) > 1
 
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/with_long_manual_pause_when_throttled_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/with_long_manual_pause_when_throttled_spec.rb
@@ -43,4 +43,4 @@ start_karafka_and_wait_until do
   DT[:paused].size >= 3
 end
 
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/with_never_ending_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/with_never_ending_error_spec.rb
@@ -35,4 +35,4 @@ start_karafka_and_wait_until do
 end
 
 assert_equal [], (1..20).to_a - DT[:attempts].uniq, DT[:attempts]
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/with_throttle_and_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/with_throttle_and_error_spec.rb
@@ -52,4 +52,4 @@ assert_equal StandardError, DT[:errors].first[:error].class
 assert_equal 'consumer.consume.error', DT[:errors].first[:type]
 assert_equal 'error.occurred', DT[:errors].first.id
 assert_equal 5, DT[0].uniq.size
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/without_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/without_marking_spec.rb
@@ -46,4 +46,4 @@ DT[0].sort.each do |offset|
   previous = offset
 end
 
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/mom/occasional_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/mom/occasional_marking_spec.rb
@@ -48,4 +48,4 @@ DT[0].each do |offset|
 end
 
 # We should start from the only offset marked as consumed + 1
-assert_equal DT[:marked].first + 1, fetch_first_offset
+assert_equal DT[:marked].first + 1, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/mom/without_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/mom/without_marking_spec.rb
@@ -41,4 +41,4 @@ DT[0].each do |offset|
   previous = offset
 end
 
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/mom_vp/without_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/mom_vp/without_marking_spec.rb
@@ -37,4 +37,4 @@ start_karafka_and_wait_until do
   DT[0].size >= 20
 end
 
-assert_equal 0, fetch_first_offset
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/mom/ftr_vp/marking_ahead_with_no_previous_in_batch_start_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/mom/ftr_vp/marking_ahead_with_no_previous_in_batch_start_spec.rb
@@ -38,4 +38,4 @@ start_karafka_and_wait_until do
   DT[:done].count.positive? && sleep(1)
 end
 
-assert_equal 0, fetch_first_offset, nil
+assert_equal 0, fetch_next_offset, nil

--- a/spec/integrations/pro/consumption/strategies/mom/vp/marking_ahead_with_no_previous_in_batch_start_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/mom/vp/marking_ahead_with_no_previous_in_batch_start_spec.rb
@@ -36,4 +36,4 @@ start_karafka_and_wait_until do
   DT[:done].count.positive? && sleep(1)
 end
 
-assert_equal 0, fetch_first_offset, nil
+assert_equal 0, fetch_next_offset, nil

--- a/spec/integrations/pro/consumption/strategies/mom/vp/with_partial_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/mom/vp/with_partial_marking_spec.rb
@@ -35,4 +35,4 @@ start_karafka_and_wait_until do
 end
 
 # Since we do middle offset marking, this should never have the last from max batch
-assert fetch_first_offset < DT[:lasts].max
+assert fetch_next_offset < DT[:lasts].max

--- a/spec/integrations/pro/consumption/strategies/vp/synchronized_with_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/synchronized_with_marking_spec.rb
@@ -36,5 +36,4 @@ start_karafka_and_wait_until do
   DT[0].size >= 100
 end
 
-# False here will mean there was nothing more to consume aside from the 100 we already did
-assert_equal false, fetch_first_offset
+assert_equal 100, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/vp/without_intermediate_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/without_intermediate_marking_spec.rb
@@ -29,6 +29,4 @@ start_karafka_and_wait_until do
   DT[0].size >= 1000
 end
 
-# All should be consumed.
-# If anything with message marking would be off, it would return an offset value
-assert !fetch_first_offset
+assert_equal 1000, fetch_next_offset

--- a/spec/integrations/pro/consumption/transactions/many_markings_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/many_markings_spec.rb
@@ -41,4 +41,4 @@ produce_many(DT.topic, DT.uuids(1))
 assert_equal '99', DT[:metadata].first
 
 # +1 from 99 because of the transaction marker
-assert_equal 101, fetch_first_offset
+assert_equal 100, fetch_next_offset

--- a/spec/integrations/pro/consumption/transactions/nested_handler_error_marking_impact_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/nested_handler_error_marking_impact_spec.rb
@@ -38,4 +38,4 @@ start_karafka_and_wait_until do
   DT.key?(:done)
 end
 
-assert_equal 1, fetch_first_offset
+assert_equal 1, fetch_next_offset

--- a/spec/integrations/pro/consumption/transactions/nested_handler_error_marking_pre_impact_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/nested_handler_error_marking_pre_impact_spec.rb
@@ -38,4 +38,4 @@ start_karafka_and_wait_until do
   DT.key?(:done)
 end
 
-assert_equal 1, fetch_first_offset
+assert_equal 1, fetch_next_offset

--- a/spec/integrations/pro/consumption/transactions/vps/all_ok_current_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/all_ok_current_spec.rb
@@ -54,4 +54,4 @@ end
 last = DT[:last].last
 
 assert_equal DT[:metadata].last, last
-assert_equal fetch_first_offset, false
+assert_equal fetch_next_offset, 100

--- a/spec/integrations/pro/consumption/transactions/vps/all_ok_exact_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/all_ok_exact_spec.rb
@@ -46,5 +46,5 @@ start_karafka_and_wait_until do
   DT[:done].uniq.size >= 10
 end
 
-assert_equal fetch_first_offset, false
+assert_equal fetch_next_offset, 100
 assert_equal DT[:metadata].last, '99'

--- a/spec/integrations/pro/consumption/transactions/vps/collapsed_transaction_error_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/collapsed_transaction_error_spec.rb
@@ -45,4 +45,4 @@ start_karafka_and_wait_until do
 end
 
 assert_equal DT[:metadata].last, ''
-assert_equal fetch_first_offset, 0
+assert_equal fetch_next_offset, 0

--- a/spec/integrations/pro/consumption/transactions/vps/collapsed_transaction_ok_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/collapsed_transaction_ok_spec.rb
@@ -43,4 +43,4 @@ start_karafka_and_wait_until do
 end
 
 assert_equal DT[:metadata].last, 'test-metadata'
-assert_equal fetch_first_offset, 1
+assert_equal fetch_next_offset, 1

--- a/spec/integrations/pro/consumption/transactions/vps/nested_handler_error_marking_impact_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/nested_handler_error_marking_impact_spec.rb
@@ -46,4 +46,4 @@ start_karafka_and_wait_until do
   DT.key?(:done)
 end
 
-assert fetch_first_offset > 0
+assert fetch_next_offset > 0

--- a/spec/integrations/pro/consumption/transactions/vps/nested_handler_error_marking_pre_impact_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/nested_handler_error_marking_pre_impact_spec.rb
@@ -46,4 +46,4 @@ start_karafka_and_wait_until do
   DT.key?(:done)
 end
 
-assert fetch_first_offset > 0
+assert fetch_next_offset > 0

--- a/spec/integrations/pro/consumption/transactions/vps/one_ok_rest_error_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/one_ok_rest_error_spec.rb
@@ -51,4 +51,4 @@ start_karafka_and_wait_until do
 end
 
 assert_equal DT[:metadata].uniq, %w[test-metadata]
-assert_equal fetch_first_offset, 1
+assert_equal fetch_next_offset, 1

--- a/spec/integrations/pro/consumption/transactions/vps/post_transaction_error_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/post_transaction_error_spec.rb
@@ -53,4 +53,4 @@ start_karafka_and_wait_until do
 end
 
 assert_equal DT[:metadata].last, 'second'
-assert_equal fetch_first_offset, 10
+assert_equal fetch_next_offset, 10

--- a/spec/integrations/pro/rails/active_job/long_running_jobs/with_shutdown_pickup_spec.rb
+++ b/spec/integrations/pro/rails/active_job/long_running_jobs/with_shutdown_pickup_spec.rb
@@ -46,4 +46,4 @@ end
 # Give Karafka time to finalize everything
 sleep(2)
 
-assert_equal DT[0][0] + 1, fetch_first_offset
+assert_equal DT[0][0] + 1, fetch_next_offset

--- a/spec/integrations/pro/rails/active_job/virtual_partitions/with_revocation_continuity_spec.rb
+++ b/spec/integrations/pro/rails/active_job/virtual_partitions/with_revocation_continuity_spec.rb
@@ -38,4 +38,4 @@ end
 sleep(1)
 
 # Intermediate jobs should be processed
-assert fetch_first_offset > 0
+assert fetch_next_offset > 0


### PR DESCRIPTION
close https://github.com/karafka/karafka/issues/1378

this PR shaves over 11 minutes from running CI. Since we run in parallel (3 processes as far as I remember) the total gain should be around 3-4 minutes.