### PR TITLE
Provide `mark_after_dispatch` option for the granular DLQ control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.4.9 (Unreleased)
 - [Enhancement] Validate `eof` kafka scope flag when `eofed` in routing enabled.
+- [Enhancement] Provide `mark_after_dispatch` setting for granular DLQ marking control.
 
 ## 2.4.8 (2024-08-09)
 - **[Feature]** Introduce ability to react to `#eof` either from `#consume` or from `#eofed` when EOF without new messages.

--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -113,6 +113,7 @@ en:
       dead_letter_queue.transactional_format: needs to be either true or false
       dead_letter_queue.dispatch_method_format: 'needs to be either #produce_sync or #produce_async'
       dead_letter_queue.marking_method_format: 'needs to be either #mark_as_consumed or #mark_as_consumed!'
+      dead_letter_queue.mark_after_dispatch_format: 'needs to be true, false or nil'
 
       active_format: needs to be either true or false
 

--- a/lib/karafka/pro/processing/strategies/dlq/ftr_lrj_mom.rb
+++ b/lib/karafka/pro/processing/strategies/dlq/ftr_lrj_mom.rb
@@ -55,7 +55,11 @@ module Karafka
                     skippable_message, _marked = find_skippable_message
                     dispatch_to_dlq(skippable_message) if dispatch_to_dlq?
 
-                    coordinator.seek_offset = skippable_message.offset + 1
+                    if mark_after_dispatch?
+                      mark_dispatched_to_dlq(skippable_message)
+                    else
+                      coordinator.seek_offset = skippable_message.offset + 1
+                    end
                   end
                 end
               end

--- a/lib/karafka/pro/processing/strategies/dlq/ftr_mom.rb
+++ b/lib/karafka/pro/processing/strategies/dlq/ftr_mom.rb
@@ -57,9 +57,9 @@ module Karafka
             end
 
             # @return [Boolean] should we mark given message as consumed after dispatch. For
-            #  MOM strategies if user did not explicitly tell us to mark, we do not mark. Default is
-            #  `nil`, which means `false` in this case. If user provided alternative value, we go
-            #  with it.
+            #  MOM strategies if user did not explicitly tell us to mark, we do not mark. Default
+            #  is `nil`, which means `false` in this case. If user provided alternative value, we
+            #  go with it.
             #
             # @note Please note, this is the opposite behavior than in case of AOM strategies.
             def mark_after_dispatch?

--- a/lib/karafka/pro/processing/strategies/dlq/lrj_mom.rb
+++ b/lib/karafka/pro/processing/strategies/dlq/lrj_mom.rb
@@ -49,10 +49,26 @@ module Karafka
                     skippable_message, _marked = find_skippable_message
                     dispatch_to_dlq(skippable_message) if dispatch_to_dlq?
 
-                    coordinator.seek_offset = skippable_message.offset + 1
+                    if mark_after_dispatch?
+                      mark_dispatched_to_dlq(skippable_message)
+                    else
+                      coordinator.seek_offset = skippable_message.offset + 1
+                    end
                   end
                 end
               end
+            end
+
+            # @return [Boolean] should we mark given message as consumed after dispatch. For
+            #  MOM strategies if user did not explicitly tell us to mark, we do not mark. Default is
+            #  `nil`, which means `false` in this case. If user provided alternative value, we go
+            #  with it.
+            #
+            # @note Please note, this is the opposite behavior than in case of AOM strategies.
+            def mark_after_dispatch?
+              return false if topic.dead_letter_queue.mark_after_dispatch.nil?
+
+              topic.dead_letter_queue.mark_after_dispatch
             end
           end
         end

--- a/lib/karafka/pro/processing/strategies/dlq/lrj_mom.rb
+++ b/lib/karafka/pro/processing/strategies/dlq/lrj_mom.rb
@@ -60,9 +60,9 @@ module Karafka
             end
 
             # @return [Boolean] should we mark given message as consumed after dispatch. For
