### PR TITLE
Introduce adaptive iterator as an alternative to LRJ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 ## 2.4.12 (Unreleased)
 - **[Feature]** Provide Poll Guarding feature as a fast alternative to Long-Running Jobs (Pro).
+- [Enhancement] Provide `Consumer#each` as a delegation to messages batch.
 - [Enhancement] Verify cancellation request envelope topic similar to the schedule one.
 - [Enhancement] Validate presence of `bootstrap.servers` to avoid incomplete partial reconfiguration.
 - [Enhancement] Support `ActiveJob#enqueue_at` via Scheduled Messages feature (Pro).
 - [Enhancement] Introduce `Karafka::App#debug!` that will switch Karafka and the default producer into extensive debug mode. Useful for CLI debugging.
 - [Enhancement] Support full overwrite of the `BaseConsumer#producer`.
 - [Enhancement] Transfer the time of last poll back to the coordinator for more accurate metrics tracking.
+- [Enhancement] Instrument `Consumer#seek` via `consumer.consuming.seek`.
 
 ## 2.4.11 (2024-09-04)
 - [Enhancement] Validate envelope target topic type for Scheduled Messages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Karafka Framework Changelog
 
 ## 2.4.12 (Unreleased)
-- **[Feature]** Provide Poll Guarding feature as a fast alternative to Long-Running Jobs (Pro).
+- **[Feature]** Provide Adaptive Iterator feature as a fast alternative to Long-Running Jobs (Pro).
 - [Enhancement] Provide `Consumer#each` as a delegation to messages batch.
 - [Enhancement] Verify cancellation request envelope topic similar to the schedule one.
 - [Enhancement] Validate presence of `bootstrap.servers` to avoid incomplete partial reconfiguration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Karafka Framework Changelog
 
 ## 2.4.12 (Unreleased)
+- **[Feature]** Provide Poll Guarding feature as a fast alternative to Long-Running Jobs (Pro).
 - [Enhancement] Verify cancellation request envelope topic similar to the schedule one.
 - [Enhancement] Validate presence of `bootstrap.servers` to avoid incomplete partial reconfiguration.
 - [Enhancement] Support `ActiveJob#enqueue_at` via Scheduled Messages feature (Pro).
 - [Enhancement] Introduce `Karafka::App#debug!` that will switch Karafka and the default producer into extensive debug mode. Useful for CLI debugging.
 - [Enhancement] Support full overwrite of the `BaseConsumer#producer`.
+- [Enhancement] Transfer the time of last poll back to the coordinator for more accurate metrics tracking.
 
 ## 2.4.11 (2024-09-04)
 - [Enhancement] Validate envelope target topic type for Scheduled Messages.

--- a/config/locales/pro_errors.yml
+++ b/config/locales/pro_errors.yml
@@ -79,10 +79,11 @@ en:
       adaptive_iterator.active_missing: needs to be present
       adaptive_iterator.active_format: 'needs to be boolean'
       adaptive_iterator.marking_method_format: 'needs to be either #mark_as_consumed or #mark_as_consumed!'
-      adaptive_iterator.mark_after_yielding_format: 'needs to be boolean'
       adaptive_iterator.adaptive_margin_format: 'needs to be boolean'
       adaptive_iterator.clean_after_yielding_format: 'needs to be boolean'
       adaptive_iterator.safety_margin_format: 'needs to be between 1 and 99'
+      adaptive_iterator_with_virtual_partitions: 'cannot be used with virtual partitions'
+      adaptive_iterator_with_long_running_job: 'cannot be used with long running jobs'
 
     consumer_group:
       patterns_format: must be an array with hashes

--- a/config/locales/pro_errors.yml
+++ b/config/locales/pro_errors.yml
@@ -79,7 +79,6 @@ en:
       adaptive_iterator.active_missing: needs to be present
       adaptive_iterator.active_format: 'needs to be boolean'
       adaptive_iterator.marking_method_format: 'needs to be either #mark_as_consumed or #mark_as_consumed!'
-      adaptive_iterator.adaptive_margin_format: 'needs to be boolean'
       adaptive_iterator.clean_after_yielding_format: 'needs to be boolean'
       adaptive_iterator.safety_margin_format: 'needs to be between 1 and 99'
       adaptive_iterator_with_virtual_partitions: 'cannot be used with virtual partitions'

--- a/config/locales/pro_errors.yml
+++ b/config/locales/pro_errors.yml
@@ -76,6 +76,14 @@ en:
       direct_assignments_swarm_overbooked: 'cannot allocate partitions in swarm that were not assigned'
       direct_assignments_patterns_active: 'patterns cannot be used with direct assignments'
 
+      adaptive_iterator.active_missing: needs to be present
+      adaptive_iterator.active_format: 'needs to be boolean'
+      adaptive_iterator.marking_method_format: 'needs to be either #mark_as_consumed or #mark_as_consumed!'
+      adaptive_iterator.mark_after_yielding_format: 'needs to be boolean'
+      adaptive_iterator.adaptive_margin_format: 'needs to be boolean'
+      adaptive_iterator.clean_after_yielding_format: 'needs to be boolean'
+      adaptive_iterator.safety_margin_format: 'needs to be between 1 and 99'
+
     consumer_group:
       patterns_format: must be an array with hashes
       patterns_missing: needs to be present

--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -112,6 +112,10 @@ module Karafka
           # Fetch message within our time boundaries
           response = poll(time_poll.remaining)
 
+          # We track when last polling happened so we can provide means to detect upcoming
+          # `max.poll.interval.ms` limit
+          @buffer.polled
+
           case response
           when :tick_time
             nil

--- a/lib/karafka/connection/listener.rb
+++ b/lib/karafka/connection/listener.rb
@@ -336,7 +336,7 @@ module Karafka
         idle_jobs = []
         eofed_jobs = []
 
-        @messages_buffer.each do |topic, partition, messages, eof|
+        @messages_buffer.each do |topic, partition, messages, eof, last_polled_at|
           # In case we did not receive any new messages without eof we skip.
           # We may yield empty array here in case we have reached eof without new messages but in
           # such cases, we can run an eof job
@@ -344,6 +344,7 @@ module Karafka
 
           coordinator = @coordinators.find_or_create(topic, partition)
           coordinator.eofed = eof
+          coordinator.last_polled_at = last_polled_at
 
           # If we did not receive any messages and we did receive eof signal, we run the eofed
           # jobs so user can take actions on reaching eof

