### PR TITLE
resolve ruby 3.1 deps fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,13 @@ jobs:
         run: |
           docker compose up -d || (sleep 5 && docker compose up -d)
 
+      # Newer versions of ActiveSupport and Rails do not work with Ruby 3.1 anymore.
+      # While we use newer by default we do want to resolve older and test, thus we remove
+      # Gemfile and let it resolve to the most compatible version possible
+      - name: Remove Gemfile.lock if Ruby 3.1
+        if: matrix.ruby == '3.1'
+        run: rm -f Gemfile.lock
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -152,13 +159,7 @@ jobs:
           chmod +t /opt/hostedtoolcache/Ruby/3*/x64/lib/ruby/gems/3*/gems
 
       - name: Bundle install
-        # Newer versions of ActiveSupport and Rails do not work with Ruby 3.1 anymore.
-        # While we use newer by default we do want to resolve older and test, thus we remove
-        # Gemfile and let it resolve to the most compatible version possible
         run: |
-          if [[ "$(ruby -e 'puts RUBY_VERSION')" == "3.1"* ]]; then
-            rm -f Gemfile.lock
-          fi
           bundle config set without development
           bundle install --jobs 4 --retry 3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,13 @@ jobs:
           chmod +t /opt/hostedtoolcache/Ruby/3*/x64/lib/ruby/gems/3*/gems
 
       - name: Bundle install
+        # Newer versions of ActiveSupport and Rails do not work with Ruby 3.1 anymore.
+        # While we use newer by default we do want to resolve older and test, thus we remove
+        # Gemfile and let it resolve to the most compatible version possible
         run: |
+          if [[ "$(ruby -e 'puts RUBY_VERSION')" == "3.1"* ]]; then
+            rm -f Gemfile.lock
+          fi
           bundle config set without development
           bundle install --jobs 4 --retry 3
 


### PR DESCRIPTION
This PR is suppose to resolve issues because of using newer ActiveSupport and friends in Gemfile.lock that are not compatible with Ruby 3.1

We do want to support Ruby 3.1 but we also want to make sure we can run specs on newer versions with newer defaults.

Ref https://github.com/karafka/karafka/pull/2328/files