-            #  MOM strategies if user did not explicitly tell us to mark, we do not mark. Default is
-            #  `nil`, which means `false` in this case. If user provided alternative value, we go
-            #  with it.
+            #  MOM strategies if user did not explicitly tell us to mark, we do not mark. Default
+            #  is `nil`, which means `false` in this case. If user provided alternative value, we
+            #  go with it.
             #
             # @note Please note, this is the opposite behavior than in case of AOM strategies.
             def mark_after_dispatch?

--- a/lib/karafka/pro/processing/strategies/dlq/mom.rb
+++ b/lib/karafka/pro/processing/strategies/dlq/mom.rb
@@ -46,8 +46,8 @@ module Karafka
                       # Save the next offset we want to go with after moving given message to DLQ
                       # Without this, we would not be able to move forward and we would end up
                       # in an infinite loop trying to un-pause from the message we've already
-                      # processed. Of course, since it's a MoM a rebalance or kill, will move it back
-                      # as no offsets are being committed
+                      # processed. Of course, since it's a MoM a rebalance or kill, will move it
+                      # back as no offsets are being committed
                       coordinator.seek_offset = skippable_message.offset + 1
                     end
                   end

--- a/lib/karafka/pro/processing/strategies/dlq/mom.rb
+++ b/lib/karafka/pro/processing/strategies/dlq/mom.rb
@@ -40,15 +40,31 @@ module Karafka
                     skippable_message, = find_skippable_message
                     dispatch_to_dlq(skippable_message) if dispatch_to_dlq?
 
-                    # Save the next offset we want to go with after moving given message to DLQ
-                    # Without this, we would not be able to move forward and we would end up
-                    # in an infinite loop trying to un-pause from the message we've already
-                    # processed. Of course, since it's a MoM a rebalance or kill, will move it back
-                    # as no offsets are being committed
-                    coordinator.seek_offset = skippable_message.offset + 1
+                    if mark_after_dispatch?
+                      mark_dispatched_to_dlq(skippable_message)
+                    else
+                      # Save the next offset we want to go with after moving given message to DLQ
+                      # Without this, we would not be able to move forward and we would end up
+                      # in an infinite loop trying to un-pause from the message we've already
+                      # processed. Of course, since it's a MoM a rebalance or kill, will move it back
+                      # as no offsets are being committed
+                      coordinator.seek_offset = skippable_message.offset + 1
+                    end
                   end
                 end
               end
+            end
+
+            # @return [Boolean] should we mark given message as consumed after dispatch. For
+            #  MOM strategies if user did not explicitly tell us to mark, we do not mark. Default is
+            #  `nil`, which means `false` in this case. If user provided alternative value, we go
+            #  with it.
+            #
+            # @note Please note, this is the opposite behavior than in case of AOM strategies.
+            def mark_after_dispatch?
+              return false if topic.dead_letter_queue.mark_after_dispatch.nil?
+
+              topic.dead_letter_queue.mark_after_dispatch
             end
           end
         end

--- a/lib/karafka/pro/processing/strategies/dlq/mom.rb
+++ b/lib/karafka/pro/processing/strategies/dlq/mom.rb
@@ -56,9 +56,9 @@ module Karafka
             end
 
             # @return [Boolean] should we mark given message as consumed after dispatch. For
-            #  MOM strategies if user did not explicitly tell us to mark, we do not mark. Default is
-            #  `nil`, which means `false` in this case. If user provided alternative value, we go
-            #  with it.
+            #  MOM strategies if user did not explicitly tell us to mark, we do not mark. Default
+            #  is `nil`, which means `false` in this case. If user provided alternative value, we
+            #  go with it.
             #
             # @note Please note, this is the opposite behavior than in case of AOM strategies.
             def mark_after_dispatch?

--- a/lib/karafka/processing/strategies/dlq_mom.rb
+++ b/lib/karafka/processing/strategies/dlq_mom.rb
@@ -33,15 +33,34 @@ module Karafka
 
             dispatch_to_dlq(skippable_message)
 
