### PR TITLE
skip require rails on env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Enhancement] Provide `Consumer#eofed?` to indicate reaching EOF.
 - [Enhancement] Always immediately report on `inconsistent_group_protocol` error.
 - [Enhancement] Reduce virtual partitioning to 1 partition when any partitioner execution in a partitioned batch crashes.
+- [Enhancement] Provide `KARAFKA_REQUIRE_RAILS` to disable default Rails `require` to run Karafka without Rails despite having Rails in the Gemfile.
 
 ## 2.4.7 (2024-08-01)
 - [Enhancement] Introduce `Karafka::Server.execution_mode` to check in what mode Karafka process operates (`standalone`, `swarm`, `supervisor`, `embedded`).

--- a/spec/integrations/rails/rails71_pristine/just-a-dependency/rails_setup_spec.rb
+++ b/spec/integrations/rails/rails71_pristine/just-a-dependency/rails_setup_spec.rb
@@ -30,3 +30,4 @@ rescue Karafka::Errors::MissingBootFileError
 end
 
 assert disabled
+assert Karafka.rails?

--- a/spec/integrations/rails/rails71_pristine/just-a-loaded-dependency/Gemfile
+++ b/spec/integrations/rails/rails71_pristine/just-a-loaded-dependency/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'karafka', path: ENV.fetch('KARAFKA_GEM_DIR')
+gem 'rails', '7.1.3', require: true

--- a/spec/integrations/rails/rails71_pristine/just-a-loaded-dependency/rails_setup_spec.rb
+++ b/spec/integrations/rails/rails71_pristine/just-a-loaded-dependency/rails_setup_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Karafka should be default require Rails when `KARAFKA_REQUIRE_RAILS` is not set to `"false"`
+
+ENV['KARAFKA_CLI'] = 'true'
+
+Bundler.require(:default)
+
+Bundler.require(:default)
+
+ENV['KARAFKA_BOOT_FILE'] = 'false'
+
+assert Karafka.rails?

--- a/spec/integrations/rails/rails71_pristine/just-a-not-loaded-dependency/Gemfile
+++ b/spec/integrations/rails/rails71_pristine/just-a-not-loaded-dependency/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'karafka', path: ENV.fetch('KARAFKA_GEM_DIR')
+gem 'rails', '7.1.3', require: true

--- a/spec/integrations/rails/rails71_pristine/just-a-not-loaded-dependency/rails_setup_spec.rb
+++ b/spec/integrations/rails/rails71_pristine/just-a-not-loaded-dependency/rails_setup_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Karafka should work without Rails even when Rails is in the Gemfile as long as the
+# KARAFKA_REQUIRE_RAILS is set to `"false"`
+
+ENV['KARAFKA_CLI'] = 'true'
+ENV['KARAFKA_REQUIRE_RAILS'] = 'false'
+
+Bundler.require(:default)
+
+Bundler.require(:default)
+
+ENV['KARAFKA_BOOT_FILE'] = 'false'
+
+assert !Karafka.rails?


### PR DESCRIPTION
This PR introduces an ENV variable to disable auto-rails require when user wants to run Rails-less Karafka despite having Rails in the Gemfile.