### PR TITLE
Support `#eofed` consumer action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Karafka Framework Changelog
 
+## 2.4.8 (Unreleased)
+- [Feature] Introduce ability to react to `#eof` either from `#consume` or from `#eofed` when EOF without new messages.
+- [Enhancement] Provide `Consumer#eof?` to indicate reaching EOF.
+- [Enhancement] Always immediately report on `inconsistent_group_protocol` error.
+
 ## 2.4.7 (2024-08-01)
 - [Enhancement] Introduce `Karafka::Server.execution_mode` to check in what mode Karafka process operates (`standalone`, `swarm`, `supervisor`, `embedded`).
 - [Enhancement] Ensure `max.poll.interval.ms` is always present and populate it with librdkafka default.

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gemspec
 group :integrations do
   gem 'activejob', require: false
   gem 'karafka-testing', '>= 2.4.0', require: false
-  gem 'karafka-web', '>= 0.9.0', require: false
+  gem 'karafka-web', '>= 0.10.0.beta1', require: false
   gem 'rspec', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka (2.4.7)
+    karafka (2.4.8)
       base64 (~> 0.2)
       karafka-core (>= 2.4.3, < 2.5.0)
       waterdrop (>= 2.7.3, < 3.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,6 @@ GEM
     factory_bot (6.4.6)
       activesupport (>= 5.0.0)
     ffi (1.17.0)
-    ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     karafka (2.4.8)
       base64 (~> 0.2)
       karafka-core (>= 2.4.3, < 2.5.0)
+      karafka-rdkafka (>= 0.17.2)
       waterdrop (>= 2.7.3, < 3.0.0)
       zeitwerk (~> 2.3)
 
@@ -35,22 +36,23 @@ GEM
     factory_bot (6.4.6)
       activesupport (>= 5.0.0)
     ffi (1.17.0)
+    ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     karafka-core (2.4.4)
       karafka-rdkafka (>= 0.15.0, < 0.18.0)
-    karafka-rdkafka (0.17.1)
+    karafka-rdkafka (0.17.2)
       ffi (~> 1.15)
       mini_portile2 (~> 2.6)
       rake (> 12)
     karafka-testing (2.4.6)
       karafka (>= 2.4.0, < 2.5.0)
       waterdrop (>= 2.7.0)
-    karafka-web (0.9.1)
+    karafka-web (0.10.0.beta1)
       erubi (~> 1.4)
-      karafka (>= 2.4.0, < 2.5.0)
+      karafka (>= 2.4.7, < 2.5.0)
       karafka-core (>= 2.4.0, < 2.5.0)
       roda (~> 3.68, >= 3.69)
       tilt (~> 2.0)
@@ -58,9 +60,9 @@ GEM
     minitest (5.24.0)
     mutex_m (0.2.0)
     ostruct (0.6.0)
-    rack (3.1.5)
+    rack (3.1.7)
     rake (13.2.1)
-    roda (3.81.0)
+    roda (3.82.0)
       rack
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -100,7 +102,7 @@ DEPENDENCIES
   factory_bot
   karafka!
   karafka-testing (>= 2.4.0)
-  karafka-web (>= 0.9.0)
+  karafka-web (>= 0.10.0.beta1)
   ostruct
   rspec
   simplecov

--- a/karafka.gemspec
+++ b/karafka.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'base64', '~> 0.2'
   spec.add_dependency 'karafka-core', '>= 2.4.3', '< 2.5.0'
+  spec.add_dependency 'karafka-rdkafka', '>= 0.17.2'
   spec.add_dependency 'waterdrop', '>= 2.7.3', '< 3.0.0'
   spec.add_dependency 'zeitwerk', '~> 2.3'
 

--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -9,7 +9,7 @@ module Karafka
 
     extend Forwardable
 
-    def_delegators :@coordinator, :topic, :partition
+    def_delegators :@coordinator, :topic, :partition, :eofed?
 
     def_delegators :producer, :produce_async, :produce_sync, :produce_many_async,
                    :produce_many_sync

--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -31,7 +31,21 @@ module Karafka
       # before we move to a regular unsubscribe.
       COOP_UNSUBSCRIBE_FACTOR = 0.5
 
-      private_constant :MAX_POLL_RETRIES, :COOP_UNSUBSCRIBE_FACTOR
+      # Errors upon which we early report that something is off without retrying prior to the
+      # report
+      EARLY_REPORT_ERRORS = [
+        :inconsistent_group_protocol, # 23
+        :max_poll_exceeded, # -147
+        :network_exception, # 13
+        :transport, # -195
+        :topic_authorization_failed, # 29
+        :group_authorization_failed, # 30
+        :cluster_authorization_failed, # 31
+        # This can happen for many reasons, including issues with static membership being fenced
+        :fatal # -150
+      ].freeze
+
+      private_constant :MAX_POLL_RETRIES, :COOP_UNSUBSCRIBE_FACTOR, :EARLY_REPORT_ERRORS
 
       # Creates a new consumer instance.
       #
@@ -98,8 +112,17 @@ module Karafka
           # Fetch message within our time boundaries
           response = poll(time_poll.remaining)
 
-          # Put a message to the buffer if there is one
-          @buffer << response if response && response != :tick_time
+          case response
+          when :tick_time
+            nil
+          # We get a hash only in case of eof error
+          when Hash
+            @buffer.eof(response[:topic], response[:partition])
+          when nil
+            nil
+          else
+            @buffer << response
+          end
 
           # Upon polling rebalance manager might have been updated.
           # If partition revocation happens, we need to remove messages from revoked partitions
@@ -576,20 +599,7 @@ module Karafka
         # We want to report early on max poll interval exceeding because it may mean that the
         # underlying processing is taking too much time and it is not LRJ
         case e.code
-        when :max_poll_exceeded # -147
-          early_report = true
-        when :network_exception # 13
-          early_report = true
-        when :transport # -195
-          early_report = true
-        when :topic_authorization_failed # 29
-          early_report = true
-        when :group_authorization_failed # 30
-          early_report = true
-        when :cluster_authorization_failed # 31
-          early_report = true
-        # This can happen for many reasons, including issues with static membership being fenced
-        when :fatal # -150
+        when *EARLY_REPORT_ERRORS
           early_report = true
         # @see
         # https://github.com/confluentinc/confluent-kafka-dotnet/issues/1366#issuecomment-821842990
@@ -603,11 +613,12 @@ module Karafka
           # No sense in retrying when no topic/partition and we're no longer running
           retryable = false unless Karafka::App.running?
         # If we detect the end of partition which can happen if `enable.partition.eof` is set to
-        # true, we can just return nil fast. This will fast yield whatever set of messages we
+        # true, we can just return fast. This will fast yield whatever set of messages we
         # already have instead of waiting. This can be used for better latency control when we do
         # not expect a lof of lag and want to quickly move to processing.
+        # We can also pass the eof notion to the consumers for improved decision making.
         when :partition_eof
-          return nil
+          return e.details
         end
 
         if early_report || !retryable

--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -145,10 +145,11 @@ module Karafka
           time_poll.checkpoint
 
           # Finally once we've (potentially) removed revoked, etc, if no messages were returned
-          # and it was not an early poll exist, we can break.
+          # and it was not an early poll exist, we can break. We also break if we got the eof
+          # signaling to propagate it asap
           # Worth keeping in mind, that the rebalance manager might have been updated despite no
           # messages being returned during a poll
-          break unless response
+          break if response.nil? || response.is_a?(Hash)
         end
 
         @buffer

--- a/lib/karafka/connection/listener.rb
+++ b/lib/karafka/connection/listener.rb
@@ -330,28 +330,54 @@ module Karafka
       # given scheduler. It also handles the idle jobs when filtering API removed all messages
       # and we need to run house-keeping
       def build_and_schedule_flow_jobs
-        return if @messages_buffer.empty?
-
         consume_jobs = []
         idle_jobs = []
+        eofed_jobs = []
 
-        @messages_buffer.each do |topic, partition, messages|
+        @messages_buffer.each do |topic, partition, messages, eof|
+          # In case we did not receive any new messages without eof we skip.
+          # We may yield empty array here in case we have reached eof without new messages but in
+          # such cases, we can run an eof job
+          next if messages.empty? && !eof
+
           coordinator = @coordinators.find_or_create(topic, partition)
-          # Start work coordination for this topic partition
-          coordinator.start(messages)
+          coordinator.eofed = eof
 
+          # If we did not receive any messages and we did receive eof signal, we run the eofed
+          # jobs so user can take actions on reaching eof
+          if messages.empty? && eof
+            @partitioner.call(topic, messages, coordinator) do |group_id|
+              coordinator.increment(:eofed)
+              executor = @executors.find_or_create(topic, partition, group_id, coordinator)
+              eofed_jobs << @jobs_builder.eofed(executor)
+            end
+
+            next
+          end
+
+          # If it is not an eof and there are no ne messages, we just run house-keeping
+          #
           # We do not increment coordinator for idle job because it's not a user related one
           # and it will not go through a standard lifecycle. Same applies to revoked and shutdown
           if messages.empty?
+            # Start work coordination for this topic partition
+            coordinator.start(messages)
             coordinator.increment(:idle)
             executor = @executors.find_or_create(topic, partition, 0, coordinator)
             idle_jobs << @jobs_builder.idle(executor)
-          else
-            @partitioner.call(topic, messages, coordinator) do |group_id, partition_messages|
-              coordinator.increment(:consume)
-              executor = @executors.find_or_create(topic, partition, group_id, coordinator)
-              consume_jobs << @jobs_builder.consume(executor, partition_messages)
-            end
+
+            next
+          end
+
+          # If there are messages, it is irrelevant if eof or not as consumption needs to happen
+          #
+          # Start work coordination for this topic partition
+          coordinator.start(messages)
+
+          @partitioner.call(topic, messages, coordinator) do |group_id, partition_messages|
+            coordinator.increment(:consume)
+            executor = @executors.find_or_create(topic, partition, group_id, coordinator)
+            consume_jobs << @jobs_builder.consume(executor, partition_messages)
           end
         end
 
@@ -366,6 +392,11 @@ module Karafka
         unless consume_jobs.empty?
           consume_jobs.each(&:before_schedule)
           @scheduler.on_schedule_consumption(consume_jobs)
+        end
+
+        unless eofed_jobs.empty?
+          eofed_jobs.each(&:before_schedule)
+          @scheduler.on_schedule_eofed(eofed_jobs)
         end
       end
 

--- a/lib/karafka/connection/messages_buffer.rb
+++ b/lib/karafka/connection/messages_buffer.rb
@@ -23,9 +23,13 @@ module Karafka
       def initialize(subscription_group)
         @subscription_group = subscription_group
         @size = 0
+
         @groups = Hash.new do |topic_groups, topic|
           topic_groups[topic] = Hash.new do |partition_groups, partition|
-            partition_groups[partition] = []
+            partition_groups[partition] = {
+              eof: false,
+              messages: []
+            }
           end
         end
       end
@@ -33,24 +37,29 @@ module Karafka
       # Remaps raw messages from the raw messages buffer to Karafka messages
       # @param raw_messages_buffer [RawMessagesBuffer] buffer with raw messages
       def remap(raw_messages_buffer)
-        clear unless @size.zero?
+        clear
 
         # Since it happens "right after" we've received the messages, it is close enough it time
         # to be used as the moment we received messages.
         received_at = Time.now
 
-        raw_messages_buffer.each do |topic, partition, messages|
+        raw_messages_buffer.each do |topic, partition, messages, eof|
           @size += messages.count
 
           ktopic = @subscription_group.topics.find(topic)
 
-          @groups[topic][partition] = messages.map do |message|
+          built_messages = messages.map do |message|
             Messages::Builders::Message.call(
               message,
               ktopic,
               received_at
             )
           end
+
+          @groups[topic][partition] = {
+            eof: eof,
+            messages: built_messages
+          }
         end
       end
 
@@ -59,10 +68,11 @@ module Karafka
       # @yieldparam [String] topic name
       # @yieldparam [Integer] partition number
       # @yieldparam [Array<Karafka::Messages::Message>] messages from a given topic partition
+      # @yieldparam [Boolean] true if eof, false otherwise
       def each
         @groups.each do |topic, partitions|
-          partitions.each do |partition, messages|
-            yield(topic, partition, messages)
+          partitions.each do |partition, details|
+            yield(topic, partition, details[:messages], details[:eof])
           end
         end
       end

--- a/lib/karafka/connection/raw_messages_buffer.rb
+++ b/lib/karafka/connection/raw_messages_buffer.rb
@@ -83,8 +83,8 @@ module Karafka
       # again and we do want to ensure as few duplications as possible
       def uniq!
         @groups.each_value do |partitions|
-          partitions.each_value do |messages|
-            messages.uniq!(&:offset)
+          partitions.each_value do |details|
+            details[:messages].uniq!(&:offset)
           end
         end
 
@@ -111,8 +111,12 @@ module Karafka
 
       # Updates the messages count if we performed any operations that could change the state
       def recount!
-        @size = @groups.each_value.sum do |partitions|
-          partitions.each_value.map(&:count).sum
+        @size = 0
+
+        @groups.each_value do |partitions|
+          partitions.each_value do |details|
+            @size += details[:messages].size
+          end
         end
       end
     end

--- a/lib/karafka/constraints.rb
+++ b/lib/karafka/constraints.rb
@@ -15,13 +15,13 @@ module Karafka
         # Skip verification if web is not used at all
         return unless require_version('karafka/web')
 
-        # All good if version higher than 0.9.0.rc3 because we expect 0.9.0.rc3 or higher
-        return if version(Karafka::Web::VERSION) >= version('0.9.0.rc3')
+        # All good if version higher than 0.10.0 because we expect 0.10.0 or higher
+        return if version(Karafka::Web::VERSION) >= version('0.10.0.beta1')
 
         # If older web-ui used, we cannot allow it
         raise(
           Errors::DependencyConstraintsError,
-          'karafka-web < 0.9.0 is not compatible with this karafka version'
+          'karafka-web < 0.10.0 is not compatible with this karafka version'
         )
       end
 

--- a/lib/karafka/instrumentation/logger_listener.rb
+++ b/lib/karafka/instrumentation/logger_listener.rb
@@ -290,6 +290,9 @@ module Karafka
         when 'consumer.tick.error'
           error "Consumer on tick failed due to an error: #{error}"
           error details
+        when 'consumer.eofed.error'
+          error "Consumer on eofed failed due to an error: #{error}"
+          error details
         when 'consumer.after_consume.error'
           error "Consumer on after_consume failed due to an error: #{error}"
           error details

--- a/lib/karafka/instrumentation/notifications.rb
+++ b/lib/karafka/instrumentation/notifications.rb
@@ -65,6 +65,10 @@ module Karafka
         consumer.tick
         consumer.ticked
 
+        consumer.before_schedule_eofed
+        consumer.eof
+        consumer.eofed
+
         consumer.before_schedule_shutdown
         consumer.shutting_down
         consumer.shutdown

--- a/lib/karafka/pro/processing/eofed_non_blocking.rb
+++ b/lib/karafka/pro/processing/eofed_non_blocking.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Processing
+      module Jobs
+        # Non-Blocking version of the Eofed job
+        # We use this version for LRJ topics for cases where saturated resources would not allow
+        # to run this job for extended period of time. Under such scenarios, if we would not use
+        # a non-blocking one, we would reach max.poll.interval.ms.
+        class EofedNonBlocking < Periodic
+          # @param args [Array] any arguments accepted by `::Karafka::Processing::Jobs::Eofed`
+          def initialize(*args)
+            super
+            @non_blocking = true
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/processing/jobs/eofed_non_blocking.rb
+++ b/lib/karafka/pro/processing/jobs/eofed_non_blocking.rb
@@ -19,7 +19,7 @@ module Karafka
         # We use this version for LRJ topics for cases where saturated resources would not allow
         # to run this job for extended period of time. Under such scenarios, if we would not use
         # a non-blocking one, we would reach max.poll.interval.ms.
-        class EofedNonBlocking < Periodic
+        class EofedNonBlocking < ::Karafka::Processing::Jobs::Eofed
           # @param args [Array] any arguments accepted by `::Karafka::Processing::Jobs::Eofed`
           def initialize(*args)
             super

--- a/lib/karafka/pro/processing/jobs_builder.rb
+++ b/lib/karafka/pro/processing/jobs_builder.rb
@@ -34,6 +34,18 @@ module Karafka
         end
 
         # @param executor [Karafka::Pro::Processing::Executor]
+        # @return [Karafka::Processing::Jobs::Eofed] eofed job for non LRJ
+        # @return [Karafka::Processing::Jobs::EofedBlocking] eofed job that is
+        #   non-blocking, so when revocation job is scheduled for LRJ it also will not block
+        def eofed(executor)
+          if executor.topic.long_running_job?
+            Jobs::EofedNonBlocking.new(executor)
+          else
+            super
+          end
+        end
+
+        # @param executor [Karafka::Pro::Processing::Executor]
         # @return [Karafka::Processing::Jobs::Revoked] revocation job for non LRJ
         # @return [Karafka::Processing::Jobs::RevokedNonBlocking] revocation job that is
         #   non-blocking, so when revocation job is scheduled for LRJ it also will not block

--- a/lib/karafka/pro/processing/schedulers/default.rb
+++ b/lib/karafka/pro/processing/schedulers/default.rb
@@ -68,6 +68,7 @@ module Karafka
           alias on_schedule_shutdown schedule_fifo
           alias on_schedule_idle schedule_fifo
           alias on_schedule_periodic schedule_fifo
+          alias on_schedule_eofed schedule_fifo
 
           # This scheduler does not have anything to manage as it is a pass through and has no
           # state

--- a/lib/karafka/processing/coordinator.rb
+++ b/lib/karafka/processing/coordinator.rb
@@ -15,6 +15,10 @@ module Karafka
 
       attr_reader :pause_tracker, :seek_offset, :topic, :partition
 
+      # This can be set directly on the listener because it can be triggered on first run without
+      # any messages
+      attr_accessor :eofed
+
       def_delegators :@pause_tracker, :attempt, :paused?
 
       # @param topic [Karafka::Routing::Topic]
@@ -32,6 +36,7 @@ module Karafka
         @mutex = Mutex.new
         @marked = false
         @failure = false
+        @eofed = false
         @changed_at = monotonic_now
       end
 
@@ -144,6 +149,11 @@ module Karafka
       # @return [Boolean] is the partition we are processing revoked or not
       def revoked?
         @revoked
+      end
+
+      # @return [Boolean] did we reach end of partition when polling data
+      def eofed?
+        @eofed
       end
 
       # @return [Boolean] was the new seek offset assigned at least once. This is needed because

--- a/lib/karafka/processing/executor.rb
+++ b/lib/karafka/processing/executor.rb
@@ -104,6 +104,18 @@ module Karafka
         consumer.on_idle
       end
 
+      # Runs the code needed before eofed work is scheduled
+      def before_schedule_eofed
+        consumer.on_before_schedule_eofed
+      end
+
+      # Runs consumed eofed operation.
+      # This may run even when there were no messages received prior. This will however not
+      # run when eof is received together with messages as in such case `#consume` will run
+      def eofed
+        consumer.on_eofed
+      end
+
       # Runs code needed before revoked job is scheduled
       def before_schedule_revoked
         consumer.on_before_schedule_revoked if @consumer

--- a/lib/karafka/processing/jobs/eofed.rb
+++ b/lib/karafka/processing/jobs/eofed.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Karafka
+  module Processing
+    module Jobs
+      # Job that runs the eofed operation when we receive eof without messages alongside.
+      class Eofed < Base
+        # @param executor [Karafka::Processing::Executor] executor that is suppose to run the job
+        # @return [Eofed]
+        def initialize(executor)
+          @executor = executor
+          super()
+        end
+
+        # Runs code prior to scheduling this eofed job
+        def before_schedule
+          executor.before_schedule_eofed
+        end
+
+        # Runs the eofed job via an executor.
+        def call
+          executor.eofed
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/processing/jobs_builder.rb
+++ b/lib/karafka/processing/jobs_builder.rb
@@ -23,6 +23,12 @@ module Karafka
       def shutdown(executor)
         Jobs::Shutdown.new(executor)
       end
+
+      # @param executor [Karafka::Processing::Executor]
+      # @return [Karafka::Processing::Jobs::Eofed] eofed job
+      def eofed(executor)
+        Jobs::Eofed.new(executor)
+      end
     end
   end
 end

--- a/lib/karafka/processing/jobs_builder.rb
+++ b/lib/karafka/processing/jobs_builder.rb
@@ -13,6 +13,12 @@ module Karafka
       end
 
       # @param executor [Karafka::Processing::Executor]
+      # @return [Karafka::Processing::Jobs::Eofed] eofed job
+      def eofed(executor)
+        Jobs::Eofed.new(executor)
+      end
+
+      # @param executor [Karafka::Processing::Executor]
       # @return [Karafka::Processing::Jobs::Revoked] revocation job
       def revoked(executor)
         Jobs::Revoked.new(executor)
@@ -22,12 +28,6 @@ module Karafka
       # @return [Karafka::Processing::Jobs::Shutdown] shutdown job
       def shutdown(executor)
         Jobs::Shutdown.new(executor)
-      end
-
-      # @param executor [Karafka::Processing::Executor]
-      # @return [Karafka::Processing::Jobs::Eofed] eofed job
-      def eofed(executor)
-        Jobs::Eofed.new(executor)
       end
     end
   end

--- a/lib/karafka/processing/schedulers/default.rb
+++ b/lib/karafka/processing/schedulers/default.rb
@@ -24,6 +24,7 @@ module Karafka
         alias on_schedule_revocation on_schedule_consumption
         alias on_schedule_shutdown on_schedule_consumption
         alias on_schedule_idle on_schedule_consumption
+        alias on_schedule_eofed on_schedule_consumption
 
         # This scheduler does not have anything to manage as it is a pass through and has no state
         def on_manage

--- a/lib/karafka/processing/strategies/default.rb
+++ b/lib/karafka/processing/strategies/default.rb
@@ -17,6 +17,7 @@ module Karafka
         %i[
           consume
           idle
+          eofed
           revoked
           shutdown
         ].each do |action|
@@ -149,6 +150,16 @@ module Karafka
           nil
         ensure
           coordinator.decrement(:idle)
+        end
+
+        # Runs the consumer `#eofed` method with reporting
+        def handle_eofed
+          Karafka.monitor.instrument('consumer.eof', caller: self)
+          Karafka.monitor.instrument('consumer.eofed', caller: self) do
+            eofed
+          end
+        ensure
+          coordinator.decrement(:eofed)
         end
 
         # We need to always un-pause the processing in case we have lost a given partition.

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '2.4.7'
+  VERSION = '2.4.8'
 end

--- a/spec/integrations/consumption/eofed/error_recovery_spec.rb
+++ b/spec/integrations/consumption/eofed/error_recovery_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# When eof is in use and `#eofed` crashes, it should emit an error but it should not cause any
+# other crashes. Since `#eofed` does not deal with new data, it is not retried. It is up to the
+# user to deal with any retry policies he may want to have
+# eofed errors should not leak and processing should continue
+
+setup_karafka(allow_errors: %w[consumer.eofed.error]) do |config|
+  config.kafka[:'enable.partition.eof'] = true
+end
+
+Karafka.monitor.subscribe('error.occurred') do |event|
+  DT[:errors] << event[:type]
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do
+      DT[:count] << true
+    end
+  end
+
+  def eofed
+    raise
+  end
+end
+
+draw_routes(Consumer)
+
+start_karafka_and_wait_until do
+  produce_many(DT.topic, DT.uuids(1)) if DT.key?(:errors)
+
+  DT[:count].size >= 20
+end
+
+assert_equal DT[:errors].uniq, %w[consumer.eofed.error]

--- a/spec/integrations/consumption/eofed/marking_as_consumed_spec.rb
+++ b/spec/integrations/consumption/eofed/marking_as_consumed_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# We should be able to mark as consumed from the `#eofed`
+
+setup_karafka do |config|
+  config.kafka[:'enable.partition.eof'] = true
+  config.max_messages = 1
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume; end
+
+  def eofed
+    return if messages.empty?
+
+    mark_as_consumed!(messages.last)
+    DT[:marked] = true
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    manual_offset_management true
+  end
+end
+
+produce_many(DT.topic, DT.uuids(2))
+
+Thread.new do
+  loop do
+    produce_many(DT.topic, DT.uuids(1))
+    sleep(2)
+  rescue WaterDrop::Errors::ProducerClosedError
+    nil
+  end
+end
+
+start_karafka_and_wait_until do
+  DT.key?(:marked)
+end
+
+assert fetch_next_offset > 0

--- a/spec/integrations/consumption/eofed/post_consumption_spec.rb
+++ b/spec/integrations/consumption/eofed/post_consumption_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# When eof is in use we may not get it as it may go with messages polling via `#consume`
+# It may happen that eof goes via `#eofed` because of polling but we will correct this spec only
+# when this would happen as it should not be frequent
+
+setup_karafka do |config|
+  config.kafka[:'enable.partition.eof'] = true
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[:eofed] = eofed?
+  end
+
+  def eofed
+    raise
+  end
+
+  def shutdown
+    DT[:shutdown] = eofed?
+  end
+end
+
+draw_routes(Consumer)
+
+produce_many(DT.topic, DT.uuids(100))
+
+start_karafka_and_wait_until do
+  DT.key?(:eofed)
+end
+
+assert DT[:eofed]
+assert DT[:shutdown]

--- a/spec/integrations/consumption/eofed/post_eof_state_change_spec.rb
+++ b/spec/integrations/consumption/eofed/post_eof_state_change_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# When we had an eof but then not, it should be reflected in the `#eofed?` status
+
+setup_karafka do |config|
+  config.kafka[:'enable.partition.eof'] = true
+  config.max_messages = 10
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each { DT[:totals] << true }
+
+    DT[:eofed] << eofed?
+  end
+
+  def eofed
+    DT[:eofed] << eofed?
+  end
+end
+
+draw_routes(Consumer)
+
+start_karafka_and_wait_until do
+  if DT.key?(:eofed)
+    unless @produced
+      @produced = true
+      produce_many(DT.topic, DT.uuids(1000))
+    end
+
+    DT[:totals].size >= 100
+  else
+    false
+  end
+end
+
+current = true
+switch = false
+DT[:eofed].each do |eof|
+  unless switch && !eof
+    current = eof
+    switch = true
+  end
+
+  assert current
+end

--- a/spec/integrations/consumption/eofed/when_eof_reached_on_an_empty_topic_spec.rb
+++ b/spec/integrations/consumption/eofed/when_eof_reached_on_an_empty_topic_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# When eof is in use and we get it on an empty topic, we should not use consume and start with
+# `#eofed`. Shutdown should also work and respond to `#eofed?`
+
+setup_karafka do |config|
+  config.kafka[:'enable.partition.eof'] = true
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    raise
+  end
+
+  def eofed
+    DT[:eofed] = eofed?
+  end
+
+  def shutdown
+    DT[:shutdown] = eofed?
+  end
+end
+
+draw_routes(Consumer)
+
+start_karafka_and_wait_until do
+  DT.key?(:eofed)
+end
+
+assert DT[:eofed]
+assert DT[:shutdown]

--- a/spec/integrations/consumption/eofed/when_eof_reached_on_multiple_empty_topics_spec.rb
+++ b/spec/integrations/consumption/eofed/when_eof_reached_on_multiple_empty_topics_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# When eof is in use and we get it on an empty topic, we should not use consume and start with
+# `#eofed` per each partition and topic independently
+
+setup_karafka do |config|
+  config.kafka[:'enable.partition.eof'] = true
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    raise
+  end
+
+  def eofed
+    DT[:eofed] << [topic.name, partition, eofed?]
+  end
+
+  def shutdown
+    DT[:shutdown] << [topic.name, partition, eofed?]
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    config(partitions: 5)
+  end
+
+  topic DT.topics[1] do
+    consumer Consumer
+    config(partitions: 5)
+  end
+end
+
+start_karafka_and_wait_until do
+  DT[:eofed].size >= 10
+end
+
+assert_equal DT[:eofed], DT[:eofed].uniq
+assert_equal DT[:shutdown], DT[:shutdown].uniq

--- a/spec/integrations/pro/consumption/eofed/vps_with_eof_spec.rb
+++ b/spec/integrations/pro/consumption/eofed/vps_with_eof_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# When using virtual partitions with eof, each VP should receive its own `#eofed` execution.
+
+setup_karafka do |config|
+  config.kafka[:'enable.partition.eof'] = true
+  config.concurrency = 10
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume; end
+
+  def eofed
+    DT[:eofed] << object_id
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    virtual_partitions(
+      partitioner: lambda(&:raw_payload)
+    )
+  end
+end
+
+start_karafka_and_wait_until do
+  produce_many(DT.topic, DT.uuids(100))
+  sleep(5)
+
+  DT[:eofed].uniq.size >= 8
+end

--- a/spec/integrations/pro/consumption/periodic_jobs/with_eof_status_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/with_eof_status_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# We should be able to maintain eof status when ticking
+
+setup_karafka do |config|
+  config.kafka[:'enable.partition.eof'] = true
+  config.max_messages = 10
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    raise
+  end
+
+  def tick
+    DT[:ticks] << eofed?
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    periodic true
+  end
+end
+
+start_karafka_and_wait_until do
+  DT[:ticks].count >= 3
+end
+
+assert_equal DT[:ticks].uniq, [true]

--- a/spec/integrations/web/incompatible_version_pristine_0.7/console_with_rails_spec.rb
+++ b/spec/integrations/web/incompatible_version_pristine_0.7/console_with_rails_spec.rb
@@ -35,7 +35,7 @@ Bundler.with_unbundled_env do
   system!('cd app && bundle install')
   msg = system!('cd app && bundle exec karafka install', raise_error: false)
 
-  exit if msg.include?('karafka-web < 0.9.0 is not compatible with this karafka version')
+  exit if msg.include?('karafka-web < 0.10.0 is not compatible with this karafka version')
 
   raise InvalidExitCode
 end

--- a/spec/lib/karafka/instrumentation/logger_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/logger_listener_spec.rb
@@ -408,6 +408,13 @@ RSpec.describe_current do
       it { expect(Karafka.logger).to have_received(:error).with(message) }
     end
 
+    context 'when it is a consumer.eofed.error' do
+      let(:type) { 'consumer.eofed.error' }
+      let(:message) { "Consumer on eofed failed due to an error: #{error}" }
+
+      it { expect(Karafka.logger).to have_received(:error).with(message) }
+    end
+
     context 'when it is a consumer.after_consume.error' do
       let(:type) { 'consumer.after_consume.error' }
       let(:message) { "Consumer on after_consume failed due to an error: #{error}" }

--- a/spec/lib/karafka/pro/processing/jobs/eofed_non_blocking_spec.rb
+++ b/spec/lib/karafka/pro/processing/jobs/eofed_non_blocking_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:job) { described_class.new(executor) }
+
+  let(:executor) { build(:processing_executor) }
+
+  it { expect(job.non_blocking?).to eq(true) }
+  it { expect(described_class).to be < ::Karafka::Processing::Jobs::Eofed }
+end