--- a/lib/karafka/instrumentation/logger_listener.rb
+++ b/lib/karafka/instrumentation/logger_listener.rb
@@ -127,6 +127,21 @@ module Karafka
         MSG
       end
 
+      # Prints info about seeking to a particular location
+      #
+      # @param event [Karafka::Core::Monitoring::Event] event details including payload
+      def on_consumer_consuming_seek(event)
+        topic = event[:topic]
+        partition = event[:partition]
+        seek_offset = event[:message].offset
+        consumer = event[:caller]
+
+        info <<~MSG.tr("\n", ' ').strip!
+          [#{consumer.id}] Seeking from #{consumer.class}
+          on topic #{topic}/#{partition} to offset #{seek_offset}
+        MSG
+      end
+
       # Logs info about system signals that Karafka received and prints backtrace for threads in
       # case of ttin
       #

--- a/lib/karafka/instrumentation/notifications.rb
+++ b/lib/karafka/instrumentation/notifications.rb
@@ -56,6 +56,7 @@ module Karafka
         consumer.consumed
         consumer.consuming.pause
         consumer.consuming.retry
+        consumer.consuming.seek
 
         consumer.before_schedule_idle
         consumer.idle

--- a/lib/karafka/pro/loader.rb
+++ b/lib/karafka/pro/loader.rb
@@ -74,8 +74,8 @@ module Karafka
         #   that need to have some special configuration stuff injected into config, etc
         def features
           [
-            Encryption,
             Cleaner,
+            Encryption,
             RecurringTasks,
             ScheduledMessages
           ]

--- a/lib/karafka/pro/processing/adaptive_iterator/consumer.rb
+++ b/lib/karafka/pro/processing/adaptive_iterator/consumer.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Processing
+      # Namespace for adaptive iterator consumer components
+      module AdaptiveIterator
+        # Consumer enhancements needed to wrap the batch iterator for adaptive iterating
+        # It automatically marks as consumed, ensures that we do not reach `max.poll.interval.ms`
+        # and does other stuff to simplify user per-message processing
+        module Consumer
+          # @param args [Array] anything accepted by `Karafka::Messages::Messages#each`
+          def each(*args)
+            adi_config = topic.adaptive_iterator
+
+            tracker = Tracker.new(
+              adi_config.safety_margin,
+              adi_config.adaptive_margin?,
+              coordinator.last_polled_at,
+              topic.subscription_group.kafka.fetch(:'max.poll.interval.ms')
+            )
+
+            messages.each(*args) do |message|
+              # Always stop if we've lost the assignment
+              return if revoked?
+              # No automatic marking risk when mom is enabled so we can fast stop
+              return if Karafka::App.done? && topic.manual_offset_management?
+
+              # Seek request on done will allow us to stop without marking the offset when user had
+              # the automatic offset marking. This should not be a big network traffic issue for
+              # the end user as we're stopping anyhow but should improve shutdown time
+              if tracker.enough? || Karafka::App.done?
+                # Enough means we no longer have time to process more data without polling as we
+                # risk reaching max poll interval. Instead we seek and we will poll again soon.
+                seek(message.offset, reset_offset: true)
+
+                return
+              end
+
+              tracker.track { yield(message) }
+
+              # Clean if this is what user configured
+              message.clean! if adi_config.clean_after_yielding?
+
+              public_send(adi_config.marking_method, message)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/processing/adaptive_iterator/consumer.rb
+++ b/lib/karafka/pro/processing/adaptive_iterator/consumer.rb
@@ -26,7 +26,6 @@ module Karafka
 
             tracker = Tracker.new(
               adi_config.safety_margin,
-              adi_config.adaptive_margin?,
               coordinator.last_polled_at,
               topic.subscription_group.kafka.fetch(:'max.poll.interval.ms')
             )

--- a/lib/karafka/pro/processing/adaptive_iterator/tracker.rb
+++ b/lib/karafka/pro/processing/adaptive_iterator/tracker.rb
@@ -25,18 +25,14 @@ module Karafka
           # Initializes a new Tracker instance.
           #
           # @param safety_margin [Float] The safety margin percentage (0-100) to leave as a buffer.
-          # @param adaptive_margin [Boolean] Indicates if the tracker should use adaptive
-          #   processing cost monitoring.
           # @param last_polled_at [Float] The timestamp of the last polling in milliseconds.
           # @param max_poll_interval_ms [Integer] The maximum poll interval time in milliseconds.
           def initialize(
             safety_margin,
-            adaptive_margin,
             last_polled_at,
             max_poll_interval_ms
           )
             @safety_margin = safety_margin / 100.0 # Convert percentage to decimal
-            @adaptive_margin = adaptive_margin
             @last_polled_at = last_polled_at
             @max_processing_cost = 0
             @max_poll_interval_ms = max_poll_interval_ms
@@ -47,9 +43,6 @@ module Karafka
           #
           # @yield Executes the block, measuring the time taken for processing.
           def track
-            # No need to measure adaptivity if not used
-            return yield unless @adaptive_margin
-
             before = monotonic_now
 
             yield
@@ -72,7 +65,6 @@ module Karafka
             safety_margin_ms = @max_poll_interval_ms * @safety_margin
 
             return true if remaining_time_ms <= safety_margin_ms
-            return false unless @adaptive_margin
             return true if remaining_time_ms - @max_processing_cost <= safety_margin_ms
 
             false

--- a/lib/karafka/pro/processing/adaptive_iterator/tracker.rb
+++ b/lib/karafka/pro/processing/adaptive_iterator/tracker.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Processing
+      module AdaptiveIterator
+        # Tracker is responsible for monitoring the processing of messages within the poll
+        # interval limitation.
+        # It ensures that the consumer does not exceed the maximum poll interval by tracking the
+        # processing cost and determining when to halt further processing (if needed).
+        class Tracker
+          include Karafka::Core::Helpers::Time
+
+          # Initializes a new Tracker instance.
+          #
+          # @param safety_margin [Float] The safety margin percentage (0-100) to leave as a buffer.
+          # @param adaptive_margin [Boolean] Indicates if the tracker should use adaptive
+          #   processing cost monitoring.
+          # @param last_polled_at [Float] The timestamp of the last polling in milliseconds.
+          # @param max_poll_interval_ms [Integer] The maximum poll interval time in milliseconds.
+          def initialize(
+            safety_margin,
+            adaptive_margin,
+            last_polled_at,
+            max_poll_interval_ms
+          )
+            @safety_margin = safety_margin / 100.0 # Convert percentage to decimal
+            @adaptive_margin = adaptive_margin
+            @last_polled_at = last_polled_at
+            @max_processing_cost = 0
+            @max_poll_interval_ms = max_poll_interval_ms
+          end
+
+          # Tracks the processing time of a block and updates the maximum processing cost.
+          # If adaptive margin is not enabled, it simply yields to the block without tracking.
+          #
+          # @yield Executes the block, measuring the time taken for processing.
+          def track
+            # No need to measure adaptivity if not used
+            return yield unless @adaptive_margin
+
+            before = monotonic_now
+
+            yield
+
+            time_taken = monotonic_now - before
+
+            return unless time_taken > @max_processing_cost
+
+            @max_processing_cost = time_taken
+          end
+
+          # Determines if there is enough time left to process more messages without exceeding the
+          # maximum poll interval, considering both the safety margin and adaptive margin.
+          #
+          # @return [Boolean] Returns true if it is time to stop processing. False otherwise.
+          def enough?
+            elapsed_time_ms = monotonic_now - @last_polled_at
+            remaining_time_ms = @max_poll_interval_ms - elapsed_time_ms
+
+            safety_margin_ms = @max_poll_interval_ms * @safety_margin
+
+            return true if remaining_time_ms <= safety_margin_ms
+            return false unless @adaptive_margin
+            return true if remaining_time_ms - @max_processing_cost <= safety_margin_ms
+
+            false
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/processing/adaptive_iterator/tracker.rb
+++ b/lib/karafka/pro/processing/adaptive_iterator/tracker.rb
@@ -39,7 +39,6 @@ module Karafka
           end
 
           # Tracks the processing time of a block and updates the maximum processing cost.
-          # If adaptive margin is not enabled, it simply yields to the block without tracking.
           #
           # @yield Executes the block, measuring the time taken for processing.
           def track

--- a/lib/karafka/pro/processing/expansions_selector.rb
+++ b/lib/karafka/pro/processing/expansions_selector.rb
@@ -25,6 +25,7 @@ module Karafka
           expansions = super
           expansions << Pro::Processing::Piping::Consumer
           expansions << Pro::Processing::OffsetMetadata::Consumer if topic.offset_metadata?
+          expansions << Pro::Processing::AdaptiveIterator::Consumer if topic.adaptive_iterator?
           expansions << Pro::Processing::PeriodicJob::Consumer if topic.periodic_job?
           expansions
         end

--- a/lib/karafka/pro/routing/features/adaptive_iterator.rb
+++ b/lib/karafka/pro/routing/features/adaptive_iterator.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Routing
+      module Features
+        # Feature that pro-actively monitors remaining time until max poll interval ms and
+        # cost of processing of each message in a batch. When there is no more time to process
+        # more messages from the batch, it will seek back so we do not reach max poll interval.
+        # It can be useful when we reach this once in a while. For a constant long-running jobs,
+        # please use the Long-Running Jobs feature instead.
+        #
+        # It also provides some wrapping over typical operations users do, like stopping if
+        # revoked, auto-marking, etc
+        class AdaptiveIterator < Base
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/routing/features/adaptive_iterator/config.rb
+++ b/lib/karafka/pro/routing/features/adaptive_iterator/config.rb
@@ -20,13 +20,11 @@ module Karafka
           Config = Struct.new(
             :active,
             :safety_margin,
-            :adaptive_margin,
             :marking_method,
             :clean_after_yielding,
             keyword_init: true
           ) do
             alias_method :active?, :active
-            alias_method :adaptive_margin?, :adaptive_margin
             alias_method :clean_after_yielding?, :clean_after_yielding
           end
         end

--- a/lib/karafka/pro/routing/features/adaptive_iterator/config.rb
+++ b/lib/karafka/pro/routing/features/adaptive_iterator/config.rb
@@ -21,14 +21,12 @@ module Karafka
             :active,
             :safety_margin,
             :adaptive_margin,
-            :mark_after_yielding,
             :marking_method,
             :clean_after_yielding,
             keyword_init: true
           ) do
             alias_method :active?, :active
             alias_method :adaptive_margin?, :adaptive_margin
