### PR TITLE
[fix] validate swarm cli and always parse options from argv

### DIFF
--- a/lib/karafka/cli/base.rb
+++ b/lib/karafka/cli/base.rb
@@ -96,7 +96,7 @@ module Karafka
                 *[names, option[2], option[1]].flatten
               ) { |value| options[option[0]] = value }
             end
-          end.parse!
+          end.parse(ARGV)
 
           options
         end

--- a/lib/karafka/swarm/supervisor.rb
+++ b/lib/karafka/swarm/supervisor.rb
@@ -47,6 +47,10 @@ module Karafka
 
         Karafka::App.warmup
 
+        config.internal.cli.contract.validate!(
+          config.internal.routing.activity_manager.to_h
+        )
+
         manager.start
 
         process.on_sigint { stop }
@@ -67,6 +71,11 @@ module Karafka
           lock
           control
         end
+
+      # If the cli contract validation failed reraise immediately.
+      rescue Karafka::Errors::InvalidConfigurationError => e
+        raise e
+
       # If anything went wrong, signal this and die
       # Supervisor is meant to be thin and not cause any issues. If you encounter this case
       # please report it as it should be considered critical
@@ -86,6 +95,11 @@ module Karafka
       end
 
       private
+
+      # @return [Karafka::Core::Configurable::Node] root config node
+      def config
+        Karafka::App.config
+      end
 
       # Keeps the lock on the queue so we control nodes only when it is needed
       # @note We convert to seconds since the queue timeout requires seconds

--- a/spec/integrations/swarm/cli_validations_for_inclusions_spec.rb
+++ b/spec/integrations/swarm/cli_validations_for_inclusions_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Karafka should fail if we specify a consumer group that was not defined
+
+setup_karafka
+
+guarded = []
+
+draw_routes(create_topics: false) do
+  consumer_group 'existing' do
+    topic 'regular' do
+      consumer Class.new
+    end
+  end
+end
+
+ARGV[0] = 'swarm'
+ARGV[1] = '--consumer-groups'
+ARGV[2] = 'non-existing'
+
+begin
+  Karafka::Cli.start
+rescue Karafka::Errors::InvalidConfigurationError => e
+  assert e.message.include?('Unknown consumer group name')
+
+  guarded << true
+end
+
+ARGV.clear
+assert_equal 1, guarded.size


### PR DESCRIPTION
Fixes: https://github.com/karafka/karafka/issues/2305

Instead of destructively calling `OptionParser#parse!` to parse the options, we can use the non-bang method and always pass `ARGV`. This way we can allow subsequent calls to other `Karafka::Cli::Base` classes and ensure they also get the options passed.

Perform CLI contract validations within the swarm supervisor. This will allow the command to fail if invalid options are passed.