--- a/spec/lib/karafka/pro/processing/jobs_builder_spec.rb
+++ b/spec/lib/karafka/pro/processing/jobs_builder_spec.rb
@@ -25,6 +25,24 @@ RSpec.describe_current do
     end
   end
 
+  describe '#eofed' do
+    context 'when it is a lrj topic' do
+      before { coordinator.topic.long_running_job true }
+
+      it 'expect to use the non blocking pro revocation job' do
+        job = builder.eofed(executor)
+        expect(job).to be_a(Karafka::Pro::Processing::Jobs::EofedNonBlocking)
+      end
+    end
+
+    context 'when it is not a lrj topic' do
+      it do
+        job = builder.eofed(executor)
+        expect(job).to be_a(Karafka::Processing::Jobs::Eofed)
+      end
+    end
+  end
+
   describe '#revoked' do
     context 'when it is a lrj topic' do
       before { coordinator.topic.long_running_job true }

--- a/spec/lib/karafka/processing/coordinator_spec.rb
+++ b/spec/lib/karafka/processing/coordinator_spec.rb
@@ -152,6 +152,18 @@ RSpec.describe_current do
     end
   end
 
+  describe '#eofed?' do
+    context 'when having newly created coordinator' do
+      it { expect(coordinator.eofed?).to eq(false) }
+    end
+
+    context 'when was eofed' do
+      before { coordinator.eofed = true }
+
+      it { expect(coordinator.eofed?).to eq(true) }
+    end
+  end
+
   describe '#manual_pause and manual_pause?' do
     context 'when there is no pause' do
       it { expect(coordinator.manual_pause?).to eq(false) }

