### PR TITLE
support partial kafka routing reconfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka Framework Changelog
 
 ## 2.4.9 (Unreleased)
+- [Enhancement] Allow for partial topic level kafka scope settings reconfiguration via `inherit` flag.
 - [Enhancement] Validate `eof` kafka scope flag when `eofed` in routing enabled.
 - [Enhancement] Provide `mark_after_dispatch` setting for granular DLQ marking control.
 - [Enhancement] Provide `Karafka::Admin.rename_consumer_group`.

--- a/lib/karafka/routing/topic.rb
+++ b/lib/karafka/routing/topic.rb
@@ -54,6 +54,20 @@ module Karafka
         RUBY
       end
 
+      # Often users want to have the same basic cluster setup with small setting alterations
+      # This method allows us to do so by setting `inherit` to `true`. Whe inherit is enabled,
+      # settings will be merged with defaults.
+      #
+      # @param settings [Hash] kafka scope settings. If `:inherit` key is provided, it will
+      #   instruct the assignment to merge with root level defaults
+      #
+      # @note It is set to `false` by default to preserve backwards compatibility
+      def kafka=(settings = {})
+        inherit = settings.delete(:inherit)
+
+        @kafka = inherit ? Karafka::App.config.kafka.merge(settings) : settings
+      end
+
       # @return [String] name of subscription that will go to librdkafka
       def subscription_name
         name

--- a/spec/integrations/routing/with_topic_inherited_settings_spec.rb
+++ b/spec/integrations/routing/with_topic_inherited_settings_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# We should be able to define defaults and then use the inherit flag to get per topic Kafka
+# scope reconfiguration
+
+setup_karafka
+
+draw_routes(create_topics: false) do
+  topic 'topic1' do
+    consumer Class.new
+    kafka(
+      'enable.partition.eof': true,
+      inherit: true
+    )
+  end
+
+  topic 'topic2' do
+    consumer Class.new
+  end
+
+  topic 'topic3' do
+    consumer Class.new
+    kafka(
+      'enable.partition.eof': true
+    )
+  end
+
+  topic 'topic4' do
+    consumer Class.new
+    kafka(
+      'enable.partition.eof': true,
+      inherit: true
+    )
+  end
+end
+
+cgs = Karafka::App.consumer_groups
+
+assert_equal 1, cgs.size
+# First and last topic setup should go to one SG
+assert_equal 3, cgs.first.subscription_groups.size
+# Merged sg should have expected topics
+assert_equal %w[topic1 topic4], cgs.first.subscription_groups.first.topics.map(&:name)
+# Merged topics should have defaults in them
+t1k = cgs.first.subscription_groups.first.topics[0].kafka
+t2k = cgs.first.subscription_groups.first.topics[1].kafka
+
+assert_equal '127.0.0.1:9092', t1k[:'bootstrap.servers']
+assert_equal true, t1k[:'enable.partition.eof']
+assert_equal '127.0.0.1:9092', t2k[:'bootstrap.servers']
+assert_equal true, t2k[:'enable.partition.eof']
+
+# Non-mergeable should not have anything special in them merged
+t1k = cgs.first.subscription_groups[2].topics[0].kafka
+assert_equal nil, t1k[:'bootstrap.servers']
+assert_equal true, t1k[:'enable.partition.eof']
+
+# The merged SG should have the alterations
+t1sg = cgs.first.subscription_groups.first.kafka
+assert_equal '127.0.0.1:9092', t1sg[:'bootstrap.servers']
+assert_equal true, t1sg[:'enable.partition.eof']


### PR DESCRIPTION
This PR improves how we draw routes. It allows to pass `:inherit` set to `true` to the kafka routing setting (as in spec) to make it merge with existing root config. This helps avoid full reconfiguration duplication to just change one flag. 