### PR TITLE
Fix default deserializer inheritance on dynamically built admin topics fetches

### DIFF
--- a/lib/karafka/routing/router.rb
+++ b/lib/karafka/routing/router.rb
@@ -33,7 +33,16 @@ module Karafka
       # @note Please note, that in case of a new topic, it will have a newly built consumer group
       #   as well, that is not part of the routing.
       def find_or_initialize_by_name(name)
-        find_by(name: name) || Topic.new(name, ConsumerGroup.new(name))
+        existing_topic = find_by(name: name)
+
+        return existing_topic if existing_topic
+
+        virtual_topic = Topic.new(name, ConsumerGroup.new(name))
+
+        Karafka::Routing::Proxy.new(
+          virtual_topic,
+          Karafka::App.config.internal.routing.builder.defaults
+        ).target
       end
 
       module_function :find_by

--- a/spec/integrations/admin/read_topic/with_default_for_non_routed_topic_spec.rb
+++ b/spec/integrations/admin/read_topic/with_default_for_non_routed_topic_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# When using read_topic with a topic that is not part of the routing, it should use the defaults
+# deserializers defined if they are present instead of the "total" framework defaults
+
+setup_karafka
+
+class Custom
+  def initialize(result)
+    @result = result
+  end
+
+  def call(_message)
+    @result
+  end
+end
+
+draw_routes do
+  defaults do
+    deserializers(
+      payload: Custom.new(1),
+      key: Custom.new(2),
+      headers: Custom.new(3)
+    )
+  end
+end
+
+produce(DT.topic, '10')
+
+message = Karafka::Admin.read_topic(DT.topic, 0, 1).last
+assert_equal 1, message.payload
+assert_equal 2, message.key
+assert_equal 3, message.headers

--- a/spec/integrations/admin/read_topic/with_defaults_but_overwritten_in_routes_spec.rb
+++ b/spec/integrations/admin/read_topic/with_defaults_but_overwritten_in_routes_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# When having defaults but also having explicit definitions, defaults should not overwrite explicit
+# for admin
+
+setup_karafka
+
+class Custom
+  def initialize(result)
+    @result = result
+  end
+
+  def call(_message)
+    @result
+  end
+end
+
+draw_routes do
+  defaults do
+    deserializers(
+      payload: Custom.new(1),
+      key: Custom.new(2),
+      headers: Custom.new(3)
+    )
+  end
+
+  topic DT.topic do
+    active(false)
+    deserializers(
+      payload: Custom.new(4),
+      key: Custom.new(5),
+      headers: Custom.new(6)
+    )
+  end
+end
+
+produce(DT.topic, '10')
+
+message = Karafka::Admin.read_topic(DT.topic, 0, 1).last
+assert_equal 4, message.payload
+assert_equal 5, message.key
+assert_equal 6, message.headers


### PR DESCRIPTION
https://github.com/karafka/karafka/issues/2015