### PR TITLE
Fix deprecation warning in `lib/karafka/railtie.rb`

### DIFF
--- a/lib/karafka/railtie.rb
+++ b/lib/karafka/railtie.rb
@@ -77,7 +77,7 @@ if Karafka.rails?
             # The change technically happens in 7.1 but 7.0 already supports this so we can make
             # a proper change for 7.0+
             if rails7plus
-              ActiveRecord::Base.connection_handler.clear_active_connections!
+              ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
             else
               ActiveRecord::Base.clear_active_connections!
             end


### PR DESCRIPTION
I found this deprecation warning when ready to Rails 7.2 in my application.

> ActiveSupport::DeprecationException: DEPRECATION WARNING: `clear_active_connections!` currently only applies to connection pools in the current role (`writing`). In Rails 7.2, this method will apply to all known pools, regardless of role. To affect only those connections belonging to a specific role, pass the role name as an argument. To switch to the new behavior, pass `:all` as the role name. (called from loop at <internal:kernel>:187) (ActiveSupport::DeprecationException)

We can suppress this warning by passing `:all` to argument.