-            # Save the next offset we want to go with after moving given message to DLQ
-            # Without this, we would not be able to move forward and we would end up
-            # in an infinite loop trying to un-pause from the message we've already processed
-            # Of course, since it's a MoM a rebalance or kill, will move it back as no
-            # offsets are being committed
-            coordinator.seek_offset = skippable_message.offset + 1
+            # We mark the broken message as consumed and move on
+            if mark_after_dispatch?
+              mark_dispatched_to_dlq(skippable_message)
+
+              return if revoked?
+            else
+              # Save the next offset we want to go with after moving given message to DLQ
+              # Without this, we would not be able to move forward and we would end up
+              # in an infinite loop trying to un-pause from the message we've already processed
+              # Of course, since it's a MoM a rebalance or kill, will move it back as no
+              # offsets are being committed
+              coordinator.seek_offset = skippable_message.offset + 1
+            end
 
             pause(coordinator.seek_offset, nil, false)
           end
+        end
+
+        # @return [Boolean] should we mark given message as consumed after dispatch. For
+        #  MOM strategies if user did not explicitly tell us to mark, we do not mark. Default is
+        #  `nil`, which means `false` in this case. If user provided alternative value, we go
+        #  with it.
+        #
+        # @note Please note, this is the opposite behavior than in case of AOM strategies.
+        def mark_after_dispatch?
+          return false if topic.dead_letter_queue.mark_after_dispatch.nil?
+
+          topic.dead_letter_queue.mark_after_dispatch
         end
       end
     end

--- a/lib/karafka/routing/features/dead_letter_queue/config.rb
+++ b/lib/karafka/routing/features/dead_letter_queue/config.rb
@@ -21,6 +21,9 @@ module Karafka
           :dispatch_method,
           # Should we use `#mark_as_consumed` or `#mark_as_consumed!` (in flows that mark)
           :marking_method,
+          # Should we mark as consumed after dispatch or not. True for most cases, except MOM where
+          # it is on user to decide (false by default)
+          :mark_after_dispatch,
           # Initialize with kwargs
           keyword_init: true
         ) do

--- a/lib/karafka/routing/features/dead_letter_queue/contracts/topic.rb
+++ b/lib/karafka/routing/features/dead_letter_queue/contracts/topic.rb
@@ -21,6 +21,7 @@ module Karafka
               required(:independent) { |val| [true, false].include?(val) }
               required(:max_retries) { |val| val.is_a?(Integer) && val >= 0 }
               required(:transactional) { |val| [true, false].include?(val) }
+              required(:mark_after_dispatch) { |val| [true, false, nil].include?(val) }
 
               required(:dispatch_method) do |val|
                 %i[produce_async produce_sync].include?(val)

--- a/lib/karafka/routing/features/dead_letter_queue/topic.rb
+++ b/lib/karafka/routing/features/dead_letter_queue/topic.rb
@@ -22,6 +22,9 @@ module Karafka
           #   whether dispatch on dlq should be sync or async (async by default)
           # @param marking_method [Symbol] `:mark_as_consumed` or `:mark_as_consumed!`. Describes
           #   whether marking on DLQ should be async or sync (async by default)
+          # @param mark_after_dispatch [Boolean, nil] Should we mark after dispatch. `nil` means
+          #   that the default strategy approach to marking will be used. `true` or `false`
+          #   overwrites the default
           # @return [Config] defined config
           def dead_letter_queue(
             max_retries: DEFAULT_MAX_RETRIES,
@@ -29,7 +32,8 @@ module Karafka
             independent: false,
             transactional: true,
             dispatch_method: :produce_async,
-            marking_method: :mark_as_consumed
+            marking_method: :mark_as_consumed,
+            mark_after_dispatch: nil
           )
             @dead_letter_queue ||= Config.new(
               active: !topic.nil?,
@@ -38,7 +42,8 @@ module Karafka
               independent: independent,
               transactional: transactional,
               dispatch_method: dispatch_method,
-              marking_method: marking_method
+              marking_method: marking_method,
+              mark_after_dispatch: mark_after_dispatch
             )
           end
 

