### PR TITLE
remove no longer needed ar connection management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Enhancement] Introduce a `#assigned` hook for consumers to be able to trigger actions when consumer is built and assigned but before first consume/ticking, etc.
 - [Enhancement] Provide `Karafka::Messages::Message#tombstone?` to be able to quickly check if a message is a tombstone message.
 - [Enhancement] Provide more flexible API for Recurring Tasks topics reconfiguration.
+- [Enhancement] Remove no longer needed Rails connection releaser.
 
 ## 2.4.9 (2024-08-23)
 - **[Feature]** Provide Kafka based Recurring (Cron) Tasks.

--- a/lib/karafka/railtie.rb
+++ b/lib/karafka/railtie.rb
@@ -65,26 +65,6 @@ if Karafka.rails?
         app.config.autoload_paths += %w[app/consumers]
       end
 
-      initializer 'karafka.release_active_record_connections' do
-        rails7plus = Rails.gem_version >= Gem::Version.new('7.0.0')
-
-        ActiveSupport.on_load(:active_record) do
-          ::Karafka::App.monitor.subscribe('worker.completed') do
-            # Always release the connection after processing is done. Otherwise thread may hang
-            # blocking the reload and further processing
-            # @see https://github.com/rails/rails/issues/44183
-            #
-            # The change technically happens in 7.1 but 7.0 already supports this so we can make
-            # a proper change for 7.0+
-            if rails7plus
-              ActiveRecord::Base.connection_handler.clear_active_connections!
-            else
-              ActiveRecord::Base.clear_active_connections!
-            end
-          end
-        end
-      end
-
       initializer 'karafka.require_karafka_boot_file' do |app|
         rails6plus = Rails.gem_version >= Gem::Version.new('6.0.0')
 


### PR DESCRIPTION
since now we use the executor/reloader wrapper for Rails, connection management and other resources management is fully on Rails. Based on the docs, we no longer have to release or manage this manually.

superseeds https://github.com/karafka/karafka/pull/2257
ref https://github.com/karafka/karafka/pull/2233