### PR TITLE
Provide ability to use custom VP reducers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka framework changelog
 
 ## 2.4.3 (Unreleased)
+- [Enhancement] Allow for customization of Virtual Partitions reducer for enhanced parallelization.
 - [Enhancement] Add more error codes to early report on polling issues (kidlab)
 - [Enhancement] Add `transport`, `network_exception` and `coordinator_load_in_progress` alongside `timed_out` to retryable errors for the proxy.
 - [Enhancement] Improve `strict_topics_namespacing` validation message.

--- a/config/locales/pro_errors.yml
+++ b/config/locales/pro_errors.yml
@@ -4,6 +4,7 @@ en:
       virtual_partitions.partitioner_respond_to_call: needs to be defined and needs to respond to `#call`
       virtual_partitions.max_partitions_format: needs to be equal or more than 1
       virtual_partitions.offset_metadata_strategy_format: needs to be either :exact or :current
+      virtual_partitions.reducer_format: "needs to respond to `#call`"
 
       long_running_job.active_format: needs to be either true or false
 

--- a/lib/karafka/pro/routing/features/virtual_partitions/config.rb
+++ b/lib/karafka/pro/routing/features/virtual_partitions/config.rb
@@ -22,6 +22,7 @@ module Karafka
             :partitioner,
             :max_partitions,
             :offset_metadata_strategy,
+            :reducer,
             keyword_init: true
           ) { alias_method :active?, :active }
         end

--- a/lib/karafka/pro/routing/features/virtual_partitions/contracts/topic.rb
+++ b/lib/karafka/pro/routing/features/virtual_partitions/contracts/topic.rb
@@ -31,6 +31,7 @@ module Karafka
               nested(:virtual_partitions) do
                 required(:active) { |val| [true, false].include?(val) }
                 required(:partitioner) { |val| val.nil? || val.respond_to?(:call) }
+                required(:reducer) { |val| val.respond_to?(:call) }
                 required(:max_partitions) { |val| val.is_a?(Integer) && val >= 1 }
                 required(:offset_metadata_strategy) { |val| %i[exact current].include?(val) }
               end

--- a/lib/karafka/pro/routing/features/virtual_partitions/topic.rb
+++ b/lib/karafka/pro/routing/features/virtual_partitions/topic.rb
@@ -26,18 +26,24 @@ module Karafka
             # @param offset_metadata_strategy [Symbol] how we should match the metadata for the
             #   offset. `:exact` will match the offset matching metadata and `:current` will select
             #   the most recently reported metadata
+            # @param reducer [nil, #call] reducer for VPs key. It allows for using a custom
+            #   reducer to achieve enhanced parallelization when the default reducer is not enough.
             # @return [VirtualPartitions] method that allows to set the virtual partitions details
             #   during the routing configuration and then allows to retrieve it
             def virtual_partitions(
               max_partitions: Karafka::App.config.concurrency,
               partitioner: nil,
-              offset_metadata_strategy: :current
+              offset_metadata_strategy: :current,
+              reducer: nil
             )
               @virtual_partitions ||= Config.new(
                 active: !partitioner.nil?,
                 max_partitions: max_partitions,
                 partitioner: partitioner,
-                offset_metadata_strategy: offset_metadata_strategy
+                offset_metadata_strategy: offset_metadata_strategy,
+                # If no reducer provided, we use this one. It just runs a modulo on the sum of
+                # a stringified version, providing fairly good distribution.
+                reducer: reducer || ->(virtual_key) { virtual_key.to_s.sum % max_partitions }
               )
             end
 