--- a/spec/integrations/admin/configs_flow_spec.rb
+++ b/spec/integrations/admin/configs_flow_spec.rb
@@ -42,6 +42,9 @@ topic2.delete('delete.retention.ms')
 
 Karafka::Admin::Configs.alter(topic1, topic2)
 
+# Wait because it can take a bit of time for topic to update config setup in kafka
+sleep(1)
+
 # And lets now verify that those settings were indeed changed
 
 rtopic1, rtopic2 = Karafka::Admin::Configs.describe(topic1, topic2)

--- a/spec/integrations/consumption/strategies/dlq/without_marking_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/without_marking_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# When using DLQ without post error marking, the committed offset should remain unchanged
+
+setup_karafka(allow_errors: %w[consumer.consume.error])
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    raise StandardError
+  end
+end
+
+class DlqConsumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[:broken] << message.offset
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    dead_letter_queue(
+      topic: DT.topics[1],
+      max_retries: 1,
+      mark_after_dispatch: false
+    )
+  end
+
+  topic DT.topics[1] do
+    consumer DlqConsumer
+  end
+end
+
+elements = DT.uuids(5)
+produce_many(DT.topic, elements)
+
+start_karafka_and_wait_until do
+  DT[:broken].size >= 3
+end
+
+assert_equal fetch_next_offset, 0

--- a/spec/integrations/consumption/strategies/dlq_mom/with_error_handling_pipeline_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_error_handling_pipeline_spec.rb
@@ -23,13 +23,13 @@ draw_routes do
     topic DT.topics[i] do
       consumer Consumer
       dead_letter_queue(topic: DT.topics[i + 1], max_retries: 1)
-      manual_offset_management
+      manual_offset_management(true)
     end
   end
 
   topic DT.topics[4] do
     consumer LastConsumer
-    manual_offset_management
+    manual_offset_management(true)
   end
 end
 

--- a/spec/integrations/consumption/strategies/dlq_mom/with_marking_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_marking_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# When we do mark and user does not mark, we will not end up with an infinite loop.
+
+setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
+  config.max_messages = 6
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      raise StandardError if message.offset == 10
+
+      DT[:offsets] << message.offset
+
+      mark_as_consumed(message)
+    end
+  end
+end
+
+class DlqConsumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[:broken] << [message.offset, message.raw_payload]
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    dead_letter_queue(
+      topic: DT.topics[1],
+      max_retries: 1,
+      # The below one is set to false by default for MOM
+      mark_after_dispatch: true
+    )
+    manual_offset_management(true)
+  end
+
+  topic DT.topics[1] do
+    consumer DlqConsumer
+    manual_offset_management(true)
+  end
+end
+
+Karafka.monitor.subscribe('error.occurred') do |event|
+  next unless event[:type] == 'consumer.consume.error'
+
+  DT[:errors] << 1
+end
+
+elements = DT.uuids(100)
+produce_many(DT.topic, elements)
+
+start_karafka_and_wait_until do
+  DT[:offsets].uniq.count >= 99
+end
+
+# The skipped one should have never been processed
+assert !DT[:offsets].include?(10)
+
+# Offsets should have been committed
+assert_equal 100, fetch_next_offset

--- a/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_error_with_retries_spec.rb
@@ -28,12 +28,12 @@ draw_routes do
   topic DT.topics[0] do
     consumer Consumer
     dead_letter_queue(topic: DT.topics[1], max_retries: 2)
-    manual_offset_management
+    manual_offset_management(true)
   end
 
   topic DT.topics[1] do
     consumer DlqConsumer
-    manual_offset_management
+    manual_offset_management(true)
   end
 end
 