-            alias_method :mark_after_yielding?, :mark_after_yielding
             alias_method :clean_after_yielding?, :clean_after_yielding
           end
         end

--- a/lib/karafka/pro/routing/features/adaptive_iterator/config.rb
+++ b/lib/karafka/pro/routing/features/adaptive_iterator/config.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Routing
+      module Features
+        class AdaptiveIterator < Base
+          # Adaptive Iterator configuration
+          Config = Struct.new(
+            :active,
+            :safety_margin,
+            :adaptive_margin,
+            :mark_after_yielding,
+            :marking_method,
+            :clean_after_yielding,
+            keyword_init: true
+          ) do
+            alias_method :active?, :active
+            alias_method :adaptive_margin?, :adaptive_margin
+            alias_method :mark_after_yielding?, :mark_after_yielding
+            alias_method :clean_after_yielding?, :clean_after_yielding
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/routing/features/adaptive_iterator/contracts/topic.rb
+++ b/lib/karafka/pro/routing/features/adaptive_iterator/contracts/topic.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Routing
+      module Features
+        class AdaptiveIterator < Base
+          # Namespace for adaptive iterator contracts
+          module Contracts
+            # Contract to validate configuration of the adaptive iterator feature
+            class Topic < Karafka::Contracts::Base
+              configure do |config|
+                config.error_messages = YAML.safe_load(
+                  File.read(
+                    File.join(Karafka.gem_root, 'config', 'locales', 'pro_errors.yml')
+                  )
+                ).fetch('en').fetch('validations').fetch('topic')
+              end
+
+              nested(:adaptive_iterator) do
+                required(:active) { |val| [true, false].include?(val) }
+                required(:safety_margin) { |val| val.is_a?(Integer) && val.positive? && val < 100 }
+                required(:adaptive_margin) { |val| [true, false].include?(val) }
+                required(:mark_after_yielding) { |val| [true, false].include?(val) }
+                required(:clean_after_yielding) { |val| [true, false].include?(val) }
+
+                required(:marking_method) do |val|
+                  %i[mark_as_consumed mark_as_consumed!].include?(val)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/pro/routing/features/adaptive_iterator/contracts/topic.rb
+++ b/lib/karafka/pro/routing/features/adaptive_iterator/contracts/topic.rb
@@ -32,12 +32,39 @@ module Karafka
                 required(:active) { |val| [true, false].include?(val) }
                 required(:safety_margin) { |val| val.is_a?(Integer) && val.positive? && val < 100 }
                 required(:adaptive_margin) { |val| [true, false].include?(val) }
