### PR TITLE
Report fast in criticals and support k8s criticals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Karafka Framework Changelog
 
+## 2.4.14 (Unreleased)
+- [Enhancement] Improve low-level critical error reporting.
+- [Enhancement] Expand Kubernetes Liveness state reporting with critical errors detection.
+
 ## 2.4.13 (2024-10-11)
 - [Enhancement] Make declarative topics return different exit codes on migrable/non-migrable states (0 - no changes, 2 - changes) when used with `--detailed-exitcode` flag.
 - [Enhancement] Introduce `config.strict_declarative_topics` that should force declaratives on all non-pattern based topics and DLQ topics

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka (2.4.13)
+    karafka (2.4.14)
       base64 (~> 0.2)
       karafka-core (>= 2.4.4, < 2.5.0)
       karafka-rdkafka (>= 0.17.2)

--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -41,6 +41,9 @@ module Karafka
         :topic_authorization_failed, # 29
         :group_authorization_failed, # 30
         :cluster_authorization_failed, # 31
+        :illegal_generation,
+        # this will not recover as fencing is permanent
+        :fenced, # -144
         # This can happen for many reasons, including issues with static membership being fenced
         :fatal # -150
       ].freeze

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '2.4.13'
+  VERSION = '2.4.14'
 end

--- a/spec/integrations/instrumentation/vendors/kubernetes/fenced_out_criticality_spec.rb
+++ b/spec/integrations/instrumentation/vendors/kubernetes/fenced_out_criticality_spec.rb
@@ -36,6 +36,7 @@ pid = fork do
   end
 end
 
+require 'net/http'
 require 'karafka/instrumentation/vendors/kubernetes/liveness_listener'
 
 listener = ::Karafka::Instrumentation::Vendors::Kubernetes::LivenessListener.new(

--- a/spec/integrations/instrumentation/vendors/kubernetes/fenced_out_criticality_spec.rb
+++ b/spec/integrations/instrumentation/vendors/kubernetes/fenced_out_criticality_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# When fenced out by a new instance, kubernetes listener should report this as a 500
+
+INSTANCE_ID = SecureRandom.uuid
+
+setup_karafka(allow_errors: true) do |config|
+  config.kafka[:'group.instance.id'] = INSTANCE_ID
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[0] = true
+  end
+end
+
+draw_routes(Consumer)
+produce_many(DT.topic, DT.uuids(1))
+
+# This one (our current one) will be fenced out by the fork
+fenced = Thread.new do
+  start_karafka_and_wait_until do
+    DT[:probing].include?('500')
+  end
+end
+
+# Wait until anything is consumed so we are sure of the assignment
+sleep(0.1) until DT.key?(0)
+
+# Fork it so fencing will be triggered
+pid = fork do
+  # Wait in fork before starting processing so the liveness listener can open a tcp connection
+  sleep(2)
+  start_karafka_and_wait_until do
+    false
+  end
+end
+
+require 'karafka/instrumentation/vendors/kubernetes/liveness_listener'
+
+listener = ::Karafka::Instrumentation::Vendors::Kubernetes::LivenessListener.new(
+  hostname: '127.0.0.1',
+  port: 9013,
+  polling_ttl: 1_000
+)
+
+# Force start to bypass the regular lifecycle since we do not want fork to have it
+listener.send(:start)
+
+Karafka.monitor.subscribe(listener)
+
+Thread.new do
+  until Karafka::App.stopping?
+    sleep(1)
+    uri = URI.parse('http://127.0.0.1:9013/')
+    response = Net::HTTP.get_response(uri)
+    puts "Health check response: #{response.code}"
+    DT[:probing] << response.code
+  end
+end
+
+sleep(0.1) until DT[:probing].include?('500')
+
+# Terminate the fork as it is no longer needed
+# We do not care about its state as we're done testing
+Process.kill(9, pid)
+Process.wait(pid)
+
+fenced.join
+
+assert DT[:probing].include?('204')
+assert DT[:probing].include?('500')


### PR DESCRIPTION
this PR fast tracks reporting on critical errors that won't be recovered and adds their awareness into the k8s state listener.

close https://github.com/karafka/karafka/issues/2327