### PR TITLE
Fix karafka.rb template typo

### DIFF
--- a/lib/karafka/templates/karafka.rb.erb
+++ b/lib/karafka/templates/karafka.rb.erb
@@ -59,7 +59,7 @@ class KarafkaApp < Karafka::App
     )
   )
 
-  # You can subscribe to all consumer related errors and record/track then that way
+  # You can subscribe to all consumer related errors and record/track them that way
   #
   # Karafka.monitor.subscribe 'error.occurred' do |event|
   #   type = event[:type]
@@ -68,7 +68,7 @@ class KarafkaApp < Karafka::App
   #   ErrorTracker.send_error(error, type, details)
   # end
 
-  # You can subscribe to all producer related errors and record/track then that way
+  # You can subscribe to all producer related errors and record/track them that way
   # Please note, that producer and consumer have their own notifications pipeline so you need to
   # setup error tracking independently for each of them
   #


### PR DESCRIPTION
Hey! Thanks for your hard work on the gem! Just started using it, exciting stuff! This PR just fixes a small typo in `karafka.rb`  template