--- a/spec/lib/karafka/processing/executor_spec.rb
+++ b/spec/lib/karafka/processing/executor_spec.rb
@@ -81,6 +81,58 @@ RSpec.describe_current do
     end
   end
 
+  describe '#before_schedule_eofed' do
+    before { allow(consumer).to receive(:on_before_schedule_eofed) }
+
+    context 'when consumer is defined as it was in use' do
+      before { executor.send(:consumer) }
+
+      it do
+        expect { executor.before_schedule_eofed }.not_to raise_error
+      end
+
+      it 'expect to run consumer on_before_schedule' do
+        executor.before_schedule_eofed
+        expect(consumer).to have_received(:on_before_schedule_eofed).with(no_args)
+      end
+    end
+
+    context 'when consumer is not defined as it was not in use' do
+      it do
+        expect { executor.before_schedule_eofed }.not_to raise_error
+      end
+
+      it 'expect to run consumer on_before_schedule' do
+        executor.before_schedule_eofed
+        expect(consumer).to have_received(:on_before_schedule_eofed).with(no_args)
+      end
+    end
+  end
+
+  describe '#eofed' do
+    before { allow(consumer).to receive(:on_eofed) }
+
+    context 'when the consumer was not yet used' do
+      before { executor.eofed }
+
+      it 'expect to run consumer as it reached eof without any data' do
+        expect(consumer).to have_received(:on_eofed)
+      end
+    end
+
+    context 'when the consumer was in use and exists' do
+      before do
+        allow(consumer).to receive(:on_consume)
+        executor.consume
+        executor.eofed
+      end
+
+      it 'expect to run consumer' do
+        expect(consumer).to have_received(:on_eofed).with(no_args)
+      end
+    end
+  end
+
   describe '#before_schedule_revoked' do
     before { allow(consumer).to receive(:on_before_schedule_revoked) }
 

