### PR TITLE
retire ruby 3.0 ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,6 @@ jobs:
           - '3.3'
           - '3.2'
           - '3.1'
-          - '3.0'
     steps:
       - uses: actions/checkout@v4
       - name: Install package dependencies
@@ -176,7 +175,6 @@ jobs:
           - '3.3'
           - '3.2'
           - '3.1'
-          - '3.0'
     steps:
       - uses: actions/checkout@v4
       - name: Install package dependencies


### PR DESCRIPTION
Per our maintenance policy, I'm removing 3.0 from CI to fully retire it in few weeks.