### PR TITLE
track execution mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Karafka Framework Changelog
 
 ## 2.4.7 (Unreleased)
+- [Enhancement] Introduce `Karafka::Server.mode` to check in what mode Karafka process operates (`standalone`, `swarm`, `supervisor`, `embedded`).
 - [Enhancement] Ensure `max.poll.interval.ms` is always present and populate it with librdkafka default.
 - [Enhancement] Introduce a shutdown time limit for unsubscription wait.
+- [Enhancement] Tag with `mode:swarm` each of the running swarm consumers.
+- [Change] Tag with `mode:embedded` instead of `embedded` the embedded consumers.
 - [Fix] License identifier `LGPL-3.0` is deprecated for SPDX (#2177).
 - [Fix] Fix an issue where custom clusters would not have default settings populated same as the primary cluster.
 - [Fix] Fix Rspec warnings of nil mocks.

--- a/lib/karafka/cli/server.rb
+++ b/lib/karafka/cli/server.rb
@@ -89,6 +89,7 @@ module Karafka
         register_inclusions
         register_exclusions
 
+        Karafka::Server.execution_mode = :standalone
         Karafka::Server.run
       end
 

--- a/lib/karafka/cli/swarm.rb
+++ b/lib/karafka/cli/swarm.rb
@@ -23,6 +23,7 @@ module Karafka
         server.register_inclusions
         server.register_exclusions
 
+        Karafka::Server.execution_mode = :supervisor
         Karafka::Swarm::Supervisor.new.run
       end
     end

--- a/lib/karafka/embedded.rb
+++ b/lib/karafka/embedded.rb
@@ -27,7 +27,8 @@ module Karafka
         Thread.new do
           Thread.current.name = 'karafka.embedded'
 
-          Karafka::Process.tags.add(:execution_mode, 'embedded')
+          Karafka::Process.tags.add(:execution_mode, 'mode:embedded')
+          Karafka::Server.execution_mode = :embedded
           Karafka::Server.start
         end
       end

--- a/lib/karafka/server.rb
+++ b/lib/karafka/server.rb
@@ -19,6 +19,17 @@ module Karafka
       # Jobs queue
       attr_accessor :jobs_queue
 
+      # Mode in which the Karafka server is executed. It can be:
+      #
+      # - :standalone - regular karafka consumer process
+      # - :embedded - embedded in a different process and not supervised
+      # - :supervisor - swarm supervisor process
+      # - :swarm - one of swarm processes
+      #
+      # Sometimes it is important to know in what mode we operate, especially from UI perspective
+      # as not everything is possible when operating in non-standalone mode, etc.
+      attr_accessor :execution_mode
+
       # Method which runs app
       def run
         self.listeners = []

--- a/lib/karafka/swarm/node.rb
+++ b/lib/karafka/swarm/node.rb
@@ -68,6 +68,8 @@ module Karafka
           monitor.subscribe(liveness_listener)
           monitor.instrument('swarm.node.after_fork', caller: self)
 
+          Karafka::Process.tags.add(:execution_mode, 'mode:swarm')
+          Server.execution_mode = :swarm
           Server.run
 
           @writer.close

--- a/spec/integrations/consumption/no_long_wait_with_eof_spec.rb
+++ b/spec/integrations/consumption/no_long_wait_with_eof_spec.rb
@@ -13,6 +13,7 @@ end
 
 class Consumer < Karafka::BaseConsumer
   def consume
+    DT[:execution_mode] = Karafka::Server.execution_mode
     DT[0] << true
   end
 end
@@ -31,3 +32,5 @@ end
 start_karafka_and_wait_until do
   DT[0].size >= 10
 end
+
+assert_equal :standalone, DT[:execution_mode]

--- a/spec/integrations/embedding/quiet_spec.rb
+++ b/spec/integrations/embedding/quiet_spec.rb
@@ -6,6 +6,8 @@ setup_karafka
 
 class Consumer < Karafka::BaseConsumer
   def consume
+    DT[:execution_mode] = Karafka::Server.execution_mode
+
     messages.each do |message|
       DT[message.metadata.partition] << message.raw_payload
     end
@@ -38,6 +40,7 @@ sleep(5)
 10.times { Karafka::Embedded.stop }
 
 assert_equal elements, DT[0]
-assert_equal 2, DT.data.size
+assert_equal 3, DT.data.size
 assert_equal [1], DT[:shutdown]
 assert_equal [], DT[:revoked]
+assert_equal :embedded, DT[:execution_mode]

--- a/spec/integrations/swarm/dead_node_cleanup_spec.rb
+++ b/spec/integrations/swarm/dead_node_cleanup_spec.rb
@@ -14,6 +14,7 @@ pids = []
 
 Karafka::App.monitor.subscribe('swarm.manager.after_fork') do |event|
   pids << event[:node].pid
+  DT[:execution_mode] = Karafka::Process.execution_mode
 end
 
 READER, WRITER = IO.pipe
@@ -47,3 +48,5 @@ end
 pids.each do |pid|
   assert !zombie_process?(pid)
 end
+
+assert_equal :supervisor, DT[:execution_mode]

--- a/spec/integrations_helper.rb
+++ b/spec/integrations_helper.rb
@@ -333,8 +333,10 @@ def start_karafka_and_wait_until(mode: :server, reset_status: false, &block)
 
   case mode
   when :server
+    Karafka::Server.execution_mode = :standalone
     Karafka::Server.run
   when :swarm
+    Karafka::Server.execution_mode = :supervisor
     Karafka::Swarm::Supervisor.new.run
   else
     raise Karafka::Errors::UnsupportedCaseError, mode


### PR DESCRIPTION
this PR allows us to track the server execution mode. Useful when collecting data as web UI cannot run certain operations on embedded, etc.