### PR TITLE
Update AppSignal client to support newer versions (#2260)

### DIFF
--- a/lib/karafka/instrumentation/vendors/appsignal/errors_listener.rb
+++ b/lib/karafka/instrumentation/vendors/appsignal/errors_listener.rb
@@ -21,7 +21,7 @@ module Karafka
           #
           # @param event [Karafka::Core::Monitoring::Event]
           def on_error_occurred(event)
-            client.send_error(event[:error])
+            client.report_error(event[:error])
           end
         end
       end

--- a/spec/support/vendors/appsignal/dummy_client.rb
+++ b/spec/support/vendors/appsignal/dummy_client.rb
@@ -36,7 +36,7 @@ module Vendors
       # Buffers the error
       #
       # @param error [Object]
-      def send_error(error)
+      def report_error(error)
         @buffer[:errors][0] << error
       end
 


### PR DESCRIPTION
* Register AppSignal probe with new helper

In AppSignal for Ruby gem 3.7 the recommended method for registering minutely probes has changed. In version 4 the old methods were removed.

Add a check to see if it listens to the new registration helper and if not, call the old helper.

* Use the AppSignal report_error helper if available

The AppSignal for Ruby gem introduced the `Appsignal.report_error` helper in Ruby gem version 3.10.0. This helper does what the client already did, check if there's a current transaction or not and report the error with `set_error` or `send_error`.

In version 4 of the Ruby gem the `report_error` helper also supports reporting multiple errors per transaction, so it's recommended to use this new helper.

* Update AppSignal Transaction initialization

In AppSignal for Ruby gem version 4 the creation for transactions was simplified. Remove the extra arguments given to the `create` method if version 4 of the Ruby gem is found.

* Refactor AppSignal current Transaction helper

Use the existing `transaction` helper method to fetch the current transaction.

* Move AppSignal version check to method

Don't check the version on `Client.new`, this causes some specs to fail because the AppSignal gem is not present.