### PR TITLE
bump karafka-testing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
-    karafka-testing (2.4.3)
+    karafka-testing (2.4.4)
       karafka (>= 2.4.0, < 2.5.0)
       waterdrop (>= 2.7.0)
     karafka-web (0.9.1)


### PR DESCRIPTION
superseeds: https://github.com/karafka/karafka/pull/2162 because renovate messes up the 3.4 tests.