### PR TITLE
log failed executions of recurring tasks

### DIFF
--- a/lib/karafka/pro/recurring_tasks/listener.rb
+++ b/lib/karafka/pro/recurring_tasks/listener.rb
@@ -21,6 +21,17 @@ module Karafka
         def on_recurring_tasks_task_executed(event)
           Dispatcher.log(event)
         end
+
+        # @param event [Karafka::Core::Monitoring::Event] error that occurred
+        # @note We do nothing with other errors. We only want to log and dispatch information about
+        #   the recurring tasks errors. The general Web UI error tracking may also work but those
+        #   are independent. It is not to replace the Web UI tracking but to just log failed
+        #   executions in the same way as successful but just with the failure as an outcome.
+        def on_error_occurred(event)
+          return unless event[:type] == 'recurring_tasks.task.execute.error'
+
+          Dispatcher.log(event)
+        end
       end
     end
   end

--- a/lib/karafka/pro/recurring_tasks/serializer.rb
+++ b/lib/karafka/pro/recurring_tasks/serializer.rb
@@ -74,7 +74,6 @@ module Karafka
         # @return [String] serialized and compressed event log data
         def log(event)
           task = event[:task]
-          time = event[:time]
 
           data = {
             schema_version: SCHEMA_VERSION,
@@ -83,9 +82,10 @@ module Karafka
             type: 'log',
             task: {
               id: task.id,
-              time_taken: time,
+              time_taken: event.payload[:time] || -1,
               previous_time: task.previous_time.to_i,
-              next_time: task.next_time.to_i
+              next_time: task.next_time.to_i,
+              result: event.payload.key?(:error) ? 'failure' : 'success'
             }
           }
 

--- a/spec/integrations/pro/recurring_tasks/logging_data_published_on_errors_spec.rb
+++ b/spec/integrations/pro/recurring_tasks/logging_data_published_on_errors_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# When tasks are triggered, by default it should publish events to the logs topic even if those
+# executions fail
+
+setup_karafka(allow_errors: %w[recurring_tasks.task.execute.error])
+
+class CountConsumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[:messages] << message.payload
+    end
+  end
+end
+
+draw_routes do
+  recurring_tasks(true) do
+    max_wait_time 500
+  end
+
+  topic Karafka::App.config.recurring_tasks.topics.logs do
+    consumer CountConsumer
+    deserializer Karafka::App.config.recurring_tasks.deserializer
+  end
+end
+
+Karafka::Pro::RecurringTasks.define('1.0.0') do
+  schedule(id: 'a', cron: '0 12 31 12 *', enabled: false) do
+    DT[:a] = true
+
+    raise
+  end
+
+  schedule(id: 'b', cron: '0 12 31 12 *', enabled: false) do
+    DT[:b] = true
+
+    raise
+  end
+
+  schedule(id: 'c', cron: '0 12 31 12 *', previous_time: Time.now - 120_000) do
+    DT[:c] = true
+
+    raise
+  end
+end
+
+start_karafka_and_wait_until do
+  unless @dispatched
+    Karafka::Pro::RecurringTasks.trigger('*')
+    @dispatched = true
+  end
+
+  DT[:messages].count >= 3
+end
+
+DT[:messages].each_with_index do |payload, i|
+  assert_equal payload[:schema_version], '1.0'
+  assert_equal payload[:schedule_version], '1.0.0'
+  assert_equal payload[:type], 'log'
+  assert payload[:dispatched_at].is_a?(Float)
+
+  task = payload[:task]
+
+  # Assertions for the task
+  assert_equal task[:id], %w[a b c][i]
+  assert_equal task[:time_taken], -1
+  assert task[:previous_time].is_a?(Integer)
+  assert task[:next_time].is_a?(Integer)
+  assert_equal task[:result], 'failure'
+end

--- a/spec/lib/karafka/pro/recurring_tasks/listener_spec.rb
+++ b/spec/lib/karafka/pro/recurring_tasks/listener_spec.rb
@@ -15,4 +15,28 @@ RSpec.describe_current do
       expect(dispatcher).to have_received(:log).with(event)
     end
   end
+
+  describe '#on_error_occurred' do
+    before { allow(dispatcher).to receive(:log) }
+
+    context 'when event type is recurring_tasks.task.execute.error' do
+      let(:event) { { type: 'recurring_tasks.task.execute.error', other_data: 'data' } }
+
+      it 'logs the event using Dispatcher' do
+        listener.on_error_occurred(event)
+
+        expect(dispatcher).to have_received(:log).with(event)
+      end
+    end
+
+    context 'when event type is not recurring_tasks.task.execute.error' do
+      let(:event) { { type: 'some_other_error', other_data: 'data' } }
+
+      it 'does not log the event' do
+        listener.on_error_occurred(event)
+
+        expect(dispatcher).not_to have_received(:log)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds karafka (not karafka-web) logging of failed executions. We do not instrument details because this is not an error tracker but execution ntracker. We instrument for consistency and better visibility.
