### PR TITLE
Improve shutdown by breaking the unsubscribe loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka Framework Changelog
 
 ## 2.4.7 (Unreleased)
+- [Enhancement] Introduce a shutdown time limit for unsubscription wait.
 - [Fix] License identifier `LGPL-3.0` is deprecated for SPDX (#2177).
 
 ## 2.4.6 (2024-07-22)

--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -26,7 +26,12 @@ module Karafka
       # How many times should we retry polling in case of a failure
       MAX_POLL_RETRIES = 20
 
-      private_constant :MAX_POLL_RETRIES
+      # How much time of the total shutdown time can we wait for our manual unsubscribe before
+      # attempting to close without unsubscribe. We try to wait for 50% of the shutdown time
+      # before we move to a regular unsubscribe.
+      COOP_UNSUBSCRIBE_FACTOR = 0.5
+
+      private_constant :MAX_POLL_RETRIES, :COOP_UNSUBSCRIBE_FACTOR
 
       # Creates a new consumer instance.
       #
@@ -277,7 +282,7 @@ module Karafka
           @unsubscribing = true
 
           # Give 50% of time for the final close before we reach the forceful
-          max_wait = ::Karafka::App.config.shutdown_timeout * 0.5
+          max_wait = ::Karafka::App.config.shutdown_timeout * COOP_UNSUBSCRIBE_FACTOR
           used = 0
           stopped_at = monotonic_now
 


### PR DESCRIPTION
This PR breaks the unsubscribe loop and delegates the final shutdown to the close when there is no time. It prevents us from getting into a wait loop if librdkafka cannot  deal with the unsubscribe fast.
