### PR TITLE
Add post-initialize consumer hook for custom component bootstrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka Framework Changelog
 
 ## 2.4.10 (Unreleased)
+- [Enhancement] Introduce a `#assigned` hook for consumers to be able to trigger actions when consumer is built and assigned but before first consume/ticking, etc.
 - [Enhancement] Provide `Karafka::Messages::Message#tombstone?` to be able to quickly check if a message is a tombstone message.
 - [Enhancement] Provide more flexible API for Recurring Tasks topics reconfiguration.
 

--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -31,6 +31,20 @@ module Karafka
       @used = false
     end
 
+    # Trigger method running after consumer is fully initialized.
+    #
+    # @private
+    def on_initialized
+      handle_initialized
+    rescue StandardError => e
+      Karafka.monitor.instrument(
+        'error.occurred',
+        error: e,
+        caller: self,
+        type: 'consumer.initialized.error'
+      )
+    end
+
     # Can be used to run preparation code prior to the job being enqueued
     #
     # @private
@@ -175,6 +189,15 @@ module Karafka
     end
 
     private
+
+    # Method called post-initialization of a consumer when all basic things are assigned.
+    # Since initialization via `#initialize` is complex and some states are set a bit later, this
+    # hook allows to initialize resources once at a time when topic, partition and other things
+    # are assigned to the consumer
+    #
+    # @note Please keep in mind that it will run many times when persistence is off. Basically once
+    #   each batch.
+    def initialized; end
 
     # Method that will perform business logic and on data received from Kafka (it will consume
     #   the data)

--- a/lib/karafka/instrumentation/logger_listener.rb
+++ b/lib/karafka/instrumentation/logger_listener.rb
@@ -275,6 +275,9 @@ module Karafka
         details = (error.backtrace || []).join("\n")
 
         case type
+        when 'consumer.initialized.error'
+          error "Consumer initialized error: #{error}"
+          error details
         when 'consumer.consume.error'
           error "Consumer consuming error: #{error}"
           error details

--- a/lib/karafka/instrumentation/notifications.rb
+++ b/lib/karafka/instrumentation/notifications.rb
@@ -48,6 +48,9 @@ module Karafka
         connection.listener.stopping
         connection.listener.stopped
 
+        consumer.initialize
+        consumer.initialized
+
         consumer.before_schedule_consume
         consumer.consume
         consumer.consumed

--- a/lib/karafka/processing/executor.rb
+++ b/lib/karafka/processing/executor.rb
@@ -181,6 +181,12 @@ module Karafka
           # overhead as this will happen only once per consumer lifetime
           consumer.messages = empty_messages
 
+          # Run the post-initialization hook for users that need to run some actions when consumer
+          # is built and ready (all basic state and info).
+          # Users should **not** overwrite the `#initialize` because it won't have all the needed
+          # data assigned yet.
+          consumer.on_initialized
+
           consumer
         end
       end

--- a/lib/karafka/processing/strategies/default.rb
+++ b/lib/karafka/processing/strategies/default.rb
@@ -31,6 +31,16 @@ module Karafka
           RUBY
         end
 
+        # Runs the post-creation, post-assignment code
+        # @note It runs in the listener loop. Should **not** be used for anything heavy or
+        #   with any potential errors. Mostly for initialization of states, etc.
+        def handle_initialized
+          Karafka.monitor.instrument('consumer.initialize', caller: self)
+          Karafka.monitor.instrument('consumer.initialized', caller: self) do
+            initialized
+          end
+        end
+
         # Marks message as consumed in an async way.
         #
         # @param message [Messages::Message] last successfully processed message.

--- a/spec/integrations/consumption/when_initialization_happens_spec.rb
+++ b/spec/integrations/consumption/when_initialization_happens_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Karafka should invoke the `#initialized` method and things like topic, partition and messages
+# should not be nil
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def initialized
+    DT[:topic] = topic
+    DT[:partition] = partition
+    DT[:messages] = messages
+  end
+
+  def consume; end
+end
+
+draw_routes(Consumer)
+
+produce_many(DT.topic, DT.uuids(1))
+
+start_karafka_and_wait_until do
+  DT.key?(:messages)
+end
+
+assert_equal DT[:topic].name, DT.topic
+assert_equal DT[:partition], 0
+assert DT[:messages].empty?