--- a/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_error_without_retries_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_error_without_retries_spec.rb
@@ -28,12 +28,12 @@ draw_routes do
   topic DT.topics[0] do
     consumer Consumer
     dead_letter_queue(topic: DT.topics[1], max_retries: 0)
-    manual_offset_management
+    manual_offset_management(true)
   end
 
   topic DT.topics[1] do
     consumer DlqConsumer
-    manual_offset_management
+    manual_offset_management(true)
   end
 end
 

--- a/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_first_message_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_first_message_spec.rb
@@ -28,12 +28,12 @@ draw_routes do
   topic DT.topics[0] do
     consumer Consumer
     dead_letter_queue(topic: DT.topics[1], max_retries: 2)
-    manual_offset_management
+    manual_offset_management(true)
   end
 
   topic DT.topics[1] do
     consumer DlqConsumer
-    manual_offset_management
+    manual_offset_management(true)
   end
 end
 

--- a/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_last_message_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_last_message_spec.rb
@@ -28,12 +28,12 @@ draw_routes do
   topic DT.topics[0] do
     consumer Consumer
     dead_letter_queue(topic: DT.topics[1], max_retries: 2)
-    manual_offset_management
+    manual_offset_management(true)
   end
 
   topic DT.topics[1] do
     consumer DlqConsumer
-    manual_offset_management
+    manual_offset_management(true)
   end
 end
 

--- a/spec/integrations/pro/consumption/strategies/dlq/default/without_post_dispatch_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/without_post_dispatch_marking_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# With marking disabled, the rolling of error should not cause offset storage on errors
+
+setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
+  config.max_messages = 10
+end
+
+DT[:offsets] = Set.new
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[:offsets] << message.offset
+
+      raise StandardError if message.offset >= 1
+
+      mark_as_consumed(message)
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    dead_letter_queue(
+      topic: DT.topics[1],
+      max_retries: 1,
+      mark_after_dispatch: false
+    )
+  end
+end
+
+produce_many(DT.topic, (0..10).to_a.map(&:to_s))
+
+start_karafka_and_wait_until do
+  DT[:offsets].size >= 10
+end
+
+assert_equal fetch_next_offset, 1

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_mom/with_post_dispatch_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_mom/with_post_dispatch_marking_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# When using manual offset management and not marking anything at all, we should not change
+# offsets until DLQ as long as DLQ has an explicit post-error marking (which is not the default)
+
+setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
+  config.max_messages = 5
+  # We set it here that way not too wait too long on stuff
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      # Mark so throttle won't start from 0
+      mark_as_consumed(message) if message.offset == 4
+
+      raise StandardError if message.offset == 5
+
+      DT[0] << message.offset
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    dead_letter_queue topic: DT.topics[1], max_retries: 1, mark_after_dispatch: true
+    long_running_job true
+    manual_offset_management true
+    throttling(limit: 5, interval: 5_000)
+  end
+end
+
+payloads = DT.uuids(50)
+produce_many(DT.topic, payloads)
+
+start_karafka_and_wait_until do
+  DT[0].size >= 20
+end
+
+assert_equal 6, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_error_handling_pipeline_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_error_handling_pipeline_spec.rb
@@ -23,14 +23,14 @@ draw_routes do
     topic DT.topics[i] do
       consumer Consumer
       dead_letter_queue(topic: DT.topics[i + 1], max_retries: 1)
-      manual_offset_management
+      manual_offset_management(true)
       throttling(limit: 50, interval: 5_000)
     end
   end
 
   topic DT.topics[4] do
     consumer LastConsumer
