### PR TITLE
improve logger listener instrumentation and shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
 # Karafka framework changelog
 
 ## 2.4.4 (Unreleased)
+- [Enhancement] Print more extensive error info on forceful shutdown.
 - [Enhancement] Include `original_key` in the DLQ dispatch headers.
 - [Enhancement] Support embedding mode control management from the trap context.
 - [Enhancement] Make sure, that the listener thread is stopped before restarting.
+- [Fix] Do not block on hanging listener shutdown when invoking forceful shutdown.
 - [Fix] Static membership fencing error is not propagated explicitly enough.
 - [Fix] Make sure DLQ dispatches raw headers and not deserialized headers (same as payload).
+- [Fix] Fix a typo where `ms` in logger listener would not have space before it.
 - [Maintenance] Require `karafka-core` `>=` `2.4.3`.
 - [Maintenance] Allow for usage of `karafka-rdkafka` `~` `0.16` to support librdkafka `2.4.0`.
+- [Maintenance] Lower the precision reporting to 100 microseconds in the logger listener.
 
 ## 2.4.3 (2024-06-12)
 - [Enhancement] Allow for customization of Virtual Partitions reducer for enhanced parallelization.

--- a/lib/karafka/instrumentation/logger_listener.rb
+++ b/lib/karafka/instrumentation/logger_listener.rb
@@ -41,7 +41,7 @@ module Karafka
         return unless log_polling?
 
         listener = event[:caller]
-        time = event[:time]
+        time = event[:time].round(2)
         messages_count = event[:messages_buffer].size
 
         message = "[#{listener.id}] Polled #{messages_count} messages in #{time}ms"
@@ -69,14 +69,14 @@ module Karafka
       # @param event [Karafka::Core::Monitoring::Event] event details including payload
       def on_worker_processed(event)
         job = event[:job]
-        time = event[:time]
+        time = event[:time].round(2)
         job_type = job.class.to_s.split('::').last
         consumer = job.executor.topic.consumer
         topic = job.executor.topic.name
         partition = job.executor.partition
         info <<~MSG.tr("\n", ' ').strip!
           [#{job.id}] #{job_type} job for #{consumer}
-          on #{topic}/#{partition} finished in #{time}ms
+          on #{topic}/#{partition} finished in #{time} ms
         MSG
       end
 
@@ -306,7 +306,24 @@ module Karafka
           fatal "Runner crashed due to an error: #{error}"
           fatal details
         when 'app.stopping.error'
-          error 'Forceful Karafka server stop'
+          # Counts number of workers and listeners that were still active when forcing the
+          # shutdown. Please note, that unless all listeners are closed, workers will not finalize
+          # their operations as well.
+          # We need to check if listeners and workers are assigned as during super early stages of
+          # boot they are not.
+          listeners = Server.listeners ? Server.listeners.count(&:active?) : 0
+          workers = Server.workers ? Server.workers.count(&:alive?) : 0
+
+          message = <<~MSG.tr("\n", ' ').strip!
+            Forceful Karafka server stop with:
+            #{workers} active workers and
+            #{listeners} active listeners
+          MSG
+
+          error message
+        when 'app.forceful_stopping.error'
+          error "Forceful shutdown error occurred: #{error}"
+          error details
         when 'librdkafka.error'
           error "librdkafka internal error occurred: #{error}"
           error details

--- a/spec/lib/karafka/instrumentation/logger_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/logger_listener_spec.rb
@@ -441,6 +441,11 @@ RSpec.describe_current do
         'Forceful Karafka server stop with: 0 active workers and 0 active listeners'
       end
 
+      before do
+        Karafka::Server.listeners = []
+        Karafka::Server.workers = []
+      end
+
       it 'expect logger to log server stop' do
         expect(Karafka.logger).to have_received(:error).with(message).at_least(:once)
       end

--- a/spec/lib/karafka/instrumentation/logger_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/logger_listener_spec.rb
@@ -441,11 +441,6 @@ RSpec.describe_current do
         'Forceful Karafka server stop with: 0 active workers and 0 active listeners'
       end
 
-      before do
-        Karafka::Server.listeners = []
-        Karafka::Server.workers = []
-      end
-
       it 'expect logger to log server stop' do
         expect(Karafka.logger).to have_received(:error).with(message).at_least(:once)
       end

--- a/spec/lib/karafka/instrumentation/logger_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/logger_listener_spec.rb
@@ -436,7 +436,15 @@ RSpec.describe_current do
     context 'when it is an app.stopping.error' do
       let(:type) { 'app.stopping.error' }
       let(:payload) { { type: type, error: Karafka::Errors::ForcefulShutdownError.new } }
-      let(:message) { 'Forceful Karafka server stop' }
+
+      let(:message) do
+        'Forceful Karafka server stop with: 0 active workers and 0 active listeners'
+      end
+
+      before do
+        Karafka::Server.listeners = []
+        Karafka::Server.workers = []
+      end
 
       it 'expect logger to log server stop' do
         expect(Karafka.logger).to have_received(:error).with(message).at_least(:once)

--- a/spec/lib/karafka/instrumentation/logger_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/logger_listener_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe_current do
   let(:topic_name) { rand.to_s }
 
   before do
+    Karafka::Server.listeners = []
+    Karafka::Server.workers = []
+
     allow(Karafka.logger).to receive(:debug)
     allow(Karafka.logger).to receive(:info)
     allow(Karafka.logger).to receive(:error)
@@ -439,11 +442,6 @@ RSpec.describe_current do
 
       let(:message) do
         'Forceful Karafka server stop with: 0 active workers and 0 active listeners'
-      end
-
-      before do
-        Karafka::Server.listeners = []
-        Karafka::Server.workers = []
       end
 
       it 'expect logger to log server stop' do


### PR DESCRIPTION
similar to waterdrop we lower the noise of time reporting
additionally I've also improved the forceful shutdown to prevent a situation when we hang on listener shutdown despite forceful.

close https://github.com/karafka/karafka/issues/2158