### PR TITLE
add karafka-testing regression specs

### DIFF
--- a/spec/integrations/testing/rspec_pristine/Gemfile
+++ b/spec/integrations/testing/rspec_pristine/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'karafka', path: ENV.fetch('KARAFKA_GEM_DIR'), require: true
+gem 'karafka-testing'
+gem 'rspec'

--- a/spec/integrations/testing/rspec_pristine/assertions.rb
+++ b/spec/integrations/testing/rspec_pristine/assertions.rb
@@ -2,13 +2,11 @@
 
 # This code is suppose to run the spec correctly and should not crash
 
-require 'active_support'
-require 'active_support/test_case'
-require 'minitest'
-require 'minitest/autorun'
-require 'mocha/minitest'
 require_relative 'karafka'
-require 'karafka/testing/minitest/helpers'
+require 'rspec'
+require 'rspec/autorun'
+require 'karafka/testing'
+require 'karafka/testing/rspec/helpers'
 
 Karafka::App.setup
 
@@ -26,14 +24,14 @@ class ExampleConsumer < ApplicationConsumer
   end
 end
 
-class Test < ActiveSupport::TestCase
-  include Karafka::Testing::Minitest::Helpers
+RSpec.configure do |config|
+  config.include Karafka::Testing::RSpec::Helpers
+end
 
-  def setup
-    @consumer = @karafka.consumer_for(:example)
-  end
+RSpec.describe ExampleConsumer do
+  subject(:consumer) { karafka.consumer_for(:example) }
 
-  test 'consume' do
+  it 'expect not to fail' do
     Karafka.producer.produce_async(
       topic: :example,
       payload: { foo: 'bar' }.to_json,
@@ -41,8 +39,6 @@ class Test < ActiveSupport::TestCase
       headers: { 'test' => 'me' }
     )
 
-    @consumer.consume
+    consumer.consume
   end
 end
-
-Minitest.run

--- a/spec/integrations/testing/rspec_pristine/test_flow_with_marking_spec.rb
+++ b/spec/integrations/testing/rspec_pristine/test_flow_with_marking_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Karafka when used with minitest should work as expected when using a client reference
+# Covers this case: https://github.com/karafka/karafka-testing/pull/198
+
+require 'tmpdir'
+require 'fileutils'
+require 'open3'
+
+current_dir = File.expand_path(__dir__)
+
+# Runs a given command in a given dir and returns its exit code
+# @param dir [String]
+# @param cmd [String]
+# @return [Array<String, Integer>]
+def cmd(dir, cmd)
+  stdout, stderr, status = Open3.capture3(
+    "cd #{dir} && KARAFKA_GEM_DIR=#{ENV['KARAFKA_GEM_DIR']} #{cmd}"
+  )
+  ["#{stdout}\n#{stderr}", status.exitstatus]
+end
+
+Dir.mktmpdir do |dir|
+  FileUtils.cp(
+    File.join(current_dir, 'Gemfile'),
+    File.join(dir, 'Gemfile')
+  )
+
+  FileUtils.cp(
+    File.join(current_dir, 'assertions.rb'),
+    File.join(dir, 'assertions.rb')
+  )
+
+  Bundler.with_unbundled_env do
+    be_install = cmd(dir, 'bundle install')
+    assert_equal 0, be_install[1], be_install[0]
+
+    kr_install = cmd(dir, 'bundle exec karafka install')
+    assert_equal 0, kr_install[1], kr_install[0]
+
+    kr_run = cmd(dir, 'bundle exec rspec assertions.rb')
+    assert_equal 0, kr_run[1], kr_run[0]
+  end
+end


### PR DESCRIPTION
Adds specs to ensure deserializers for minitest and rspec work as expected.

ref https://github.com/karafka/karafka-testing/pull/203