### PR TITLE
Add some more error codes to early report

### DIFF
--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -553,6 +553,12 @@ module Karafka
           early_report = true
         when :transport # -195
           early_report = true
+        when :topic_authorization_failed # 29
+          early_report = true
+        when :group_authorization_failed # 30
+          early_report = true
+        when :cluster_authorization_failed # 31
+          early_report = true
         # @see
         # https://github.com/confluentinc/confluent-kafka-dotnet/issues/1366#issuecomment-821842990
         # This will be raised each time poll detects a non-existing topic. When auto creation is


### PR DESCRIPTION
Recently, after upgrading to Karafka 2.4.0 by mistake, I encountered this issue https://github.com/karafka/karafka/issues/2085. There was no error reported on staging and production servers, the Karafka process appeared to be up and running but didn't consume any messages. We had to enable the debug mode in local host to understand what went wrong.

So for errors like `topic_authorization_failed`, `group_authorization_failed` and `cluster_authorization_failed`, `rdkafka` will raise the error only on the first poll, from the second poll tick, the message will be always null and make it look good, but in fact, cause the entire `poll` return null result without any error: https://github.com/karafka/rdkafka-ruby/blob/2900f6aa0d281ef8c12918c076b1cbab3f0d86fe/lib/rdkafka/consumer.rb#L530-L531

Therefore, in this PR, I'm adding those codes to the list of early-report errors.