### PR TITLE
Add conditional eof handling

### DIFF
--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -116,6 +116,8 @@ en:
 
       active_format: needs to be either true or false
 
+      eofed.active_format: needs to be either true or false
+
       declaratives.partitions_format: needs to be more or equal to 1
       declaratives.active_format: needs to be true
       declaratives.replication_factor_format: needs to be more or equal to 1

--- a/lib/karafka/connection/listener.rb
+++ b/lib/karafka/connection/listener.rb
@@ -348,9 +348,14 @@ module Karafka
           # If we did not receive any messages and we did receive eof signal, we run the eofed
           # jobs so user can take actions on reaching eof
           if messages.empty? && eof
-            @executors.find_all_or_create(topic, partition, coordinator).each do |executor|
-              coordinator.increment(:eofed)
-              eofed_jobs << @jobs_builder.eofed(executor)
+            # If user wants to run the eofed jobs on eof we do it. Otherwise we just allow it to
+            # pass through. This allows to configure if user actually wants to have `#eofed`
+            # logic or if he wants to only use fast eof work yield
+            if coordinator.topic.eofed?
+              @executors.find_all_or_create(topic, partition, coordinator).each do |executor|
+                coordinator.increment(:eofed)
+                eofed_jobs << @jobs_builder.eofed(executor)
+              end
             end
 
             next
@@ -358,7 +363,7 @@ module Karafka
 
           coordinator.start(messages)
 
-          # If it is not an eof and there are no ne messages, we just run house-keeping
+          # If it is not an eof and there are no new messages, we just run house-keeping
           #
           # We do not increment coordinator for idle job because it's not a user related one
           # and it will not go through a standard lifecycle. Same applies to revoked and shutdown

--- a/lib/karafka/routing/features/eofed.rb
+++ b/lib/karafka/routing/features/eofed.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Karafka
+  module Routing
+    module Features
+      # Namespace for feature allowing to enable the `#eofed` jobs.
+      # We do not enable it always because users may only be interested in fast eofed yielding
+      # without running the `#eofed` operation at all. This safes on empty cycles of running
+      # pointless empty jobs.
+      class Eofed < Base
+      end
+    end
+  end
+end

--- a/lib/karafka/routing/features/eofed/config.rb
+++ b/lib/karafka/routing/features/eofed/config.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Karafka
+  module Routing
+    module Features
+      class Eofed < Base
+        # Config of this feature
+        Config = Struct.new(
+          :active,
+          keyword_init: true
+        ) { alias_method :active?, :active }
+      end
+    end
+  end
+end

--- a/lib/karafka/routing/features/eofed/contracts/topic.rb
+++ b/lib/karafka/routing/features/eofed/contracts/topic.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Karafka
+  module Routing
+    module Features
+      class Eofed < Base
+        # Eofed related contracts namespace
+        module Contracts
+          # Contract for eofed topic setup
+          class Topic < Karafka::Contracts::Base
+            configure do |config|
+              config.error_messages = YAML.safe_load(
+                File.read(
+                  File.join(Karafka.gem_root, 'config', 'locales', 'errors.yml')
+                )
+              ).fetch('en').fetch('validations').fetch('topic')
+            end
+
+            nested :eofed do
+              required(:active) { |val| [true, false].include?(val) }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/routing/features/eofed/topic.rb
+++ b/lib/karafka/routing/features/eofed/topic.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Karafka
+  module Routing
+    module Features
+      class Eofed < Base
+        # Routing topic eofed API
+        module Topic
+          # @param active [Boolean] should the `#eofed` job run on eof
+          def eofed(active = false)
+            @eofed ||= Config.new(
+              active: active
+            )
+          end
+
+          # @return [Boolean] Are `#eofed` jobs active
+          def eofed?
+            eofed.active?
+          end
+
+          # @return [Hash] topic setup hash
+          def to_h
+            super.merge(
+              eofed: eofed.to_h
+            ).freeze
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/integrations/consumption/eofed/error_recovery_spec.rb
+++ b/spec/integrations/consumption/eofed/error_recovery_spec.rb
@@ -25,7 +25,12 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-draw_routes(Consumer)
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    eofed true
+  end
+end
 
 start_karafka_and_wait_until do
   produce_many(DT.topic, DT.uuids(1)) if DT.key?(:errors)

--- a/spec/integrations/consumption/eofed/marking_as_consumed_spec.rb
+++ b/spec/integrations/consumption/eofed/marking_as_consumed_spec.rb
@@ -22,6 +22,7 @@ draw_routes do
   topic DT.topic do
     consumer Consumer
     manual_offset_management true
+    eofed true
   end
 end
 

--- a/spec/integrations/consumption/eofed/post_consumption_spec.rb
+++ b/spec/integrations/consumption/eofed/post_consumption_spec.rb
@@ -6,19 +6,19 @@
 
 setup_karafka do |config|
   config.kafka[:'enable.partition.eof'] = true
+  config.max_messages = 100
+  config.max_wait_time = 30_000
+  config.shutdown_timeout = 60_000
 end
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    DT[:eofed] = eofed?
+    DT[:eof] = eofed?
   end
 
+  # This should never happen because we do not reach eof without messages
   def eofed
     raise
-  end
-
-  def shutdown
-    DT[:shutdown] = eofed?
   end
 end
 
@@ -32,8 +32,5 @@ end
 produce_many(DT.topic, DT.uuids(100))
 
 start_karafka_and_wait_until do
-  DT.key?(:eofed)
+  DT[:eof] == true
 end
-
-assert DT[:eofed]
-assert DT[:shutdown]

--- a/spec/integrations/consumption/eofed/post_eof_state_change_spec.rb
+++ b/spec/integrations/consumption/eofed/post_eof_state_change_spec.rb
@@ -19,7 +19,12 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-draw_routes(Consumer)
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    eofed true
+  end
+end
 
 start_karafka_and_wait_until do
   if DT.key?(:eofed)