-                required(:mark_after_yielding) { |val| [true, false].include?(val) }
                 required(:clean_after_yielding) { |val| [true, false].include?(val) }
 
                 required(:marking_method) do |val|
                   %i[mark_as_consumed mark_as_consumed!].include?(val)
                 end
+              end
+
+              # Since adaptive iterator uses `#seek` and can break processing in the middle, we
+              # cannot use it with virtual partitions that can process data in a distributed
+              # manner
+              virtual do |data, errors|
+                next unless errors.empty?
+
+                adaptive_iterator = data[:adaptive_iterator]
+                virtual_partitions = data[:virtual_partitions]
+
+                next unless adaptive_iterator[:active]
+                next unless virtual_partitions[:active]
+
+                [[%i[adaptive_iterator], :with_virtual_partitions]]
+              end
+
+              # There is no point of using the adaptive iterator with LRJ because of how LRJ works
+              virtual do |data, errors|
+                next unless errors.empty?
+
+                adaptive_iterator = data[:adaptive_iterator]
+                long_running_jobs = data[:long_running_job]
+
+                next unless adaptive_iterator[:active]
+                next unless long_running_jobs[:active]
+
+                [[%i[adaptive_iterator], :with_long_running_job]]
               end
             end
           end

--- a/lib/karafka/pro/routing/features/adaptive_iterator/contracts/topic.rb
+++ b/lib/karafka/pro/routing/features/adaptive_iterator/contracts/topic.rb
@@ -31,7 +31,6 @@ module Karafka
               nested(:adaptive_iterator) do
                 required(:active) { |val| [true, false].include?(val) }
                 required(:safety_margin) { |val| val.is_a?(Integer) && val.positive? && val < 100 }
-                required(:adaptive_margin) { |val| [true, false].include?(val) }
                 required(:clean_after_yielding) { |val| [true, false].include?(val) }
 
                 required(:marking_method) do |val|

--- a/lib/karafka/pro/routing/features/adaptive_iterator/topic.rb
+++ b/lib/karafka/pro/routing/features/adaptive_iterator/topic.rb
@@ -18,6 +18,7 @@ module Karafka
         class AdaptiveIterator < Base
           # Topic extension allowing us to enable and configure adaptive iterator
           module Topic
+            # @param active [Boolean] should we use the automatic adaptive iterator
             # @param safety_margin [Integer]
             #   How big of a margin we leave ourselves so we can safely communicate back with
             #   Kafka, etc. We stop and seek back when we've burned 85% of the time by default.
@@ -27,22 +28,20 @@ module Karafka
             #   This computes the cost of processing based on first processed message. If the cost
             #   of processing despite being below the safety margin would not allow us to process
             #   the message, we will not
-            # @param mark_after_yielding [Boolean] Should we mark after each message
             # @param marking_method [Symbol] If we should, how should we mark
             # @param clean_after_yielding [Boolean]  Should we clean post-yielding via the
             #   cleaner API
             def adaptive_iterator(
-              safety_margin: 15,
+              active: false,
+              safety_margin: 10,
               adaptive_margin: true,
-              mark_after_yielding: true,
               marking_method: :mark_as_consumed,
               clean_after_yielding: true
             )
               @adaptive_iterator ||= Config.new(
-                active: true,
+                active: active,
                 safety_margin: safety_margin,
                 adaptive_margin: adaptive_margin,
-                mark_after_yielding: mark_after_yielding,
                 marking_method: marking_method,
                 clean_after_yielding: clean_after_yielding
               )

--- a/lib/karafka/pro/routing/features/adaptive_iterator/topic.rb
+++ b/lib/karafka/pro/routing/features/adaptive_iterator/topic.rb
@@ -24,24 +24,18 @@ module Karafka
             #   Kafka, etc. We stop and seek back when we've burned 85% of the time by default.
             #   We leave 15% of time for post-processing operations so we have space before we
             #   hit max.poll.interval.ms.
-            # @param adaptive_margin [Boolean]
-            #   This computes the cost of processing based on first processed message. If the cost
-            #   of processing despite being below the safety margin would not allow us to process
-            #   the message, we will not
             # @param marking_method [Symbol] If we should, how should we mark
             # @param clean_after_yielding [Boolean]  Should we clean post-yielding via the
             #   cleaner API
             def adaptive_iterator(
               active: false,
               safety_margin: 10,
-              adaptive_margin: true,
               marking_method: :mark_as_consumed,
               clean_after_yielding: true
             )
               @adaptive_iterator ||= Config.new(
                 active: active,
                 safety_margin: safety_margin,
-                adaptive_margin: adaptive_margin,
                 marking_method: marking_method,
                 clean_after_yielding: clean_after_yielding
               )

--- a/lib/karafka/pro/routing/features/adaptive_iterator/topic.rb
+++ b/lib/karafka/pro/routing/features/adaptive_iterator/topic.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# This Karafka component is a Pro component under a commercial license.
+# This Karafka component is NOT licensed under LGPL.
+#
+# All of the commercial components are present in the lib/karafka/pro directory of this
+# repository and their usage requires commercial license agreement.
+#
+# Karafka has also commercial-friendly license, commercial support and commercial components.
+#
+# By sending a pull request to the pro components, you are agreeing to transfer the copyright of
+# your code to Maciej Mensfeld.
+
+module Karafka
+  module Pro
+    module Routing
+      module Features
+        class AdaptiveIterator < Base
+          # Topic extension allowing us to enable and configure adaptive iterator
+          module Topic
+            # @param safety_margin [Integer]
+            #   How big of a margin we leave ourselves so we can safely communicate back with
+            #   Kafka, etc. We stop and seek back when we've burned 85% of the time by default.
+            #   We leave 15% of time for post-processing operations so we have space before we
+            #   hit max.poll.interval.ms.
+            # @param adaptive_margin [Boolean]
+            #   This computes the cost of processing based on first processed message. If the cost
+            #   of processing despite being below the safety margin would not allow us to process
+            #   the message, we will not
+            # @param mark_after_yielding [Boolean] Should we mark after each message
+            # @param marking_method [Symbol] If we should, how should we mark
+            # @param clean_after_yielding [Boolean]  Should we clean post-yielding via the
+            #   cleaner API
+            def adaptive_iterator(
+              safety_margin: 15,
+              adaptive_margin: true,
+              mark_after_yielding: true,
+              marking_method: :mark_as_consumed,
+              clean_after_yielding: true
+            )
+              @adaptive_iterator ||= Config.new(
+                active: true,
+                safety_margin: safety_margin,
+                adaptive_margin: adaptive_margin,
+                mark_after_yielding: mark_after_yielding,
+                marking_method: marking_method,
+                clean_after_yielding: clean_after_yielding
+              )
+            end
+
+            # @return [Boolean] Is adaptive iterator active. It is always `true`, since we use it
+            #   via explicit messages batch wrapper
+            def adaptive_iterator?
+              adaptive_iterator.active?
+            end
+
+            # @return [Hash] topic with all its native configuration options plus poll guarding
+            #   setup configuration.
+            def to_h
+              super.merge(
+                adaptive_iterator: adaptive_iterator.to_h
+              ).freeze
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/processing/coordinator.rb
+++ b/lib/karafka/processing/coordinator.rb
@@ -19,6 +19,9 @@ module Karafka
       # any messages
       attr_accessor :eofed
 
