### PR TITLE
Update AppSignal client to support newer versions

### DIFF
--- a/lib/karafka/instrumentation/vendors/appsignal/client.rb
+++ b/lib/karafka/instrumentation/vendors/appsignal/client.rb
@@ -99,7 +99,11 @@ module Karafka
           # @param name [Symbol] probe name
           # @param probe [Proc] code to run every minute
           def register_probe(name, probe)
-            ::Appsignal::Minutely.probes.register(name, probe)
+            if ::Appsignal::Probes.respond_to?(:register)
+              ::Appsignal::Probes.register(name, probe)
+            else
+              ::Appsignal::Minutely.probes.register(name, probe)
+            end
           end
 
           private

--- a/lib/karafka/instrumentation/vendors/appsignal/client.rb
+++ b/lib/karafka/instrumentation/vendors/appsignal/client.rb
@@ -15,6 +15,8 @@ module Karafka
           #   nil if it is to remain default.
           #   Defaults to `Appsignal::Transaction::BACKGROUND_JOB` in the execution flow.
           def initialize(namespace_name: nil)
+            @version_4_or_newer =
+              Gem::Version.new(Appsignal::VERSION) >= Gem::Version.new("4.0.0")
             @namespace_name = namespace_name
           end
 
@@ -23,11 +25,16 @@ module Karafka
           # @param action_name [String] action name. For processing this should be equal to
           #   consumer class + method name
           def start_transaction(action_name)
-            transaction = ::Appsignal::Transaction.create(
-              SecureRandom.uuid,
-              namespace_name,
-              ::Appsignal::Transaction::GenericRequest.new({})
-            )
+            transaction =
+              if @version_4_or_newer
+                ::Appsignal::Transaction.create(namespace_name)
+              else
+                ::Appsignal::Transaction.create(
+                  SecureRandom.uuid,
+                  namespace_name,
+                  ::Appsignal::Transaction::GenericRequest.new({})
+                )
+              end
 
             transaction.set_action_if_nil(action_name)
           end

--- a/lib/karafka/instrumentation/vendors/appsignal/client.rb
+++ b/lib/karafka/instrumentation/vendors/appsignal/client.rb
@@ -52,10 +52,10 @@ module Karafka
           def metadata=(metadata_hash)
             return unless transaction?
 
-            transaction = ::Appsignal::Transaction.current
+            current_transaction = transaction
 
             stringify_hash(metadata_hash).each do |key, value|
-              transaction.set_metadata(key, value)
+              current_transaction.set_metadata(key, value)
             end
           end
 

--- a/lib/karafka/instrumentation/vendors/appsignal/errors_listener.rb
+++ b/lib/karafka/instrumentation/vendors/appsignal/errors_listener.rb
@@ -21,7 +21,7 @@ module Karafka
           #
           # @param event [Karafka::Core::Monitoring::Event]
           def on_error_occurred(event)
-            client.send_error(event[:error])
+            client.report_error(event[:error])
           end
         end
       end

--- a/spec/support/vendors/appsignal/dummy_client.rb
+++ b/spec/support/vendors/appsignal/dummy_client.rb
@@ -36,7 +36,7 @@ module Vendors
       # Buffers the error
       #
       # @param error [Object]
-      def send_error(error)
+      def report_error(error)
         @buffer[:errors][0] << error
       end
 


### PR DESCRIPTION
Closes #2238

﻿## Register AppSignal probe with new helper

In AppSignal for Ruby gem 3.7 the recommended method for registering minutely probes has changed. In version 4 the old methods were removed.

Add a check to see if it listens to the new registration helper and if not, call the old helper.

## Use the AppSignal report_error helper if available

The AppSignal for Ruby gem introduced the `Appsignal.report_error` helper in Ruby gem version 3.10.0. This helper does what the client already did, check if there's a current transaction or not and report the error with `set_error` or `send_error`.

In version 4 of the Ruby gem the `report_error` helper also supports reporting multiple errors per transaction, so it's recommended to use this new helper.

## Update AppSignal Transaction initialization

In AppSignal for Ruby gem version 4 the creation for transactions was simplified. Remove the extra arguments given to the `create` method if version 4 of the Ruby gem is found.

## Refactor AppSignal current Transaction helper

Use the existing `transaction` helper method to fetch the current transaction.
