### PR TITLE
Draft/WIP/Idea: Wrap worker/job execution with rails reloader or executor

### DIFF
--- a/lib/karafka/railtie.rb
+++ b/lib/karafka/railtie.rb
@@ -65,16 +65,6 @@ if Karafka.rails?
         app.config.autoload_paths += %w[app/consumers]
       end
 
-      initializer 'karafka.configure_worker_external_executor' do |app|
-        external_worker_executor = if Karafka::App.config.consumer_persistence
-          proc { |&block| app.executor.wrap(&block) }
-        else
-          proc { |&block| app.reloader.wrap(&block) }
-        end
-
-        Karafka::App.config.internal.processing.external_worker_executor = external_worker_executor
-      end
-
       initializer 'karafka.release_active_record_connections' do
         rails7plus = Rails.gem_version >= Gem::Version.new('7.0.0')
 
@@ -122,6 +112,18 @@ if Karafka.rails?
           app.config.after_initialize do
             require karafka_boot_file
           end
+        end
+      end
+
+      initializer 'karafka.configure_worker_external_executor' do |app|
+        app.config.after_initialize do
+          external_worker_executor = if Karafka::App.config.consumer_persistence
+            proc { |&block| app.executor.wrap(&block) }
+          else
+            proc { |&block| app.reloader.wrap(&block) }
+          end
+
+          Karafka::App.config.internal.processing.external_worker_executor = external_worker_executor
         end
       end
     end

--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -285,6 +285,8 @@ module Karafka
           setting :expansions_selector, default: Processing::ExpansionsSelector.new
           # option [Class] executor class
           setting :executor_class, default: Processing::Executor
+          # option external_worker_executor [proc] callable object that will be used to wrap execution of a job
+          setting :external_worker_executor, default: proc { |&block| block.call }
         end
 
         # Things related to operating on messages


### PR DESCRIPTION
This is a stab at removing the manual code reloading and instead wrapping execution (if integrated with a rails app) with the rails executor or reloader (depending on whether consumer_persistence is enabled or not). I was having some wild reloading issues in development that I could not seem to fix... but this does it!

This is how sidekiq handles this as well: https://github.com/sidekiq/sidekiq/blob/ed8b217d32f026acc1fae7221dca18d1baa86d11/lib/sidekiq/processor.rb#L135-L147

There seems to be other important things handled by the executor we likely want! (Query cache enabling/disabling, connection management -- I didn't try it out, but possibly we won't need the other initializer that clears AR connections on worker completion?) https://guides.rubyonrails.org/threading_and_code_execution.html#wrapping-application-code