--- a/spec/lib/karafka/processing/jobs/eofed_spec.rb
+++ b/spec/lib/karafka/processing/jobs/eofed_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:job) { described_class.new(executor) }
+
+  let(:executor) { build(:processing_executor) }
+
+  before do
+    allow(executor).to receive(:eofed)
+    job.call
+  end
+
+  it { expect(job.id).to eq(executor.id) }
+  it { expect(job.group_id).to eq(executor.group_id) }
+  it { expect(job.non_blocking?).to eq(false) }
+
+  it 'expect to run eofed on the executor' do
+    expect(executor).to have_received(:eofed)
+  end
+
+  describe '#before_schedule' do
+    before do
+      allow(executor).to receive(:before_schedule_eofed)
+      job.before_schedule
+    end
+
+    it 'expect to run before_schedule_eofed on the executor' do
+      expect(executor).to have_received(:before_schedule_eofed)
+    end
+  end
+end

--- a/spec/lib/karafka/processing/jobs_builder_spec.rb
+++ b/spec/lib/karafka/processing/jobs_builder_spec.rb
@@ -12,6 +12,13 @@ RSpec.describe_current do
     end
   end
 
+  describe '#eofed' do
+    it do
+      job = builder.eofed(executor)
+      expect(job).to be_a(Karafka::Processing::Jobs::Eofed)
+    end
+  end
+
   describe '#revoked' do
     it do
       job = builder.revoked(executor)


### PR DESCRIPTION
At the moment when consumer reaches eof there is no way to know about it directly and trigger appropriate actions.

There are cases such as corn or self-produced/consumed topics where knowledge about EOF is a key factor. This PR adds EOF notion to consumers.

close https://github.com/karafka/karafka/issues/2202