### PR TITLE
Add redraw method

### DIFF
--- a/lib/karafka/routing/builder.rb
+++ b/lib/karafka/routing/builder.rb
@@ -67,6 +67,9 @@ module Karafka
         end
       end
 
+      # Clear out the drawn routes.
+      alias :array_clear :clear
+
       # Clear routes and draw them again with the given block. Helpful for testing purposes.
       # @param block [Proc] block we will evaluate within the builder context
       def redraw(&block)
@@ -83,9 +86,6 @@ module Karafka
       def active
         select(&:active?)
       end
-
-      # Clear out the drawn routes.
-      alias :array_clear :clear
 
       # Clears the builder and the draws memory
       def clear

--- a/lib/karafka/routing/builder.rb
+++ b/lib/karafka/routing/builder.rb
@@ -67,6 +67,15 @@ module Karafka
         end
       end
 
+      # Clear routes and draw them again with the given block. Helpful for testing purposes.
+      def redraw(&block)
+        @mutex.synchronize do
+          @draws.clear
+          array_clear
+        end
+        draw(&block)
+      end
+
       # @return [Array<Karafka::Routing::ConsumerGroup>] only active consumer groups that
       #   we want to use. Since Karafka supports multi-process setup, we need to be able
       #   to pick only those consumer groups that should be active in our given process context
@@ -74,12 +83,14 @@ module Karafka
         select(&:active?)
       end
 
+      alias_method :array_clear, :clear
+
       # Clears the builder and the draws memory
       def clear
         @mutex.synchronize do
           @defaults = EMPTY_DEFAULTS
           @draws.clear
-          super
+          array_clear
         end
       end
 

--- a/lib/karafka/routing/builder.rb
+++ b/lib/karafka/routing/builder.rb
@@ -68,7 +68,7 @@ module Karafka
       end
 
       # Clear out the drawn routes.
-      alias :array_clear :clear
+      alias array_clear clear
 
       # Clear routes and draw them again with the given block. Helpful for testing purposes.
       # @param block [Proc] block we will evaluate within the builder context

--- a/lib/karafka/routing/builder.rb
+++ b/lib/karafka/routing/builder.rb
@@ -69,6 +69,7 @@ module Karafka
 
       # Clear out the drawn routes.
       alias array_clear clear
+      private :array_clear
 
       # Clear routes and draw them again with the given block. Helpful for testing purposes.
       # @param block [Proc] block we will evaluate within the builder context

--- a/lib/karafka/routing/builder.rb
+++ b/lib/karafka/routing/builder.rb
@@ -68,6 +68,7 @@ module Karafka
       end
 
       # Clear routes and draw them again with the given block. Helpful for testing purposes.
+      # @param block [Proc] block we will evaluate within the builder context
       def redraw(&block)
         @mutex.synchronize do
           @draws.clear
@@ -83,7 +84,8 @@ module Karafka
         select(&:active?)
       end
 
-      alias_method :array_clear, :clear
+      # Clear out the drawn routes.
+      alias :array_clear :clear
 
       # Clears the builder and the draws memory
       def clear

--- a/spec/lib/karafka/routing/builder_spec.rb
+++ b/spec/lib/karafka/routing/builder_spec.rb
@@ -271,6 +271,41 @@ RSpec.describe_current do
     end
   end
 
+  describe '#redraw' do
+    let(:topic1) { builder.first.topics.first }
+    let(:topic2) { builder.last.topics.last }
+    let(:draw1) do
+      builder.draw do
+        topic :topic_name1 do
+          # Here we should have instance doubles, etc but it takes
+          # shitload of time to setup instance evaluation from instance variables,
+          # so instead we check against constant names
+          consumer Class.new(Karafka::BaseConsumer)
+          deserializer ->(data) { data }
+        end
+      end
+    end
+    let(:draw2) do
+      builder.redraw do
+        topic :topic_name2 do
+          consumer Class.new(Karafka::BaseConsumer)
+          deserializer ->(data) { data }
+        end
+      end
+    end
+
+    before do
+      draw1
+      draw2
+    end
+
+    it { expect(topic1.id).to eq 'app_topic_name2' }
+    it { expect(builder.size).to eq 1 }
+    it { expect(topic1.name).to eq 'topic_name2' }
+    it { expect(topic1.subscription_group_details).not_to eq(nil) }
+    it { expect(builder.first.id).to eq 'app' }
+  end
+
   describe '#active' do
     let(:active_group) { instance_double(Karafka::Routing::ConsumerGroup, active?: true) }
     let(:inactive_group) { instance_double(Karafka::Routing::ConsumerGroup, active?: false) }


### PR DESCRIPTION
This allows testing code to define its own routes _without_ blowing away the defaults. I've found this helpful when I have overall defaults that I want to keep around, but I want to test my own routing plugin with various routes.