### PR TITLE
Supports moving offset to `:earliest` and `:latest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka framework changelog
 
 ## 2.4.1 (Unreleased)
+- [Enhancement] Support `:earliest` and `:latest` in `Karafka::Admin#seek_consumer_group`.
 - [Fix] Support migrating via aliases and plan with aliases usage.
 
 ## 2.4.0 (2024-04-26)

--- a/lib/karafka/admin.rb
+++ b/lib/karafka/admin.rb
@@ -162,6 +162,18 @@ module Karafka
       #
       # @example Move offset to 5 seconds ago on partition 2
       #   Karafka::Admin.seek_consumer_group('group-id', { 'topic' => { 2 => 5.seconds.ago } })
+      #
+      # @example Move to the earliest offset on all the partitions of a topic
+      #   Karafka::Admin.seek_consumer_group('group-id', { 'topic' => :earliest })
+      #
+      # @example Move to the latest (high-watermark) offset on all the partitions of a topic
+      #   Karafka::Admin.seek_consumer_group('group-id', { 'topic' => :latest })
+      #
+      # @example Move offset of a single partition to earliest
+      #   Karafka::Admin.seek_consumer_group('group-id', { 'topic' => { 1 => :earliest } })
+      #
+      # @example Move offset of a single partition to latest
+      #   Karafka::Admin.seek_consumer_group('group-id', { 'topic' => { 1 => :latest } })
       def seek_consumer_group(consumer_group_id, topics_with_partitions_and_offsets)
         tpl_base = {}
 

--- a/lib/karafka/admin.rb
+++ b/lib/karafka/admin.rb
@@ -10,6 +10,12 @@ module Karafka
   #   Cluster on which operations are performed can be changed via `admin.kafka` config, however
   #   there is no multi-cluster runtime support.
   module Admin
+    # More or less number of seconds of 1 hundred years
+    # Used for time referencing that does not have to be accurate but needs to be big
+    HUNDRED_YEARS = 100 * 365.25 * 24 * 60 * 60
+
+    private_constant :HUNDRED_YEARS
+
     class << self
       # Allows us to read messages from the topic
       #
@@ -170,6 +176,29 @@ module Karafka
           else
             topic_info(topic)[:partition_count].times do |partition|
               tpl_base[topic][partition] = partitions_with_offsets
+            end
+          end
+        end
+
+        tpl_base.each_value do |partitions|
+          partitions.transform_values! do |position|
+            # This remap allows us to transform some special cases in a reference that can be
+            # understood by Kafka
+            case position
+            # Earliest is not always 0. When compacting/deleting it can be much later, that's why
+            # we fetch the oldest possible offset
+            when :earliest
+              Time.now - HUNDRED_YEARS
+            # Latest will always be the high-watermark offset and we can get it just by getting
+            # a future position
+            when :latest
+              Time.now + HUNDRED_YEARS
+            # Same as `:earliest`
+            when false
+              Time.now - HUNDRED_YEARS
+            # Regular offset case
+            else
+              position
             end
           end
         end

--- a/spec/integrations/admin/consumer_groups/seek_consumer_group/to_earliest_latest_par_partition_spec.rb
+++ b/spec/integrations/admin/consumer_groups/seek_consumer_group/to_earliest_latest_par_partition_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# We should be able to move the offset per partition using `:earliest` and `:latest`
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[partition] << message.offset
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer(Consumer)
+    config(partitions: 2)
+  end
+end
+
+10.times do
+  produce(DT.topic, '', partition: 0)
+  produce(DT.topic, '', partition: 1)
+end
+
+start_karafka_and_wait_until do
+  DT[0].size >= 10 &&
+    DT[1].size >= 10
+end
+
+Karafka::Admin.seek_consumer_group(
+  DT.consumer_group,
+  {
+    DT.topic => {
+      0 => :latest,
+      1 => :earliest
+    }
+  }
+)
+
+offsets_with_lags = Karafka::Admin.read_lags_with_offsets[DT.consumer_group][DT.topic]
+
+assert_equal 10, offsets_with_lags[0][:offset]
+assert_equal 0, offsets_with_lags[0][:lag]
+
+assert_equal 0, offsets_with_lags[1][:offset]
+assert_equal 10, offsets_with_lags[1][:lag]

--- a/spec/integrations/admin/consumer_groups/seek_consumer_group/to_earliest_on_topic_spec.rb
+++ b/spec/integrations/admin/consumer_groups/seek_consumer_group/to_earliest_on_topic_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# We should be able to move the the earliest offset by providing :earliest as the seek value on
+# the topic level
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[0] << message.offset
+    end
+  end
+end
+
+draw_routes(Consumer)
+
+10.times do
+  sleep(0.1)
+  produce(DT.topic, '')
+end
+
+start_karafka_and_wait_until do
+  DT[0].size >= 10
+end
+
+Karafka::Admin.seek_consumer_group(
+  DT.consumer_group,
+  { DT.topic => :earliest }
+)
+
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/admin/consumer_groups/seek_consumer_group/to_earliest_on_topic_via_false_spec.rb
+++ b/spec/integrations/admin/consumer_groups/seek_consumer_group/to_earliest_on_topic_via_false_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# We should be able to move the the earliest offset by providing `false` as the seek value on
+# the topic level
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[0] << message.offset
+    end
+  end
+end
+
+draw_routes(Consumer)
+
+10.times do
+  sleep(0.1)
+  produce(DT.topic, '')
+end
+
+start_karafka_and_wait_until do
+  DT[0].size >= 10
+end
+
+Karafka::Admin.seek_consumer_group(
+  DT.consumer_group,
+  { DT.topic => false }
+)
+
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/admin/consumer_groups/seek_consumer_group/to_latest_spec.rb
+++ b/spec/integrations/admin/consumer_groups/seek_consumer_group/to_latest_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# We should be able to move the the latest offset by providing :latest as the seek value on
+# the topic level
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[0] << message.offset
+    end
+  end
+end
+
+draw_routes(Consumer)
+
+10.times do
+  sleep(0.1)
+  produce(DT.topic, '')
+end
+
+start_karafka_and_wait_until do
+  DT[0].size >= 10
+end
+
+Karafka::Admin.seek_consumer_group(
+  DT.consumer_group,
+  { DT.topic => :latest }
+)
+
+assert_equal 10, fetch_next_offset


### PR DESCRIPTION
I decided not to provide negative lookups as this can be easily implemented already using `read_watermark_offsets`:

```ruby
# Move 100 behind the most recent on partition 2
highwatermark_offset = Karafka::Admin.read_watermark_offsets('topic', 2).last
Karafka::Admin.seek_consumer_group('group-id', { 'topic' => { 2 => highwatermark_offset - 100 } })
```

close https://github.com/karafka/karafka/issues/2063