--- a/spec/integrations/consumption/eofed/when_eof_reached_on_an_empty_topic_spec.rb
+++ b/spec/integrations/consumption/eofed/when_eof_reached_on_an_empty_topic_spec.rb
@@ -21,7 +21,12 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-draw_routes(Consumer)
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    eofed true
+  end
+end
 
 start_karafka_and_wait_until do
   DT.key?(:eofed)

--- a/spec/integrations/consumption/eofed/when_eof_reached_on_multiple_empty_topics_spec.rb
+++ b/spec/integrations/consumption/eofed/when_eof_reached_on_multiple_empty_topics_spec.rb
@@ -25,11 +25,13 @@ draw_routes do
   topic DT.topics[0] do
     consumer Consumer
     config(partitions: 5)
+    eofed true
   end
 
   topic DT.topics[1] do
     consumer Consumer
     config(partitions: 5)
+    eofed true
   end
 end
 

--- a/spec/integrations/consumption/eofed/without_eofed_on_spec.rb
+++ b/spec/integrations/consumption/eofed/without_eofed_on_spec.rb
@@ -7,7 +7,9 @@ setup_karafka do |config|
 end
 
 class Consumer < Karafka::BaseConsumer
-  def consume; end
+  def consume
+    DT[:consumed] = true
+  end
 
   # This should never run because topic has `#eofed` set to false (default).
   def eofed
@@ -31,7 +33,7 @@ start_karafka_and_wait_until do
 
   sleep(5)
 
-  DT.key?(:eofed)
+  DT.key?(:consumed)
 end
 
 assert DT[:shutdown]

--- a/spec/integrations/pro/consumption/eofed/vps_with_eof_spec.rb
+++ b/spec/integrations/pro/consumption/eofed/vps_with_eof_spec.rb
@@ -18,6 +18,7 @@ end
 draw_routes do
   topic DT.topic do
     consumer Consumer
+    eofed true
     virtual_partitions(
       partitioner: lambda(&:raw_payload)
     )

--- a/spec/integrations/pro/consumption/periodic_jobs/with_eof_status_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/with_eof_status_spec.rb
@@ -21,6 +21,7 @@ draw_routes do
   topic DT.topic do
     consumer Consumer
     periodic true
+    eofed true
   end
 end
 

--- a/spec/lib/karafka/routing/features/eofed/config_spec.rb
+++ b/spec/lib/karafka/routing/features/eofed/config_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:config) { described_class.new(active: active) }
+
+  describe '#active?' do
+    context 'when active' do
+      let(:active) { true }
+
+      it { expect(config.active?).to eq(true) }
+    end
+
+    context 'when not active' do
+      let(:active) { false }
+
+      it { expect(config.active?).to eq(false) }
+    end
+  end
+end

--- a/spec/lib/karafka/routing/features/eofed/contracts/topic_spec.rb
+++ b/spec/lib/karafka/routing/features/eofed/contracts/topic_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:check) { described_class.new.call(config) }
+
+  let(:config) do
+    {
+      eofed: {
+        active: true
+      }
+    }
+  end
+
+  context 'when config is valid' do
+    it { expect(check).to be_success }
+  end
+
+  context 'when active flag is not boolean' do
+    before { config[:eofed][:active] = rand }
+
+    it { expect(check).not_to be_success }
+  end
+end

--- a/spec/lib/karafka/routing/features/eofed/topic_spec.rb
+++ b/spec/lib/karafka/routing/features/eofed/topic_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:topic) do
+    build(:routing_topic).tap do |topic|
+      topic.singleton_class.prepend described_class
+    end
+  end
+
+  describe '#eofed' do
+    context 'when we use eofed without any arguments' do
+      it 'expect to initialize with defaults' do
+        expect(topic.eofed.active?).to eq(false)
+      end
+    end
+
+    context 'when we use eofed with active status' do
+      it 'expect to use proper active status' do
+        topic.eofed(true)
+        expect(topic.eofed.active?).to eq(true)
+      end
+    end
+
+    context 'when we use eofed multiple times with different values' do
+      it 'expect to use proper active status' do
+        topic.eofed(true)
+        topic.eofed(false)
+        expect(topic.eofed.active?).to eq(true)
+      end
+    end
+  end
+
+  describe '#eofed?' do
+    context 'when active' do
+      before { topic.eofed(true) }
+
+      it { expect(topic.eofed?).to eq(true) }
+    end
+
+    context 'when not active' do
+      before { topic.eofed(false) }
+
+      it { expect(topic.eofed?).to eq(false) }
+    end
+  end
+
+  describe '#to_h' do
+    it { expect(topic.to_h[:eofed]).to eq(topic.eofed.to_h) }
+  end
+end

--- a/spec/lib/karafka/routing/features/eofed_spec.rb
+++ b/spec/lib/karafka/routing/features/eofed_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  it { expect(described_class).to be < ::Karafka::Routing::Features::Base }
+end

--- a/spec/lib/karafka/routing/topic_spec.rb
+++ b/spec/lib/karafka/routing/topic_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe_current do
         kafka deserializers max_messages max_wait_time initial_offset id name active consumer
         consumer_group_id pause_max_timeout pause_timeout pause_with_exponential_backoff
         subscription_group_details active_job consumer_persistence dead_letter_queue declaratives
-        inline_insights manual_offset_management
+        inline_insights manual_offset_management eofed
       ]
     end
 


### PR DESCRIPTION
This PR adds an `#eofed` routing setting to control if eofed should trigger a consumer action.

Without this it would not be possible to use fast eof messages yielding without triggering `#eofed` actions even if they would be pointless.