### PR TITLE
relax web constraints

### DIFF
--- a/lib/karafka/constraints.rb
+++ b/lib/karafka/constraints.rb
@@ -15,13 +15,13 @@ module Karafka
         # Skip verification if web is not used at all
         return unless require_version('karafka/web')
 
-        # All good if version higher than 0.10.0 because we expect 0.10.0 or higher
-        return if version(Karafka::Web::VERSION) >= version('0.10.0.beta1')
+        # All good if version higher than 0.9.0.rc3 because we expect 0.9.0.rc3 or higher
+        return if version(Karafka::Web::VERSION) >= version('0.9.0.rc3')
 
         # If older web-ui used, we cannot allow it
         raise(
           Errors::DependencyConstraintsError,
-          'karafka-web < 0.10.0 is not compatible with this karafka version'
+          'karafka-web < 0.9.0 is not compatible with this karafka version'
         )
       end
 

--- a/spec/integrations/web/incompatible_version_pristine_0.7/console_with_rails_spec.rb
+++ b/spec/integrations/web/incompatible_version_pristine_0.7/console_with_rails_spec.rb
@@ -35,7 +35,7 @@ Bundler.with_unbundled_env do
   system!('cd app && bundle install')
   msg = system!('cd app && bundle exec karafka install', raise_error: false)
 
-  exit if msg.include?('karafka-web < 0.10.0 is not compatible with this karafka version')
+  exit if msg.include?('karafka-web < 0.9.0 is not compatible with this karafka version')
 
   raise InvalidExitCode
 end


### PR DESCRIPTION
web 0.9 will work with karafka 2.4.8 as long as `#eofed` is not used, so no point in locking users.