+      # Last polled at time set based on the incoming last poll time
+      attr_accessor :last_polled_at
+
       def_delegators :@pause_tracker, :attempt, :paused?
 
       # @param topic [Karafka::Routing::Topic]
@@ -38,6 +41,7 @@ module Karafka
         @failure = false
         @eofed = false
         @changed_at = monotonic_now
+        @last_polled_at = @changed_at
       end
 
       # Starts the coordinator for given consumption jobs

--- a/spec/integrations/instrumentation/consumer_seeking_spec.rb
+++ b/spec/integrations/instrumentation/consumer_seeking_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# We should be able to instrument seeking
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[:messages] << messages.first.offset
+
+    seek(0)
+  end
+end
+
+draw_routes(Consumer)
+
+Karafka::App.monitor.subscribe('consumer.consuming.seek') do |event|
+  DT[:seeks] << event
+end
+
+produce_many(DT.topic, DT.uuids(1))
+
+start_karafka_and_wait_until do
+  DT[:messages].size >= 5
+end
+
+assert_equal DT[:messages].uniq, [0]
+assert DT[:seeks].count >= 4
+
+assert DT[:seeks].first[:caller].is_a?(Consumer)
+assert_equal DT[:seeks].first[:topic], DT.topic
+assert_equal DT[:seeks].first[:message].offset, 0

--- a/spec/integrations/pro/consumption/adaptive_iterator/with_adaptive_estimated_processing_limited_spec.rb
+++ b/spec/integrations/pro/consumption/adaptive_iterator/with_adaptive_estimated_processing_limited_spec.rb
@@ -24,8 +24,7 @@ draw_routes do
     consumer Consumer
     adaptive_iterator(
       active: true,
-      safety_margin: 1,
-      adaptive_margin: true
+      safety_margin: 1
     )
   end
 end

--- a/spec/integrations/pro/consumption/adaptive_iterator/with_adaptive_estimated_processing_limited_spec.rb
+++ b/spec/integrations/pro/consumption/adaptive_iterator/with_adaptive_estimated_processing_limited_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# With adaptive margin, if the max cost of message would cause reaching max poll, we should seek
+# back
+
+setup_karafka do |config|
+  config.concurrency = 1
+  config.max_messages = 100
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    each do |message|
+      sleep((message.offset % 3))
+      DT[:offsets] << message.offset
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    adaptive_iterator(
+      active: true,
+      safety_margin: 1,
+      adaptive_margin: true
+    )
+  end
+end
+
+produce_many(DT.topic, DT.uuids(10))
+
+start_karafka_and_wait_until do
+  DT[:offsets].size >= 10
+end
+
+assert_equal DT[:offsets], (0..9).to_a

--- a/spec/integrations/pro/consumption/adaptive_iterator/with_fast_exit_on_stop_spec.rb
+++ b/spec/integrations/pro/consumption/adaptive_iterator/with_fast_exit_on_stop_spec.rb
@@ -23,8 +23,7 @@ draw_routes do
     consumer Consumer
     adaptive_iterator(
       active: true,
-      safety_margin: 1,
-      adaptive_margin: true
+      safety_margin: 1
     )
   end
 end

--- a/spec/integrations/pro/consumption/adaptive_iterator/with_fast_exit_on_stop_spec.rb
+++ b/spec/integrations/pro/consumption/adaptive_iterator/with_fast_exit_on_stop_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# We should stop fast and not process all in batch and offset position should be preserved
+
+setup_karafka do |config|
+  config.concurrency = 1
+  config.max_messages = 100
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    each do |message|
+      sleep((message.offset % 3))
+      DT[:offsets] << message.offset
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    adaptive_iterator(
+      active: true,
+      safety_margin: 1,
+      adaptive_margin: true
+    )
+  end
+end
+
+produce_many(DT.topic, DT.uuids(10))
+
+start_karafka_and_wait_until do
+  DT[:offsets].size >= 3
+end
+
+assert_equal DT[:offsets].last + 1, fetch_next_offset

--- a/spec/integrations/pro/consumption/adaptive_iterator/without_adaptive_stable_processing_limited_spec.rb
+++ b/spec/integrations/pro/consumption/adaptive_iterator/without_adaptive_stable_processing_limited_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# When processing messages with iterator enabled and reaching max.poll.interval, we should never
+# get any errors and processing should be consecutive
+
+setup_karafka do |config|
+  config.concurrency = 1
+  config.max_messages = 100
+  config.kafka[:'max.poll.interval.ms'] = 10_000
+  config.kafka[:'session.timeout.ms'] = 10_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    each do |message|
+      sleep(1)
+      DT[:offsets] << message.offset
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    adaptive_iterator(
+      active: true,
+      safety_margin: 20,
+      adaptive_margin: false
+    )
+  end
+end
+
+produce_many(DT.topic, DT.uuids(20))
+
+start_karafka_and_wait_until do
+  DT[:offsets].size >= 20
+end
+
+assert_equal DT[:offsets], (0..19).to_a

--- a/spec/integrations/pro/consumption/adaptive_iterator/without_adaptive_stable_processing_limited_spec.rb
+++ b/spec/integrations/pro/consumption/adaptive_iterator/without_adaptive_stable_processing_limited_spec.rb
@@ -24,8 +24,7 @@ draw_routes do
     consumer Consumer
     adaptive_iterator(
       active: true,
-      safety_margin: 20,
-      adaptive_margin: false
+      safety_margin: 20
     )
   end
 end

