### PR TITLE
support custom errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This release contains **BREAKING** changes. Make sure to read and apply upgrade 
 - [Enhancement] Publish listeners status lifecycle events.
 - [Enhancement] Use proxy wrapper for Admin metadata requests.
 - [Enhancement] Use limited scope topic info data when operating on direct topics instead of full cluster queries.
+- [Enhancement] No longer raise `Karafka::UnsupportedCaseError` for not recognized error types to support dynamic errors reporting.
 - [Change] Do not create new proxy object to Rdkafka with certain low-level operations and re-use existing.
 - [Change] Update `karafka.erb` template with a placeholder for waterdrop and karafka error instrumentation.
 - [Fix] Pro Swarm liveness listener can report incorrect failure when dynamic multiplexing scales down.

--- a/lib/karafka/instrumentation/logger_listener.rb
+++ b/lib/karafka/instrumentation/logger_listener.rb
@@ -327,9 +327,10 @@ module Karafka
         when 'connection.client.unsubscribe.error'
           error "Client unsubscribe error occurred: #{error}"
           error details
+        # This handles any custom errors coming from places like Web-UI, etc
         else
-          # This should never happen. Please contact the maintainers
-          raise Errors::UnsupportedCaseError, event
+          error "#{type} error occurred: #{error}"
+          error details
         end
       end
 

--- a/spec/lib/karafka/instrumentation/logger_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/logger_listener_spec.rb
@@ -485,15 +485,11 @@ RSpec.describe_current do
       it { expect(Karafka.logger).to have_received(:error).with(message) }
     end
 
-    context 'when it is an unsupported error type' do
-      subject(:error_trigger) { listener.on_error_occurred(event) }
+    context 'when it is a different error type' do
+      let(:type) { 'different.error' }
+      let(:message) { "different.error error occurred: #{error}" }
 
-      # We use the before { trigger } for all other cases and not worth duplicating, that's why
-      # we overwrite it here
-      let(:trigger) { nil }
-      let(:type) { 'unsupported.error' }
-
-      it { expect { error_trigger }.to raise_error(Karafka::Errors::UnsupportedCaseError) }
+      it { expect(Karafka.logger).to have_received(:error).with(message) }
     end
   end
 end


### PR DESCRIPTION
this PR changes how we report unrecognized errors. Thanks to this change we will no longer raise and we will report, so we can also ship errors from web-ui, etc.