### PR TITLE
update issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,8 +17,8 @@ If Karafka or its components are critical to your infrastructure, we encourage y
 Please take a moment to review the following resources before submitting your report:
 
 - [Issue Reporting Guide](https://karafka.io/docs/Support/#issue-reporting-guide) - A guide on what information is required for effective issue reporting.
-- [Karafka Support Policy](https://karafka.io/docs/Support/) - Details on the scope of support offered for different versions and tiers.
-- [Karafka Versions, Lifecycle, and EOL](https://karafka.io/docs/Versions-Lifecycle-and-EOL/) - Information about the current supported versions and End-Of-Life (EOL) policies.
+- [Support Policy](https://karafka.io/docs/Support/) - Details on the scope of support offered for different versions and tiers.
+- [Versions, Lifecycle, and EOL](https://karafka.io/docs/Versions-Lifecycle-and-EOL/) - Information about the current supported versions and End-Of-Life (EOL) policies.
 
 ## Bug Report Details
 
@@ -26,10 +26,6 @@ Please provide all the details per our [Issue Reporting Guide](https://karafka.i
 
 > [!IMPORTANT]
 > Failing to provide the required details may result in the issue being closed. Please include all necessary information to help us understand and resolve your issue effectively.
-
-### Screenshots/Logs
-
-If applicable, add screenshots or logs to help explain your problem.
 
 ## Additional Context
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,49 +3,36 @@ name: Bug Report
 about: Report an issue with Karafka you've discovered.
 ---
 
-*Be clear, concise and precise in your description of the problem.
-Open an issue with a descriptive title and a summary in grammatically correct,
-complete sentences.*
+Thank you for reporting an issue with Karafka. To make this process smoother for everyone involved, please read the following information before filling out the template.
 
-*Use the template below when reporting bugs. Please, make sure that
-you're running the latest stable Karafka and that the problem you're reporting
-hasn't been reported (and potentially fixed) already.*
+> [!IMPORTANT]
+> We do not provide OSS support for outdated versions of Karafka. Please ensure that you are using a version that is still actively supported, as we cannot assist with no longer maintained versions unless you support us with our [Pro offering](https://karafka.io/docs/Pro-Support/).
 
-*Before filing the ticket you should replace all text above the horizontal
-rule with your own words.*
+## Important Links
 
---------
+Please take a moment to review the following resources before submitting your report:
 
-## Expected behavior
+- [Issue Reporting Guide](https://karafka.io/docs/Support/#issue-reporting-guide) - A guide on what information is required for effective issue reporting.
+- [Karafka Support Policy](https://karafka.io/docs/Support/) - Details on the scope of support offered for different versions and tiers.
+- [Karafka Versions, Lifecycle, and EOL](https://karafka.io/docs/Versions-Lifecycle-and-EOL/) - Information about the current supported versions and End-Of-Life (EOL) policies.
 
-Describe here how you expected Karafka to behave in this particular situation.
+## Encouragement for Pro Support
 
-## Actual behavior
+We acknowledge that understanding the specifics of your application and its configuration can be essential for resolving certain issues. However, due to the extensive time and resources such analysis can require, this falls beyond our Open Source Support scope.
 
-Describe here what actually happened.
+If Karafka or its components are critical to your infrastructure, we encourage you to consider our [Pro Offering](https://karafka.io/docs/Pro-Support/). By backing Karafka through our Pro offering, you can gain direct assistance and ensure your use case receives the dedicated attention it deserves.
 
-## Steps to reproduce the problem
+## Bug Report Details
 
-This is extremely important! Providing us with a reliable way to reproduce
-a problem will expedite its solution.
+Please provide all the details per our [Issue Reporting Guide](https://karafka.io/docs/Support/#issue-reporting-guide).
 
-## Your setup details
+> [!IMPORTANT]
+> Failing to provide the required details may result in the issue being closed. Please include all necessary information to help us understand and resolve your issue effectively.
 
-Please provide kafka version and the output of `karafka info` or `bundle exec karafka info` if using Bundler.
+### Screenshots/Logs
 
-Here's an example:
+If applicable, add screenshots or logs to help explain your problem.
 
-```
-$ [bundle exec] karafka info
-Karafka version: 2.2.10 + Pro
-Ruby version: ruby 3.2.2 (2023-03-30 revision e51014f9c0) [x86_64-linux]
-Rdkafka version: 0.13.8
-Consumer groups count: 2
-Subscription groups count: 2
-Workers count: 2
-Application client id: example_app
-Boot file: /app/karafka.rb
-Environment: development
-License: Commercial
-License entity: karafka-ci
-```
+## Additional Context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,3 @@
----
-name: Bug Report
-about: Report an issue with Karafka you've discovered.
----
-
 Thank you for reporting an issue with Karafka. To make this process smoother for everyone involved, please read the following information before filling out the template.
 
 > [!IMPORTANT]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,8 @@
+---
+name: Bug Report
+about: Report an issue with Karafka you've discovered.
+---
+
 Thank you for reporting an issue with Karafka. To make this process smoother for everyone involved, please read the following information before filling out the template.
 
 > [!IMPORTANT]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,6 +8,10 @@ Thank you for reporting an issue with Karafka. To make this process smoother for
 > [!IMPORTANT]
 > We do not provide OSS support for outdated versions of Karafka. Please ensure that you are using a version that is still actively supported, as we cannot assist with no longer maintained versions unless you support us with our [Pro offering](https://karafka.io/docs/Pro-Support/).
 
+We acknowledge that understanding the specifics of your application and its configuration can be essential for resolving certain issues. However, due to the extensive time and resources such analysis can require, this falls beyond our Open Source Support scope.
+
+If Karafka or its components are critical to your infrastructure, we encourage you to consider our [Pro Offering](https://karafka.io/docs/Pro-Support/). By backing Karafka through our Pro offering, you can gain direct assistance and ensure your use case receives the dedicated attention it deserves.
+
 ## Important Links
 
 Please take a moment to review the following resources before submitting your report:
@@ -15,12 +19,6 @@ Please take a moment to review the following resources before submitting your re
 - [Issue Reporting Guide](https://karafka.io/docs/Support/#issue-reporting-guide) - A guide on what information is required for effective issue reporting.
 - [Karafka Support Policy](https://karafka.io/docs/Support/) - Details on the scope of support offered for different versions and tiers.
 - [Karafka Versions, Lifecycle, and EOL](https://karafka.io/docs/Versions-Lifecycle-and-EOL/) - Information about the current supported versions and End-Of-Life (EOL) policies.
-
-## Encouragement for Pro Support
-
-We acknowledge that understanding the specifics of your application and its configuration can be essential for resolving certain issues. However, due to the extensive time and resources such analysis can require, this falls beyond our Open Source Support scope.
-
-If Karafka or its components are critical to your infrastructure, we encourage you to consider our [Pro Offering](https://karafka.io/docs/Pro-Support/). By backing Karafka through our Pro offering, you can gain direct assistance and ensure your use case receives the dedicated attention it deserves.
 
 ## Bug Report Details
 


### PR DESCRIPTION
I'm recently getting more and more issues where users do not comply with the requirements. I made a page with issue reporting requirements, and this update updates the template on GH to align.

While it forces users to go to the reporting guide page, it simplifies things as I do not have to edit them in two places.

A similar template will be rolled out for all the ecosystem components.