--- a/spec/integrations/pro/consumption/adaptive_iterator/without_anything_running_spec.rb
+++ b/spec/integrations/pro/consumption/adaptive_iterator/without_anything_running_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# When processing messages with iterator enabled but no features enabled, it should work
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    each do |message|
+      DT[:done] = message
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    adaptive_iterator(
+      active: true,
+      clean_after_yielding: false
+    )
+  end
+end
+
+produce_many(DT.topic, DT.uuids(10))
+
+start_karafka_and_wait_until do
+  DT.key?(:done)
+end

--- a/spec/integrations/pro/consumption/from_earliest_direct_iterator_spec.rb
+++ b/spec/integrations/pro/consumption/from_earliest_direct_iterator_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Karafka should be able to easily consume all the messages from earliest (default) exactly
+# the same way with pro as it does without
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    each do |message|
+      DT[message.metadata.partition] << message.raw_payload
+    end
+  end
+end
+
+draw_routes(Consumer)
+
+elements = DT.uuids(100)
+produce_many(DT.topic, elements)
+
+start_karafka_and_wait_until do
+  DT[0].size >= 100
+end
+
+assert_equal elements, DT[0]
+assert_equal 1, DT.data.size
+assert_equal 100, fetch_next_offset

--- a/spec/lib/karafka/connection/raw_messages_buffer_spec.rb
+++ b/spec/lib/karafka/connection/raw_messages_buffer_spec.rb
@@ -3,6 +3,21 @@
 RSpec.describe_current do
   subject(:buffer) { described_class.new }
 
+  describe '#last_polled_at' do
+    it { expect(buffer.last_polled_at).to be > 0 }
+
+    context 'when polled' do
+      before { buffer }
+
+      it 'expect to be newer then moment ago' do
+        now = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) * 1_000
+        expect(buffer.last_polled_at).to be < now
+        buffer.polled
+        expect(buffer.last_polled_at).to be > now
+      end
+    end
+  end
+
   describe '#<<, #size and #each' do
     context 'when there are no messages' do
       it { expect(buffer.size).to eq(0) }

--- a/spec/lib/karafka/instrumentation/logger_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/logger_listener_spec.rb
@@ -175,6 +175,29 @@ RSpec.describe_current do
     it { expect(Karafka.logger).to have_received(:info).with(message) }
   end
 
+  describe '#on_consumer_consuming_seek' do
+    subject(:trigger) { listener.on_consumer_consuming_seek(event) }
+
+    let(:consumer) { Class.new(Karafka::BaseConsumer).new }
+    let(:kafka_message) { create(:messages_message) }
+    let(:message) do
+      <<~MSG.tr("\n", ' ').strip
+        [#{consumer.id}] Seeking from #{consumer.class}
+        on topic Topic/0 to offset #{kafka_message.offset}
+      MSG
+    end
+    let(:payload) do
+      {
+        caller: consumer,
+        topic: 'Topic',
+        partition: 0,
+        message: kafka_message
+      }
+    end
+
+    it { expect(Karafka.logger).to have_received(:info).with(message) }
+  end
+
   describe '#on_process_notice_signal' do
     subject(:trigger) { listener.on_process_notice_signal(event) }
 

--- a/spec/lib/karafka/pro/processing/adaptive_iterator/tracker_spec.rb
+++ b/spec/lib/karafka/pro/processing/adaptive_iterator/tracker_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:tracker) do
+    described_class.new(
+      safety_margin,
+      adaptive_margin,
+      last_polled_at,
+      max_poll_interval_ms
+    )
+  end
+
+  let(:safety_margin) { 15 }
+  let(:adaptive_margin) { true }
+  let(:last_polled_at) { described_class.new(1, 1, 1, 1).monotonic_now }
+  let(:max_poll_interval_ms) { 10_000 }
+
+  before { tracker }
+
+  describe '#track' do
+    context 'when adaptive_margin is true' do
+      it 'yields the block and tracks processing time' do
+        expect do |block|
+          tracker.track(&block)
+        end.to yield_control
+      end
+    end
+
+    context 'when adaptive_margin is false' do
+      let(:adaptive_margin) { false }
+
+      it 'yields the block without tracking processing time' do
+        expect do |block|
+          tracker.track(&block)
+        end.to yield_control
+      end
+    end
+  end
+
+  describe '#enough?' do
+    context 'when there is enough time left for processing' do
+      it 'returns false' do
+        sleep(0.01) # Simulate a small delay
+        expect(tracker.enough?).to be(false)
+      end
+    end
+
+    context 'when there is not enough time left considering the safety margin' do
+      let(:max_poll_interval_ms) { 550 }
+
+      it 'returns true' do
+        sleep(0.5) # Simulate a delay that makes it hit the safety margin
+        expect(tracker.enough?).to be(true)
+      end
+    end
+
+    context 'when adaptive_margin is enabled and max processing cost is considered' do
+      let(:max_poll_interval_ms) { 700 }
+
+      it 'returns true if the remaining time is less than the max processing cost' do
+        tracker.track do
+          sleep(0.3) # Simulate a processing delay to set max_processing_cost
+        end
+
+        sleep(0.1) # Simulate some more elapsed time
+        expect(tracker.enough?).to be(true)
+      end
+
+      it 'returns false if there is still enough time considering max processing cost' do
+        tracker.track do
+          sleep(0.01) # Set a small max processing cost
+        end
+
+        sleep(0.01) # Simulate small delay
+        expect(tracker.enough?).to be(false)
+      end
+    end
+  end
+end

--- a/spec/lib/karafka/pro/processing/adaptive_iterator/tracker_spec.rb
+++ b/spec/lib/karafka/pro/processing/adaptive_iterator/tracker_spec.rb
@@ -4,21 +4,19 @@ RSpec.describe_current do
   subject(:tracker) do
     described_class.new(
       safety_margin,
-      adaptive_margin,
       last_polled_at,
       max_poll_interval_ms
     )
   end
 
   let(:safety_margin) { 15 }
-  let(:adaptive_margin) { true }
   let(:last_polled_at) { described_class.new(1, 1, 1, 1).monotonic_now }
   let(:max_poll_interval_ms) { 10_000 }
 
   before { tracker }
 
   describe '#track' do
