### PR TITLE
Give up on running .0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,7 @@ jobs:
         ruby:
           - '3.3'
           - '3.2'
-          # We run it against the oldest and the newest of a given major to make sure, that there
-          # are no syntax-sugars that we would use that were introduced down the road
           - '3.1'
-          - '3.1.0'
           - '3.0'
         include:
           - ruby: '3.3'


### PR DESCRIPTION
Similar to rdkafka, this should not be our policy when this can be upgraded easily.