--- a/spec/integrations/instrumentation/initialized_flow_spec.rb
+++ b/spec/integrations/instrumentation/initialized_flow_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Karafka should publish correct events post-initializing the consumer instances
+# When initialization fails, it should also publish error
+
+setup_karafka(allow_errors: %w[consumer.initialized.error])
+
+class OkConsumer < Karafka::BaseConsumer
+  def initialized
+    DT[:ok] = true
+  end
+
+  def consume; end
+end
+
+class NotOkConsumer < Karafka::BaseConsumer
+  def initialized
+    DT[:not_ok] = true
+
+    raise
+  end
+
+  def consume; end
+end
+
+Karafka::App.monitor.subscribe('consumer.initialize') do |event|
+  DT[:pre] << event[:caller].class
+end
+
+Karafka::App.monitor.subscribe('consumer.initialized') do |event|
+  DT[:post] << event[:caller].class
+end
+
+Karafka::App.monitor.subscribe('error.occurred') do |event|
+  DT[:errors] << event[:type]
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer OkConsumer
+  end
+
+  topic DT.topics[1] do
+    consumer NotOkConsumer
+  end
+end
+
+produce(DT.topics[0], rand.to_s)
+produce(DT.topics[1], rand.to_s)
+
+start_karafka_and_wait_until do
+  DT.key?(:ok) && DT.key?(:not_ok)
+end
+
+assert DT[:pre].include?(OkConsumer)
+assert DT[:pre].include?(NotOkConsumer)
+assert DT[:post].include?(OkConsumer)
+assert !DT[:post].include?(NotOkConsumer)
+assert_equal DT[:errors], %w[consumer.initialized.error]

--- a/spec/integrations/pro/consumption/periodic_jobs/initialized_prior_to_ticking_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/initialized_prior_to_ticking_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# We should run the initialized hook prior to ticking
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def initialized
+    DT[:initialized] = Time.now.to_f
+  end
+
+  def consume; end
+
+  def tick
+    DT[:tick] = Time.now.to_f
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    periodic(interval: 100)
+  end
+end
+
+start_karafka_and_wait_until do
+  DT.key?(:tick)
+end
+
+assert DT[:initialized] < DT[:tick]

--- a/spec/lib/karafka/base_consumer_spec.rb
+++ b/spec/lib/karafka/base_consumer_spec.rb
@@ -471,4 +471,27 @@ RSpec.describe_current do
       expect(consumer.send(:attempt)).to eq(1)
     end
   end
+
+  # Complex notification tracking is in the integrations
+  describe '#on_initialized' do
+    it { expect { consumer.on_initialized }.not_to raise_error }
+
+    context 'when handle_initialized raises error' do
+      let(:working_class) do
+        ClassBuilder.inherit(described_class) do
+          attr_reader :consumed
+
+          def consume
+            self
+          end
+
+          def handle_initialized
+            raise
+          end
+        end
+      end
+
+      it { expect { consumer.on_initialized }.not_to raise_error }
+    end
+  end
 end

--- a/spec/lib/karafka/instrumentation/logger_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/logger_listener_spec.rb
@@ -380,6 +380,13 @@ RSpec.describe_current do
       it { expect(Karafka.logger).to have_received(:error).with(message) }
     end
 
+    context 'when it is a consumer.initialized.error' do
+      let(:type) { 'consumer.initialized.error' }
+      let(:message) { "Consumer initialized error: #{error}" }
+
+      it { expect(Karafka.logger).to have_received(:error).with(message) }
+    end
+
     context 'when it is a consumer.consume.error' do
       let(:type) { 'consumer.consume.error' }
       let(:message) { "Consumer consuming error: #{error}" }


### PR DESCRIPTION
This PR adds new consumer `#initialized` method that can be used to setup some sub-components when all things related to consumer and its assignment are ready.

I noticed users overwrite the `#initialize` but the issue is, some pieces of the puzzle like `#topic` will be missing at this stage.