-    context 'when adaptive_margin is true' do
+    context 'when adaptive margin kicks in' do
       it 'yields the block and tracks processing time' do
         expect do |block|
           tracker.track(&block)
@@ -26,7 +24,7 @@ RSpec.describe_current do
       end
     end
 
-    context 'when adaptive_margin is false' do
+    context 'when adaptive margin does not kick in' do
       let(:adaptive_margin) { false }
 
       it 'yields the block without tracking processing time' do
@@ -54,7 +52,7 @@ RSpec.describe_current do
       end
     end
 
-    context 'when adaptive_margin is enabled and max processing cost is considered' do
+    context 'when adaptive margin kicks in and max processing cost is considered' do
       let(:max_poll_interval_ms) { 700 }
 
       it 'returns true if the remaining time is less than the max processing cost' do

--- a/spec/lib/karafka/pro/processing/adaptive_iterator/tracker_spec.rb
+++ b/spec/lib/karafka/pro/processing/adaptive_iterator/tracker_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe_current do
   end
 
   let(:safety_margin) { 15 }
-  let(:last_polled_at) { described_class.new(1, 1, 1, 1).monotonic_now }
+  let(:last_polled_at) { described_class.new(1, 1, 1).monotonic_now }
   let(:max_poll_interval_ms) { 10_000 }
 
   before { tracker }

--- a/spec/lib/karafka/pro/routing/features/adaptive_iterator/config_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/adaptive_iterator/config_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:config) { described_class.new(safety_margin: safety_margin, active: active) }
+
+  let(:safety_margin) { 1 }
+  let(:active) { true }
+
+  describe '#active?' do
+    context 'when active' do
+      it { expect(config.active?).to eq(true) }
+    end
+
+    context 'when not active' do
+      let(:active) { false }
+
+      it { expect(config.active?).to eq(false) }
+    end
+  end
+
+  describe '#to_h' do
+    it { expect(config.to_h[:safety_margin]).to eq(safety_margin) }
+    it { expect(config.to_h[:active]).to eq(true) }
+  end
+end

--- a/spec/lib/karafka/pro/routing/features/adaptive_iterator/contracts/topic_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/adaptive_iterator/contracts/topic_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe_current do
       adaptive_iterator: {
         active: true,
         safety_margin: 15,
-        adaptive_margin: true,
         clean_after_yielding: true,
         marking_method: :mark_as_consumed
       },
@@ -39,12 +38,6 @@ RSpec.describe_current do
 
   context 'when safety_margin is 100 or more' do
     before { config[:adaptive_iterator][:safety_margin] = 100 }
-
-    it { expect(check).not_to be_success }
-  end
-
-  context 'when adaptive_margin is not a boolean' do
-    before { config[:adaptive_iterator][:adaptive_margin] = nil }
 
     it { expect(check).not_to be_success }
   end

--- a/spec/lib/karafka/pro/routing/features/adaptive_iterator/contracts/topic_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/adaptive_iterator/contracts/topic_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:check) { described_class.new.call(config) }
+
+  let(:config) do
+    {
+      adaptive_iterator: {
+        active: true,
+        safety_margin: 15,
+        adaptive_margin: true,
+        mark_after_yielding: true,
+        clean_after_yielding: true,
+        marking_method: :mark_as_consumed
+      }
+    }
+  end
+
+  context 'when config is valid' do
+    it { expect(check).to be_success }
+  end
+
+  context 'when safety_margin is not an integer' do
+    before { config[:adaptive_iterator][:safety_margin] = 'invalid_margin' }
+
+    it { expect(check).not_to be_success }
+  end
+
+  context 'when safety_margin is not positive' do
+    before { config[:adaptive_iterator][:safety_margin] = -5 }
+
+    it { expect(check).not_to be_success }
+  end
+
+  context 'when safety_margin is 100 or more' do
+    before { config[:adaptive_iterator][:safety_margin] = 100 }
+
+    it { expect(check).not_to be_success }
+  end
+
+  context 'when adaptive_margin is not a boolean' do
+    before { config[:adaptive_iterator][:adaptive_margin] = nil }
+
+    it { expect(check).not_to be_success }
+  end
+
+  context 'when marking_method is not a valid symbol' do
+    before { config[:adaptive_iterator][:marking_method] = :invalid_method }
+
+    it { expect(check).not_to be_success }
+  end
+
+  context 'when mark_after_yielding is not a boolean' do
+    before { config[:adaptive_iterator][:mark_after_yielding] = nil }
+
+    it { expect(check).not_to be_success }
+  end
+
+  context 'when clean_after_yielding is not a boolean' do
+    before { config[:adaptive_iterator][:clean_after_yielding] = nil }
+
+    it { expect(check).not_to be_success }
+  end
+end

--- a/spec/lib/karafka/pro/routing/features/adaptive_iterator/contracts/topic_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/adaptive_iterator/contracts/topic_spec.rb
@@ -9,9 +9,14 @@ RSpec.describe_current do
         active: true,
         safety_margin: 15,
         adaptive_margin: true,
-        mark_after_yielding: true,
         clean_after_yielding: true,
         marking_method: :mark_as_consumed
+      },
+      virtual_partitions: {
+        active: false
+      },
+      long_running_job: {
+        active: false
       }
     }
   end
@@ -50,14 +55,20 @@ RSpec.describe_current do
     it { expect(check).not_to be_success }
   end
 
-  context 'when mark_after_yielding is not a boolean' do
-    before { config[:adaptive_iterator][:mark_after_yielding] = nil }
+  context 'when clean_after_yielding is not a boolean' do
+    before { config[:adaptive_iterator][:clean_after_yielding] = nil }
 
     it { expect(check).not_to be_success }
   end
 
-  context 'when clean_after_yielding is not a boolean' do
-    before { config[:adaptive_iterator][:clean_after_yielding] = nil }
+  context 'when trying to use the adaptive iterator with virtual partitions' do
+    before { config[:virtual_partitions][:active] = true }
+
+    it { expect(check).not_to be_success }
+  end
+
+  context 'when trying to use the adaptive iterator with long running job' do
+    before { config[:long_running_job][:active] = true }
 
     it { expect(check).not_to be_success }
   end

