### PR TITLE
Don't report declarative partitions with fewer topics than on cluster

### DIFF
--- a/lib/karafka/cli/topics/plan.rb
+++ b/lib/karafka/cli/topics/plan.rb
@@ -97,7 +97,7 @@ module Karafka
 
             existing_partitions = existing_topic.fetch(:partition_count)
 
-            next if declarative_topic.declaratives.partitions == existing_partitions
+            next if declarative_topic.declaratives.partitions <= existing_partitions
 
             @topics_to_repartition << [declarative_topic, existing_partitions]
           end

--- a/spec/integrations/cli/declaratives/plan/when_with_partitions_spec.rb
+++ b/spec/integrations/cli/declaratives/plan/when_with_partitions_spec.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-# When declarative topics exist with repartition request, it should work
+# When declarative topics exist with repartition request, it should work,
+# while ignoring topics that already have more partitions than specified
 
 setup_karafka
 
 Karafka::Admin.create_topic(DT.topics[0], 1, 1)
 Karafka::Admin.create_topic(DT.topics[1], 3, 1)
+Karafka::Admin.create_topic(DT.topics[2], 5, 1)
 
 draw_routes(create_topics: false) do
   topic DT.topics[0] do
@@ -16,6 +18,11 @@ draw_routes(create_topics: false) do
   topic DT.topics[1] do
     active false
     config(partitions: 5)
+  end
+
+  topic DT.topics[2] do
+    active false
+    config(partitions: 3)
   end
 end
 


### PR DESCRIPTION
We've recently started using the declarative topic management in our deploy pipeline, and its super convenient.

One thing I noticed is that whilst `karafka topics migrate` is conservative, and will never reduce the number of partitions on an existing topic, `karafka topics plan`'s output suggests otherwise.

Example output:

```tf
Following topics will be repartitioned:

  ~ topic-a:
    ~ partitions: "3" => "1"

  ~ topic-b:
    ~ partitions: "3" => "1"

  ~ topic-c:
    ~ partitions: "3" => "1"
```

This PR just tweaks the `karafka topics plan` command to ignore topics that have fewer topics in the declarative topics definition than exist on the broker.