--- a/spec/integrations/pro/consumption/strategies/vp/round_robin_with_direct_reducer_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/round_robin_with_direct_reducer_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# When using a round-robin partitioner, Karafka should assign messages correctly to utilize all
+# VPs. We test two instances to make sure that they operate independently
+# Since the default reducer does not work perfectly with all concurrency settings, we can use a
+# custom reducer to match the virtual key with partitions 1:1.
+
+class RoundRobinPartitioner
+  def initialize
+    @cycle = (0...Karafka::App.config.concurrency).cycle
+  end
+
+  def call(_message)
+    @cycle.next
+  end
+end
+
+setup_karafka do |config|
+  config.concurrency = 11
+  config.max_messages = 100
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[topic.name] << object_id
+  end
+end
+
+draw_routes do
+  2.times do |i|
+    consumer_group DT.consumer_groups[i] do
+      topic DT.topics[i] do
+        consumer Consumer
+        filter VpStabilizer
+        virtual_partitions(
+          partitioner: RoundRobinPartitioner.new,
+          reducer: ->(virtual_key) { virtual_key }
+        )
+      end
+    end
+  end
+end
+
+produce_many(DT.topics[0], DT.uuids(200))
+produce_many(DT.topics[1], DT.uuids(200))
+
+# No specs needed, will hang if not working correctly
+start_karafka_and_wait_until do
+  DT[DT.topics[0]].uniq.size >= 11 && DT[DT.topics[1]].uniq.size >= 11
+end

--- a/spec/lib/karafka/pro/routing/features/virtual_partitions/contracts/topic_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/virtual_partitions/contracts/topic_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe_current do
       virtual_partitions: {
         active: true,
         partitioner: ->(_) { 1 },
+        reducer: ->(_) { 1 },
         max_partitions: 2,
         offset_metadata_strategy: :exact
       },
@@ -42,6 +43,12 @@ RSpec.describe_current do
 
   context 'when virtual partitions are active but no partitioner' do
     before { config[:virtual_partitions][:partitioner] = nil }
+
+    it { expect(check).not_to be_success }
+  end
+
+  context 'when there is no reducer' do
+    before { config[:virtual_partitions][:reducer] = nil }
 
     it { expect(check).not_to be_success }
   end

--- a/spec/lib/karafka/pro/routing/features/virtual_partitions/topic_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/virtual_partitions/topic_spec.rb
@@ -43,6 +43,62 @@ RSpec.describe_current do
     end
   end
 
+  describe '#reducer' do
+    subject(:reducer) { topic.virtual_partitions.reducer }
+
+    before { allow(Karafka::App.config).to receive(:concurrency).and_return(concurrency) }
+
+    context 'when using default reducer' do
+      context 'when concurrency is set to 1' do
+        let(:concurrency) { 1 }
+
+        it 'expect to reduce all to one value' do
+          reduced = Array.new(100) { |i| reducer.call(i) }
+
+          expect(reduced.uniq.size).to eq(1)
+        end
+
+        it 'expect to also reduce and other random stuff to 1' do
+          reduced = Array.new(100) { reducer.call(rand.to_s) }
+
+          expect(reduced.uniq.size).to eq(1)
+        end
+      end
+
+      context 'when concurrency is set to 5' do
+        let(:concurrency) { 5 }
+
+        it 'expect to reduce all to 5' do
+          reduced = Array.new(5) { |i| reducer.call(i) }
+
+          expect(reduced.uniq.size).to eq(5)
+        end
+      end
+
+      # yes 10, not 11 because this is fast but not perfect, this is why we give an option to use
+      # custom reducers
+      context 'when concurrency is set to 11' do
+        let(:concurrency) { 11 }
+
+        it 'expect to reduce all numericals to 10' do
+          reduced = Array.new(11) { |i| reducer.call(i) }
+
+          expect(reduced.uniq.size).to eq(10)
+        end
+      end
+
+      context 'when concurrency is set to 21' do
+        let(:concurrency) { 21 }
+
+        it 'expect to reduce all numericals to 17' do
+          reduced = Array.new(21) { |i| reducer.call(i) }
+
+          expect(reduced.uniq.size).to eq(17)
+        end
+      end
+    end
+  end
+
   describe '#to_h' do
     it { expect(topic.to_h[:virtual_partitions]).to eq(topic.virtual_partitions.to_h) }
   end


### PR DESCRIPTION
This PR extracts the default reducer code to a customizable reducer, allowing for the usage of custom reducers for better (wider) mapping of the virtual partition keys.

As shown in the included specs, the default reducer is good but may not cover all people's cases due to the nature of their keys or concurrency settings. This is compensated by giving them the ability to write their own.

close https://github.com/karafka/karafka/issues/2127