--- a/spec/lib/karafka/pro/routing/features/adaptive_iterator/topic_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/adaptive_iterator/topic_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:topic) do
+    build(:routing_topic).tap do |topic|
+      topic.singleton_class.prepend described_class
+    end
+  end
+
+  describe '#adaptive_iterator' do
+    context 'when we use adaptive_iterator without any arguments' do
+      it 'expects to initialize with defaults' do
+        expect(topic.adaptive_iterator.active?).to eq(true)
+        expect(topic.adaptive_iterator.safety_margin).to eq(15)
+        expect(topic.adaptive_iterator.adaptive_margin).to eq(true)
+        expect(topic.adaptive_iterator.mark_after_yielding).to eq(true)
+        expect(topic.adaptive_iterator.marking_method).to eq(:mark_as_consumed)
+        expect(topic.adaptive_iterator.clean_after_yielding).to eq(true)
+      end
+    end
+
+    context 'when we use adaptive_iterator with custom safety margin' do
+      it 'expects to use the provided safety margin' do
+        safety_margin = 10
+        topic.adaptive_iterator(safety_margin: safety_margin)
+        expect(topic.adaptive_iterator.safety_margin).to eq(safety_margin)
+      end
+    end
+
+    context 'when we use adaptive_iterator with adaptive_margin set to false' do
+      it 'expects to use the provided adaptive_margin' do
+        topic.adaptive_iterator(adaptive_margin: false)
+        expect(topic.adaptive_iterator.adaptive_margin).to eq(false)
+      end
+    end
+
+    context 'when we use custom marking method' do
+      it 'expects to use the provided marking method' do
+        marking_method = :custom_mark_method
+        topic.adaptive_iterator(marking_method: marking_method)
+        expect(topic.adaptive_iterator.marking_method).to eq(marking_method)
+      end
+    end
+
+    context 'when we disable clean_after_yielding' do
+      it 'expects clean_after_yielding to be false' do
+        topic.adaptive_iterator(clean_after_yielding: false)
+        expect(topic.adaptive_iterator.clean_after_yielding).to eq(false)
+      end
+    end
+  end
+
+  describe '#adaptive_iterator?' do
+    context 'when adaptive_iterator is always active' do
+      before { topic.adaptive_iterator }
+
+      it { expect(topic.adaptive_iterator?).to eq(true) }
+    end
+  end
+
+  describe '#to_h' do
+    it 'expects to include adaptive_iterator configuration in the hash' do
+      expect(topic.to_h[:adaptive_iterator]).to eq(topic.adaptive_iterator.to_h)
+    end
+  end
+end

--- a/spec/lib/karafka/pro/routing/features/adaptive_iterator/topic_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/adaptive_iterator/topic_spec.rb
@@ -10,10 +10,9 @@ RSpec.describe_current do
   describe '#adaptive_iterator' do
     context 'when we use adaptive_iterator without any arguments' do
       it 'expects to initialize with defaults' do
-        expect(topic.adaptive_iterator.active?).to eq(true)
-        expect(topic.adaptive_iterator.safety_margin).to eq(15)
+        expect(topic.adaptive_iterator.active?).to eq(false)
+        expect(topic.adaptive_iterator.safety_margin).to eq(10)
         expect(topic.adaptive_iterator.adaptive_margin).to eq(true)
-        expect(topic.adaptive_iterator.mark_after_yielding).to eq(true)
         expect(topic.adaptive_iterator.marking_method).to eq(:mark_as_consumed)
         expect(topic.adaptive_iterator.clean_after_yielding).to eq(true)
       end
@@ -21,7 +20,7 @@ RSpec.describe_current do
 
     context 'when we use adaptive_iterator with custom safety margin' do
       it 'expects to use the provided safety margin' do
-        safety_margin = 10
+        safety_margin = 5
         topic.adaptive_iterator(safety_margin: safety_margin)
         expect(topic.adaptive_iterator.safety_margin).to eq(safety_margin)
       end
@@ -51,10 +50,10 @@ RSpec.describe_current do
   end
 
   describe '#adaptive_iterator?' do
-    context 'when adaptive_iterator is always active' do
+    context 'when adaptive_iterator is not active' do
       before { topic.adaptive_iterator }
 
-      it { expect(topic.adaptive_iterator?).to eq(true) }
+      it { expect(topic.adaptive_iterator?).to eq(false) }
     end
   end
 

--- a/spec/lib/karafka/pro/routing/features/adaptive_iterator/topic_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/adaptive_iterator/topic_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe_current do
       it 'expects to initialize with defaults' do
         expect(topic.adaptive_iterator.active?).to eq(false)
         expect(topic.adaptive_iterator.safety_margin).to eq(10)
-        expect(topic.adaptive_iterator.adaptive_margin).to eq(true)
         expect(topic.adaptive_iterator.marking_method).to eq(:mark_as_consumed)
         expect(topic.adaptive_iterator.clean_after_yielding).to eq(true)
       end
@@ -23,13 +22,6 @@ RSpec.describe_current do
         safety_margin = 5
         topic.adaptive_iterator(safety_margin: safety_margin)
         expect(topic.adaptive_iterator.safety_margin).to eq(safety_margin)
-      end
-    end
-
-    context 'when we use adaptive_iterator with adaptive_margin set to false' do
-      it 'expects to use the provided adaptive_margin' do
-        topic.adaptive_iterator(adaptive_margin: false)
-        expect(topic.adaptive_iterator.adaptive_margin).to eq(false)
       end
     end
 

--- a/spec/lib/karafka/pro/routing/features/adaptive_iterator_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/adaptive_iterator_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  it { expect(described_class).to be < ::Karafka::Pro::Routing::Features::Base }
+end

--- a/spec/lib/karafka/processing/coordinator_spec.rb
+++ b/spec/lib/karafka/processing/coordinator_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe_current do
   let(:pause_tracker) { build(:time_trackers_pause) }
   let(:message) { build(:messages_message) }
 
+  describe '#last_polled_at' do
+    it { expect(coordinator.last_polled_at).to be > 0 }
+  end
+
   describe '#pause_tracker' do
     it { expect(coordinator.pause_tracker).to eq(pause_tracker) }
   end


### PR DESCRIPTION
close https://github.com/karafka/karafka/issues/2168

This is an alternative to LRJ, when a risk of reaching max.poll.interval is low and it can happen "once in a while". For example when making external HTTP calls that are usually fast ubt not wanting to risk that it will suddenly go slow or having a big batch with messages where after processing 90% it would reach max poll interval but big batches are not the usual standard. In such case instead of lowering the general batch size we can use this feature to re-seek the position and trigger polling, effectively mitigating this.