-    manual_offset_management
+    manual_offset_management(true)
     throttling(limit: 50, interval: 5_000)
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_error_and_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_error_and_marking_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# When non-recoverable error happens and we want explicit marking, it should mark
+
+setup_karafka(allow_errors: %w[consumer.consume.error])
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      raise StandardError if message.offset == 10
+
+      DT[:offsets] << message.offset
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    dead_letter_queue(topic: DT.topics[1], max_retries: 0, mark_after_dispatch: true)
+    manual_offset_management true
+    throttling(limit: 50, interval: 5_000)
+  end
+end
+
+elements = DT.uuids(100)
+produce_many(DT.topic, elements)
+
+start_karafka_and_wait_until do
+  DT[:offsets].uniq.count >= 99
+end
+
+assert_equal 11, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_error_with_retries_spec.rb
@@ -28,13 +28,13 @@ draw_routes do
   topic DT.topics[0] do
     consumer Consumer
     dead_letter_queue(topic: DT.topics[1], max_retries: 2)
-    manual_offset_management
+    manual_offset_management(true)
     throttling(limit: 50, interval: 5_000)
   end
 
   topic DT.topics[1] do
     consumer DlqConsumer
-    manual_offset_management
+    manual_offset_management(true)
     throttling(limit: 50, interval: 5_000)
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_error_without_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_error_without_retries_spec.rb
@@ -28,13 +28,13 @@ draw_routes do
   topic DT.topics[0] do
     consumer Consumer
     dead_letter_queue(topic: DT.topics[1], max_retries: 0)
-    manual_offset_management
+    manual_offset_management(true)
     throttling(limit: 50, interval: 5_000)
   end
 
   topic DT.topics[1] do
     consumer DlqConsumer
-    manual_offset_management
+    manual_offset_management(true)
     throttling(limit: 50, interval: 5_000)
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_first_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_first_message_spec.rb
@@ -28,13 +28,13 @@ draw_routes do
   topic DT.topics[0] do
     consumer Consumer
     dead_letter_queue(topic: DT.topics[1], max_retries: 2)
-    manual_offset_management
+    manual_offset_management(true)
     throttling(limit: 50, interval: 5_000)
   end
 
   topic DT.topics[1] do
     consumer DlqConsumer
-    manual_offset_management
+    manual_offset_management(true)
     throttling(limit: 50, interval: 5_000)
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_last_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_last_message_spec.rb
@@ -28,13 +28,13 @@ draw_routes do
   topic DT.topics[0] do
     consumer Consumer
     dead_letter_queue(topic: DT.topics[1], max_retries: 2)
-    manual_offset_management
+    manual_offset_management(true)
     throttling(limit: 50, interval: 5_000)
   end
 
   topic DT.topics[1] do
     consumer DlqConsumer
-    manual_offset_management
+    manual_offset_management(true)
     throttling(limit: 50, interval: 5_000)
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/non_recoverable_with_dispatch_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/non_recoverable_with_dispatch_marking_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Upon non-recoverable errors and the DLQ dispatch with marking, Karafka should mark
+
+class Listener
+  def on_error_occurred(event)
+    DT[:errors] << event
+  end
+end
+
+Karafka.monitor.subscribe(Listener.new)
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 10
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      raise StandardError if message.offset == 1 || message.offset == 25
+
+      DT[0] << message.offset
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    long_running_job true
+    dead_letter_queue topic: DT.topics[1], max_retries: 0, mark_after_dispatch: true
+    manual_offset_management true
+  end
+end
+
+produce_many(DT.topics[0], DT.uuids(50))
+
+start_karafka_and_wait_until do
+  DT[:errors].size >= 2 && DT[0].count >= 46
+end
+
+assert_equal fetch_next_offset, 26

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/with_manual_seek_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/with_manual_seek_spec.rb
@@ -20,7 +20,7 @@ draw_routes do
   topic DT.topics[0] do
     consumer Consumer
     long_running_job true
