### PR TITLE
require waterdrop 2.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [Fix] Installer doesn't respect directories in `KARAFKA_BOOT_FILE`.
 - [Fix] Fix case where non absolute boot file path would not work as expected.
 - [Fix] Allow for installing Karafka in a non-existing (yet) directory
+- [Maintenance] Require `waterdrop` `>=` `2.7.3` to support idempotent producer detection.
 
 ## 2.4.2 (2024-05-14)
 - [Enhancement] Validate ActiveJob adapter custom producer format.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,6 @@ GEM
     factory_bot (6.4.6)
       activesupport (>= 5.0.0)
     ffi (1.17.0)
-    ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     karafka (2.4.3)
       base64 (~> 0.2)
       karafka-core (>= 2.4.0, < 2.5.0)
-      waterdrop (>= 2.7.0, < 3.0.0)
+      waterdrop (>= 2.7.3, < 3.0.0)
       zeitwerk (~> 2.3)
 
 GEM
@@ -35,6 +35,7 @@ GEM
     factory_bot (6.4.6)
       activesupport (>= 5.0.0)
     ffi (1.17.0)
+    ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.5)
@@ -84,7 +85,7 @@ GEM
     tilt (2.3.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    waterdrop (2.7.2)
+    waterdrop (2.7.3)
       karafka-core (>= 2.4.0, < 3.0.0)
       karafka-rdkafka (>= 0.15.1)
       zeitwerk (~> 2.3)

--- a/karafka.gemspec
+++ b/karafka.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'base64', '~> 0.2'
   spec.add_dependency 'karafka-core', '>= 2.4.0', '< 2.5.0'
-  spec.add_dependency 'waterdrop', '>= 2.7.0', '< 3.0.0'
+  spec.add_dependency 'waterdrop', '>= 2.7.3', '< 3.0.0'
   spec.add_dependency 'zeitwerk', '~> 2.3'
 
   spec.required_ruby_version = '>= 3.0.0'


### PR DESCRIPTION
make sure waterdrop 2.7.3 is required to be able to detect `idemponent?` on producers for altering in web ui