-    manual_offset_management
+    manual_offset_management(true)
     dead_letter_queue topic: DT.topics[1]
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/non_recoverable_with_dispatch_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/non_recoverable_with_dispatch_marking_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Upon non-recoverable errors and the DLQ dispatch with marking, Karafka should mark
+
+class Listener
+  def on_error_occurred(event)
+    DT[:errors] << event
+  end
+end
+
+Karafka.monitor.subscribe(Listener.new)
+
+setup_karafka(allow_errors: true) do |config|
+  config.max_messages = 10
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      raise StandardError if message.offset == 1 || message.offset == 25
+
+      DT[0] << message.offset
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    dead_letter_queue topic: DT.topics[1], max_retries: 0, mark_after_dispatch: true
+    manual_offset_management true
+  end
+end
+
+produce_many(DT.topics[0], DT.uuids(50))
+
+start_karafka_and_wait_until do
+  DT[:errors].size >= 2 && DT[0].count >= 46
+end
+
+assert_equal fetch_next_offset, 26

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/with_error_handling_pipeline_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/with_error_handling_pipeline_spec.rb
@@ -23,13 +23,13 @@ draw_routes do
     topic DT.topics[i] do
       consumer Consumer
       dead_letter_queue(topic: DT.topics[i + 1], max_retries: 1)
-      manual_offset_management
+      manual_offset_management(true)
     end
   end
 
   topic DT.topics[4] do
     consumer LastConsumer
-    manual_offset_management
+    manual_offset_management(true)
   end
 end
 

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/with_non_recoverable_error_with_retries_spec.rb
@@ -28,12 +28,12 @@ draw_routes do
   topic DT.topics[0] do
     consumer Consumer
     dead_letter_queue(topic: DT.topics[1], max_retries: 2)
-    manual_offset_management
+    manual_offset_management(true)
   end
 
   topic DT.topics[1] do
     consumer DlqConsumer
-    manual_offset_management
+    manual_offset_management(true)
   end
 end
 

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/with_non_recoverable_error_without_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/with_non_recoverable_error_without_retries_spec.rb
@@ -28,12 +28,12 @@ draw_routes do
   topic DT.topics[0] do
     consumer Consumer
     dead_letter_queue(topic: DT.topics[1], max_retries: 0)
-    manual_offset_management
+    manual_offset_management(true)
   end
 
   topic DT.topics[1] do
     consumer DlqConsumer
-    manual_offset_management
+    manual_offset_management(true)
   end
 end
 

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/with_non_recoverable_first_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/with_non_recoverable_first_message_spec.rb
@@ -28,12 +28,12 @@ draw_routes do
   topic DT.topics[0] do
     consumer Consumer
     dead_letter_queue(topic: DT.topics[1], max_retries: 2)
-    manual_offset_management
+    manual_offset_management(true)
   end
 
   topic DT.topics[1] do
     consumer DlqConsumer
-    manual_offset_management
+    manual_offset_management(true)
   end
 end
 

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/with_non_recoverable_last_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/with_non_recoverable_last_message_spec.rb
@@ -28,12 +28,12 @@ draw_routes do
   topic DT.topics[0] do
     consumer Consumer
     dead_letter_queue(topic: DT.topics[1], max_retries: 2)
-    manual_offset_management
+    manual_offset_management(true)
   end
 
   topic DT.topics[1] do
     consumer DlqConsumer
-    manual_offset_management
+    manual_offset_management(true)
   end
 end
 

--- a/spec/lib/karafka/routing/features/dead_letter_queue/contracts/topic_spec.rb
+++ b/spec/lib/karafka/routing/features/dead_letter_queue/contracts/topic_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe_current do
         independent: false,
         transactional: true,
         dispatch_method: :produce_async,
-        marking_method: :mark_as_consumed
+        marking_method: :mark_as_consumed,
+        mark_after_dispatch: nil
       }
     }
   end
@@ -65,6 +66,12 @@ RSpec.describe_current do
 
   context 'when marking_method is not any of methods' do
     before { config[:dead_letter_queue][:marking_method] = false }
+
+    it { expect(check).not_to be_success }
+  end
+
+  context 'when mark_after_dispatch is not any of expected' do
+    before { config[:dead_letter_queue][:mark_after_dispatch] = rand }
 
     it { expect(check).not_to be_success }
   end


### PR DESCRIPTION
close https://github.com/karafka/karafka/issues/1673