### PR TITLE
provide the wrap api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Karafka Framework Changelog
 
+## 2.4.16 (Unreleased)
+- [Enhancement] Introduce `Consumer#wrap` for connection pooling management and other wrapped operations.
+
 ## 2.4.15 (2024-12-04)
 - [Fix] Assignment tracker current state fetch during a rebalance loop can cause an error on multi CG setup.
 - [Fix] Prevent double post-transaction offset dispatch to Kafka.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,6 @@ GEM
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
     ffi (1.17.0)
-    ffi (1.17.0-x86_64-linux-gnu)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    karafka (2.4.15)
+    karafka (2.4.16)
       base64 (~> 0.2)
       karafka-core (>= 2.4.4, < 2.5.0)
       karafka-rdkafka (>= 0.17.2)
@@ -42,6 +42,7 @@ GEM
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
     ffi (1.17.0)
+    ffi (1.17.0-x86_64-linux-gnu)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)

--- a/lib/karafka/instrumentation/logger_listener.rb
+++ b/lib/karafka/instrumentation/logger_listener.rb
@@ -294,7 +294,7 @@ module Karafka
           error "Consumer initialized error: #{error}"
           error details
         when 'consumer.wrap.error'
-          error "Consumer wrap error: #{error}"
+          error "Consumer wrap failed due to an error: #{error}"
           error details
         when 'consumer.consume.error'
           error "Consumer consuming error: #{error}"

--- a/lib/karafka/instrumentation/logger_listener.rb
+++ b/lib/karafka/instrumentation/logger_listener.rb
@@ -293,6 +293,9 @@ module Karafka
         when 'consumer.initialized.error'
           error "Consumer initialized error: #{error}"
           error details
+        when 'consumer.wrap.error'
+          error "Consumer wrap error: #{error}"
+          error details
         when 'consumer.consume.error'
           error "Consumer consuming error: #{error}"
           error details

--- a/lib/karafka/instrumentation/notifications.rb
+++ b/lib/karafka/instrumentation/notifications.rb
@@ -77,6 +77,9 @@ module Karafka
         consumer.shutting_down
         consumer.shutdown
 
+        consumer.wrap
+        consumer.wrapped
+
         dead_letter_queue.dispatched
 
         filtering.throttled

--- a/lib/karafka/instrumentation/vendors/datadog/logger_listener.rb
+++ b/lib/karafka/instrumentation/vendors/datadog/logger_listener.rb
@@ -56,32 +56,7 @@ module Karafka
             consumer = job.executor.topic.consumer
             topic = job.executor.topic.name
 
-            action = case job_type
-                     when 'Periodic'
-                       'tick'
-                     when 'PeriodicNonBlocking'
-                       'tick'
-                     when 'Shutdown'
-                       'shutdown'
-                     when 'Revoked'
-                       'revoked'
-                     when 'RevokedNonBlocking'
-                       'revoked'
-                     when 'Idle'
-                       'idle'
-                     when 'Eofed'
-                       'eofed'
-                     when 'EofedNonBlocking'
-                       'eofed'
-                     when 'ConsumeNonBlocking'
-                       'consume'
-                     when 'Consume'
-                       'consume'
-                     else
-                       raise Errors::UnsupportedCaseError, job_type
-                     end
-
-            current_span.resource = "#{consumer}##{action}"
+            current_span.resource = "#{consumer}##{job.class.action}"
             info "[#{job.id}] #{job_type} job for #{consumer} on #{topic} started"
 
             pop_tags

--- a/lib/karafka/pro/processing/jobs/consume_non_blocking.rb
+++ b/lib/karafka/pro/processing/jobs/consume_non_blocking.rb
@@ -26,6 +26,8 @@ module Karafka
         # @note It needs to be working with a proper consumer that will handle the partition
         #   management. This layer of the framework knows nothing about Kafka messages consumption.
         class ConsumeNonBlocking < ::Karafka::Processing::Jobs::Consume
+          self.action = :consume
+
           # Makes this job non-blocking from the start
           # @param args [Array] any arguments accepted by `::Karafka::Processing::Jobs::Consume`
           def initialize(*args)

--- a/lib/karafka/pro/processing/jobs/eofed_non_blocking.rb
+++ b/lib/karafka/pro/processing/jobs/eofed_non_blocking.rb
@@ -20,6 +20,8 @@ module Karafka
         # to run this job for extended period of time. Under such scenarios, if we would not use
         # a non-blocking one, we would reach max.poll.interval.ms.
         class EofedNonBlocking < ::Karafka::Processing::Jobs::Eofed
+          self.action = :eofed
+
           # @param args [Array] any arguments accepted by `::Karafka::Processing::Jobs::Eofed`
           def initialize(*args)
             super

--- a/lib/karafka/pro/processing/jobs/periodic.rb
+++ b/lib/karafka/pro/processing/jobs/periodic.rb
@@ -18,6 +18,8 @@ module Karafka
         # Job that represents a "ticking" work. Work that we run periodically for the Periodics
         # enabled topics.
         class Periodic < ::Karafka::Processing::Jobs::Base
+          self.action = :tick
+
           # @param executor [Karafka::Pro::Processing::Executor] pro executor that is suppose to
           #   run a given job
           def initialize(executor)

--- a/lib/karafka/pro/processing/jobs/periodic_non_blocking.rb
+++ b/lib/karafka/pro/processing/jobs/periodic_non_blocking.rb
@@ -20,6 +20,8 @@ module Karafka
         # to run this job for extended period of time. Under such scenarios, if we would not use
         # a non-blocking one, we would reach max.poll.interval.ms.
         class PeriodicNonBlocking < Periodic
+          self.action = :tick
+
           # @param args [Array] any arguments accepted by `::Karafka::Processing::Jobs::Periodic`
           def initialize(*args)
             super

--- a/lib/karafka/pro/processing/jobs/revoked_non_blocking.rb
+++ b/lib/karafka/pro/processing/jobs/revoked_non_blocking.rb
@@ -24,6 +24,8 @@ module Karafka
         # in scenarios where there are more jobs than threads, without this being async we
         # would potentially stop polling
         class RevokedNonBlocking < ::Karafka::Processing::Jobs::Revoked
+          self.action = :revoked
+
           # Makes this job non-blocking from the start
           # @param args [Array] any arguments accepted by `::Karafka::Processing::Jobs::Revoked`
           def initialize(*args)

--- a/lib/karafka/pro/processing/strategies/aj/lrj_mom_vp.rb
+++ b/lib/karafka/pro/processing/strategies/aj/lrj_mom_vp.rb
@@ -69,8 +69,8 @@ module Karafka
                 coordinator.revoke
               end
 
-              Karafka.monitor.instrument('consumer.revoke', caller: self)
-              Karafka.monitor.instrument('consumer.revoked', caller: self) do
+              monitor.instrument('consumer.revoke', caller: self)
+              monitor.instrument('consumer.revoked', caller: self) do
                 revoked
               end
             ensure

--- a/lib/karafka/pro/processing/strategies/default.rb
+++ b/lib/karafka/pro/processing/strategies/default.rb
@@ -208,7 +208,7 @@ module Karafka
 
           # No actions needed for the standard flow here
           def handle_before_schedule_consume
-            Karafka.monitor.instrument('consumer.before_schedule_consume', caller: self)
+            monitor.instrument('consumer.before_schedule_consume', caller: self)
 
             nil
           end
@@ -227,8 +227,8 @@ module Karafka
             # This can happen primarily when an LRJ job gets to the internal worker queue and
             # this partition is revoked prior processing.
             unless revoked?
-              Karafka.monitor.instrument('consumer.consume', caller: self)
-              Karafka.monitor.instrument('consumer.consumed', caller: self) do
+              monitor.instrument('consumer.consume', caller: self)
+              monitor.instrument('consumer.consumed', caller: self) do
                 consume
               end
             end
@@ -274,8 +274,8 @@ module Karafka
               coordinator.revoke
             end
 
-            Karafka.monitor.instrument('consumer.revoke', caller: self)
-            Karafka.monitor.instrument('consumer.revoked', caller: self) do
+            monitor.instrument('consumer.revoke', caller: self)
+            monitor.instrument('consumer.revoked', caller: self) do
               revoked
             end
           ensure
@@ -284,15 +284,15 @@ module Karafka
 
           # No action needed for the tick standard flow
           def handle_before_schedule_tick
-            Karafka.monitor.instrument('consumer.before_schedule_tick', caller: self)
+            monitor.instrument('consumer.before_schedule_tick', caller: self)
 
             nil
           end
 
           # Runs the consumer `#tick` method with reporting
           def handle_tick
-            Karafka.monitor.instrument('consumer.tick', caller: self)
-            Karafka.monitor.instrument('consumer.ticked', caller: self) do
+            monitor.instrument('consumer.tick', caller: self)
+            monitor.instrument('consumer.ticked', caller: self) do
               tick
             end
           ensure

--- a/lib/karafka/pro/processing/strategies/dlq/default.rb
+++ b/lib/karafka/pro/processing/strategies/dlq/default.rb
@@ -119,7 +119,7 @@ module Karafka
               )
 
               # Notify about dispatch on the events bus
-              Karafka.monitor.instrument(
+              monitor.instrument(
                 'dead_letter_queue.dispatched',
                 caller: self,
                 message: skippable_message

--- a/lib/karafka/pro/processing/strategies/ftr/default.rb
+++ b/lib/karafka/pro/processing/strategies/ftr/default.rb
@@ -89,7 +89,7 @@ module Karafka
 
                 throttle_message = filter.cursor
 
-                Karafka.monitor.instrument(
+                monitor.instrument(
                   'filtering.seek',
                   caller: self,
                   message: throttle_message
@@ -104,7 +104,7 @@ module Karafka
 
                 throttle_message = filter.cursor
 
-                Karafka.monitor.instrument(
+                monitor.instrument(
                   'filtering.throttled',
                   caller: self,
                   message: throttle_message,

--- a/lib/karafka/pro/processing/strategies/lrj/default.rb
+++ b/lib/karafka/pro/processing/strategies/lrj/default.rb
@@ -72,8 +72,8 @@ module Karafka
                 coordinator.revoke
               end
 
-              Karafka.monitor.instrument('consumer.revoke', caller: self)
-              Karafka.monitor.instrument('consumer.revoked', caller: self) do
+              monitor.instrument('consumer.revoke', caller: self)
+              monitor.instrument('consumer.revoked', caller: self) do
                 revoked
               end
             ensure

--- a/lib/karafka/pro/processing/strategies/lrj/mom.rb
+++ b/lib/karafka/pro/processing/strategies/lrj/mom.rb
@@ -64,8 +64,8 @@ module Karafka
                 coordinator.revoke
               end
 
-              Karafka.monitor.instrument('consumer.revoke', caller: self)
-              Karafka.monitor.instrument('consumer.revoked', caller: self) do
+              monitor.instrument('consumer.revoke', caller: self)
+              monitor.instrument('consumer.revoked', caller: self) do
                 revoked
               end
             ensure

--- a/lib/karafka/processing/executor.rb
+++ b/lib/karafka/processing/executor.rb
@@ -81,6 +81,13 @@ module Karafka
         consumer.on_before_consume
       end
 
+      # Runs the wrap/around execution context appropriate for a given action
+      # @param action [Symbol] action execution wrapped with our block
+      # @param block [Proc] execution context
+      def wrap(action, &block)
+        consumer.on_wrap(action, &block)
+      end
+
       # Runs consumer data processing against given batch and handles failures and errors.
       def consume
         # We run the consumer client logic...

--- a/lib/karafka/processing/jobs/base.rb
+++ b/lib/karafka/processing/jobs/base.rb
@@ -15,12 +15,25 @@ module Karafka
 
         attr_reader :executor
 
+        class << self
+          # @return [Symbol] Job matching appropriate action
+          attr_accessor :action
+        end
+
         # Creates a new job instance
         def initialize
           # All jobs are blocking by default and they can release the lock when blocking operations
           # are done (if needed)
           @non_blocking = false
           @status = :pending
+        end
+
+        # Runs the wrap/around job hook within which the rest of the flow happens
+        # @param block [Proc] whole user related processing flow
+        # @note We inject the action name so user can decide whether to run custom logic on a
+        #   given action or not.
+        def wrap(&block)
+          executor.wrap(self.class.action, &block)
         end
 
         # When redefined can run any code prior to the job being scheduled

--- a/lib/karafka/processing/jobs/consume.rb
+++ b/lib/karafka/processing/jobs/consume.rb
@@ -9,6 +9,8 @@ module Karafka
         # @return [Array<Rdkafka::Consumer::Message>] array with messages
         attr_reader :messages
 
+        self.action = :consume
+
         # @param executor [Karafka::Processing::Executor] executor that is suppose to run a given
         #   job
         # @param messages [Karafka::Messages::Messages] karafka messages batch

--- a/lib/karafka/processing/jobs/eofed.rb
+++ b/lib/karafka/processing/jobs/eofed.rb
@@ -5,6 +5,8 @@ module Karafka
     module Jobs
       # Job that runs the eofed operation when we receive eof without messages alongside.
       class Eofed < Base
+        self.action = :eofed
+
         # @param executor [Karafka::Processing::Executor] executor that is suppose to run the job
         # @return [Eofed]
         def initialize(executor)

--- a/lib/karafka/processing/jobs/idle.rb
+++ b/lib/karafka/processing/jobs/idle.rb
@@ -6,6 +6,8 @@ module Karafka
       # Type of job that we may use to run some extra handling that happens without the user
       # related lifecycle event like consumption, revocation, etc.
       class Idle < Base
+        self.action = :idle
+
         # @param executor [Karafka::Processing::Executor] executor that is suppose to run a given
         #   job on an active consumer
         # @return [Shutdown]

--- a/lib/karafka/processing/jobs/revoked.rb
+++ b/lib/karafka/processing/jobs/revoked.rb
@@ -5,6 +5,8 @@ module Karafka
     module Jobs
       # Job that runs the revoked operation when we loose a partition on a consumer that lost it.
       class Revoked < Base
+        self.action = :revoked
+
         # @param executor [Karafka::Processing::Executor] executor that is suppose to run the job
         # @return [Revoked]
         def initialize(executor)

--- a/lib/karafka/processing/jobs/shutdown.rb
+++ b/lib/karafka/processing/jobs/shutdown.rb
@@ -5,6 +5,8 @@ module Karafka
     module Jobs
       # Job that runs on each active consumer upon process shutdown (one job per consumer).
       class Shutdown < Base
+        self.action = :shutdown
+
         # @param executor [Karafka::Processing::Executor] executor that is suppose to run a given
         #   job on an active consumer
         # @return [Shutdown]

--- a/lib/karafka/processing/strategies/default.rb
+++ b/lib/karafka/processing/strategies/default.rb
@@ -24,7 +24,7 @@ module Karafka
           class_eval <<~RUBY, __FILE__, __LINE__ + 1
             # No actions needed for the standard flow here
             def handle_before_schedule_#{action}
-              Karafka.monitor.instrument('consumer.before_schedule_#{action}', caller: self)
+              monitor.instrument('consumer.before_schedule_#{action}', caller: self)
 
               nil
             end
@@ -35,8 +35,8 @@ module Karafka
         # @note It runs in the listener loop. Should **not** be used for anything heavy or
         #   with any potential errors. Mostly for initialization of states, etc.
         def handle_initialized
-          Karafka.monitor.instrument('consumer.initialize', caller: self)
-          Karafka.monitor.instrument('consumer.initialized', caller: self) do
+          monitor.instrument('consumer.initialize', caller: self)
+          monitor.instrument('consumer.initialized', caller: self) do
             initialized
           end
         end
@@ -115,10 +115,21 @@ module Karafka
           coordinator.pause_tracker.increment
         end
 
+        # Runs the wrapping to execute appropriate action wrapped with the wrapper method code
+        #
+        # @param action [Symbol]
+        # @param block [Proc]
+        def handle_wrap(action, &block)
+          monitor.instrument('consumer.wrap', caller: self)
+          monitor.instrument('consumer.wrapped', caller: self) do
+            wrap(action, &block)
+          end
+        end
+
         # Run the user consumption code
         def handle_consume
-          Karafka.monitor.instrument('consumer.consume', caller: self)
-          Karafka.monitor.instrument('consumer.consumed', caller: self) do
+          monitor.instrument('consumer.consume', caller: self)
+          monitor.instrument('consumer.consumed', caller: self) do
             consume
           end
 
@@ -164,8 +175,8 @@ module Karafka
 
         # Runs the consumer `#eofed` method with reporting
         def handle_eofed
-          Karafka.monitor.instrument('consumer.eof', caller: self)
-          Karafka.monitor.instrument('consumer.eofed', caller: self) do
+          monitor.instrument('consumer.eof', caller: self)
+          monitor.instrument('consumer.eofed', caller: self) do
             eofed
           end
         ensure
@@ -180,8 +191,8 @@ module Karafka
 
           coordinator.revoke
 
-          Karafka.monitor.instrument('consumer.revoke', caller: self)
-          Karafka.monitor.instrument('consumer.revoked', caller: self) do
+          monitor.instrument('consumer.revoke', caller: self)
+          monitor.instrument('consumer.revoked', caller: self) do
             revoked
           end
         ensure
@@ -190,8 +201,8 @@ module Karafka
 
         # Runs the shutdown code
         def handle_shutdown
-          Karafka.monitor.instrument('consumer.shutting_down', caller: self)
-          Karafka.monitor.instrument('consumer.shutdown', caller: self) do
+          monitor.instrument('consumer.shutting_down', caller: self)
+          monitor.instrument('consumer.shutdown', caller: self) do
             shutdown
           end
         ensure

--- a/lib/karafka/processing/strategies/dlq.rb
+++ b/lib/karafka/processing/strategies/dlq.rb
@@ -117,7 +117,7 @@ module Karafka
           )
 
           # Notify about dispatch on the events bus
-          Karafka.monitor.instrument(
+          monitor.instrument(
             'dead_letter_queue.dispatched',
             caller: self,
             message: skippable_message

--- a/lib/karafka/processing/worker.rb
+++ b/lib/karafka/processing/worker.rb
@@ -19,7 +19,8 @@ module Karafka
     class Worker
       include Helpers::Async
       include Helpers::ConfigImporter.new(
-        worker_job_call_wrapper: %i[internal processing worker_job_call_wrapper]
+        worker_job_call_wrapper: %i[internal processing worker_job_call_wrapper],
+        monitor: %i[monitor]
       )
 
       # @return [String] id of this worker
@@ -54,9 +55,9 @@ module Karafka
 
         if job
           job.wrap do
-            Karafka.monitor.instrument('worker.process', instrument_details)
+            monitor.instrument('worker.process', instrument_details)
 
-            Karafka.monitor.instrument('worker.processed', instrument_details) do
+            monitor.instrument('worker.processed', instrument_details) do
               job.before_call
 
               # If a job is marked as non blocking, we can run a tick in the job queue and if there
@@ -85,7 +86,7 @@ module Karafka
       # rubocop:disable Lint/RescueException
       rescue Exception => e
         # rubocop:enable Lint/RescueException
-        Karafka.monitor.instrument(
+        monitor.instrument(
           'error.occurred',
           caller: self,
           job: job,
@@ -101,7 +102,7 @@ module Karafka
         end
 
         # Always publish info, that we completed all the work despite its result
-        Karafka.monitor.instrument('worker.completed', instrument_details)
+        monitor.instrument('worker.completed', instrument_details)
       end
     end
   end

--- a/lib/karafka/version.rb
+++ b/lib/karafka/version.rb
@@ -3,5 +3,5 @@
 # Main module namespace
 module Karafka
   # Current Karafka version
-  VERSION = '2.4.15'
+  VERSION = '2.4.16'
 end

--- a/spec/integrations/consumption/wrapping/consume_spec.rb
+++ b/spec/integrations/consumption/wrapping/consume_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Karafka should allow for wrapping on consume
+
+setup_karafka
+
+PRODUCER = rand
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[:producer] = producer
+
+    messages.each do |message|
+      DT[message.metadata.partition] << message.raw_payload
+    end
+  end
+
+  def wrap(action)
+    DT[:actions] << action
+
+    return yield unless action == :consume
+
+    self.producer = PRODUCER
+
+    yield
+
+    self.producer = nil
+  end
+end
+
+draw_routes(Consumer)
+
+elements = DT.uuids(10)
+produce_many(DT.topic, elements)
+
+start_karafka_and_wait_until do
+  DT[0].size >= 10
+end
+
+assert_equal PRODUCER, DT[:producer]
+assert_equal DT[:actions].uniq, %i[consume shutdown]

--- a/spec/integrations/consumption/wrapping/on_error_spec.rb
+++ b/spec/integrations/consumption/wrapping/on_error_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Errors in the processing should not affect wrapping itself
+
+setup_karafka(allow_errors: %w[consumer.consume.error])
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[:done] << true
+
+    raise
+  end
+
+  def wrap(_action)
+    DT[:before] = true
+    yield
+    DT[:after] = true
+  end
+end
+
+draw_routes(Consumer)
+
+produce(DT.topic, '')
+
+start_karafka_and_wait_until do
+  DT.key?(:done)
+end
+
+assert DT.key?(:before)
+assert DT.key?(:after)

--- a/spec/integrations/pro/consumption/transactions/with_wrapped_producer_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/with_wrapped_producer_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# We should be able to replace the default producer with a transactional one
+# We set the default producer to a broken location so in case our wrapping would not work, it will
+# crash
+
+setup_karafka(allow_errors: %w[consumer.consume.error])
+
+TRANSACTIONAL_PRODUCER = ::WaterDrop::Producer.new do |producer_config|
+  producer_config.kafka = Karafka::Setup::AttributesMap.producer(Karafka::App.config.kafka.dup)
+  producer_config.kafka[:'transactional.id'] = SecureRandom.uuid
+  producer_config.logger = Karafka::App.config.logger
+end
+
+DEFAULT_PRODUCER = ::WaterDrop::Producer.new do |producer_config|
+  producer_config.kafka = { 'bootstrap.servers': '127.0.0.1:9090' }
+  producer_config.logger = Karafka::App.config.logger
+end
+
+Karafka::App.config.producer = DEFAULT_PRODUCER
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[:producer] = producer
+    DT[:done] = true
+
+    raise
+  end
+
+  def wrap(_action)
+    default_producer = producer
+    self.producer = TRANSACTIONAL_PRODUCER
+    yield
+    self.producer = default_producer
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    dead_letter_queue(
+      topic: DT.topics[1],
+      max_retries: 0,
+      dispatch_method: :produce_sync
+    )
+  end
+end
+
+TRANSACTIONAL_PRODUCER.produce_sync(topic: DT.topic, payload: '1')
+
+start_karafka_and_wait_until do
+  DT.key?(:done)
+end
+
+assert_equal TRANSACTIONAL_PRODUCER, DT[:producer]

--- a/spec/lib/karafka/instrumentation/logger_listener_spec.rb
+++ b/spec/lib/karafka/instrumentation/logger_listener_spec.rb
@@ -431,6 +431,13 @@ RSpec.describe_current do
       it { expect(Karafka.logger).to have_received(:error).with(message) }
     end
 
+    context 'when it is a consumer.wrap.error' do
+      let(:type) { 'consumer.wrap.error' }
+      let(:message) { "Consumer wrap failed due to an error: #{error}" }
+
+      it { expect(Karafka.logger).to have_received(:error).with(message) }
+    end
+
     context 'when it is a consumer.tick.error' do
       let(:type) { 'consumer.tick.error' }
       let(:message) { "Consumer on tick failed due to an error: #{error}" }

--- a/spec/lib/karafka/pro/processing/jobs/consume_non_blocking_spec.rb
+++ b/spec/lib/karafka/pro/processing/jobs/consume_non_blocking_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe_current do
   let(:messages) { [rand] }
   let(:time_now) { Time.now }
 
+  specify { expect(described_class.action).to eq(:consume) }
+
   it { expect(job.non_blocking?).to eq(true) }
   it { expect(described_class).to be < ::Karafka::Processing::Jobs::Consume }
 

--- a/spec/lib/karafka/pro/processing/jobs/eofed_non_blocking_spec.rb
+++ b/spec/lib/karafka/pro/processing/jobs/eofed_non_blocking_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe_current do
 
   let(:executor) { build(:processing_executor) }
 
+  specify { expect(described_class.action).to eq(:eofed) }
+
   it { expect(job.non_blocking?).to eq(true) }
   it { expect(described_class).to be < ::Karafka::Processing::Jobs::Eofed }
 end

--- a/spec/lib/karafka/pro/processing/jobs/periodic_non_blocking_spec.rb
+++ b/spec/lib/karafka/pro/processing/jobs/periodic_non_blocking_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe_current do
 
   let(:executor) { build(:processing_executor) }
 
+  specify { expect(described_class.action).to eq(:tick) }
+
   it { expect(job.non_blocking?).to eq(true) }
   it { expect(described_class).to be < ::Karafka::Pro::Processing::Jobs::Periodic }
 end

--- a/spec/lib/karafka/pro/processing/jobs/periodic_spec.rb
+++ b/spec/lib/karafka/pro/processing/jobs/periodic_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe_current do
     job.call
   end
 
+  specify { expect(described_class.action).to eq(:tick) }
+
   it { expect(job.id).to eq(executor.id) }
   it { expect(job.group_id).to eq(executor.group_id) }
   it { expect(job.non_blocking?).to eq(false) }

--- a/spec/lib/karafka/pro/processing/jobs/revoked_non_blocking_spec.rb
+++ b/spec/lib/karafka/pro/processing/jobs/revoked_non_blocking_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe_current do
 
   let(:executor) { build(:processing_executor) }
 
+  specify { expect(described_class.action).to eq(:revoked) }
+
   it { expect(job.non_blocking?).to eq(true) }
   it { expect(described_class).to be < ::Karafka::Processing::Jobs::Revoked }
 end

--- a/spec/lib/karafka/processing/jobs/base_spec.rb
+++ b/spec/lib/karafka/processing/jobs/base_spec.rb
@@ -3,6 +3,8 @@
 RSpec.describe_current do
   subject(:job) { described_class.new }
 
+  specify { expect(described_class.action).to eq(nil) }
+
   describe '#non_blocking?' do
     it 'expect all the newly created jobs to be blocking' do
       expect(job.non_blocking?).to eq(false)

--- a/spec/lib/karafka/processing/jobs/consume_spec.rb
+++ b/spec/lib/karafka/processing/jobs/consume_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe_current do
 
   it { expect(job.non_blocking?).to eq(false) }
 
+  specify { expect(described_class.action).to eq(:consume) }
+
   describe '#before_schedule' do
     before do
       allow(executor).to receive(:before_schedule_consume)

--- a/spec/lib/karafka/processing/jobs/eofed_spec.rb
+++ b/spec/lib/karafka/processing/jobs/eofed_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe_current do
     job.call
   end
 
+  specify { expect(described_class.action).to eq(:eofed) }
+
   it { expect(job.id).to eq(executor.id) }
   it { expect(job.group_id).to eq(executor.group_id) }
   it { expect(job.non_blocking?).to eq(false) }

--- a/spec/lib/karafka/processing/jobs/idle_spec.rb
+++ b/spec/lib/karafka/processing/jobs/idle_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe_current do
     job.call
   end
 
+  specify { expect(described_class.action).to eq(:idle) }
+
   it { expect(job.id).to eq(executor.id) }
   it { expect(job.group_id).to eq(executor.group_id) }
   it { expect(job.non_blocking?).to eq(false) }

--- a/spec/lib/karafka/processing/jobs/revoked_spec.rb
+++ b/spec/lib/karafka/processing/jobs/revoked_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe_current do
     job.call
   end
 
+  specify { expect(described_class.action).to eq(:revoked) }
+
   it { expect(job.id).to eq(executor.id) }
   it { expect(job.group_id).to eq(executor.group_id) }
   it { expect(job.non_blocking?).to eq(false) }

--- a/spec/lib/karafka/processing/jobs/shutdown_spec.rb
+++ b/spec/lib/karafka/processing/jobs/shutdown_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe_current do
     job.call
   end
 
+  specify { expect(described_class.action).to eq(:shutdown) }
+
   it { expect(job.id).to eq(executor.id) }
   it { expect(job.group_id).to eq(executor.group_id) }
   it { expect(job.non_blocking?).to eq(false) }

--- a/spec/lib/karafka/processing/worker_spec.rb
+++ b/spec/lib/karafka/processing/worker_spec.rb
@@ -40,9 +40,10 @@ RSpec.describe_current do
     end
 
     context 'when it is a non-closing, blocking job' do
-      let(:job) { OpenStruct.new(group_id: 1, id: 1, call: true) }
+      let(:job) { OpenStruct.new(group_id: 1, id: 1, call: true, wrap: true) }
 
       before do
+        allow(job).to receive(:wrap).and_yield
         allow(job).to receive(:before_call)
         allow(job).to receive(:call)
         allow(job).to receive(:after_call)
@@ -66,6 +67,7 @@ RSpec.describe_current do
       let(:job) { OpenStruct.new(group_id: 1, id: 1, call: true, non_blocking?: true) }
 
       before do
+        allow(job).to receive(:wrap).and_yield
         allow(job).to receive(:before_call)
         allow(job).to receive(:call)
         allow(job).to receive(:after_call)
@@ -101,6 +103,7 @@ RSpec.describe_current do
       end
 
       before do
+        allow(job).to receive(:wrap).and_yield
         allow(job).to receive(:before_call).and_raise(StandardError)
 
         detected_errors


### PR DESCRIPTION
This PR introduces a consumer level `#wrap` API that wraps the whole Karafka consumer execution flow.

In general karafka consumer execution (whether it's a consume, idle or anything else) has two parts:

- user part (user code)
- framework code (our code)

The issue we want to solve with this API is being able to use user set context (like the same transactional producer) for both user code and framework code. Since there is no way now to "assign" transactional producer for the execution time, it cannot be assigned and release after everything is done.

This API fixes this by providing the `#wrap` on consumer that needs to be yielded and that will run the whole job consumer context including framework management stuff that happens post user code execution.

It is mainly needed to normalize the transactional flows in such a way that ensures that post-execution framework managed offset marking is done with the same resources as user transactional stuff.

FYI I also checked the yielding performance on the 4 levels of yielding:

```ruby
puts Benchmark.measure { 100000.times { d{c{b{a{}}}} } }
  0.019726   0.000287   0.020013 (  0.020016)
```

given the fact that it is a per job/batch operation and not a high-frequency execution, this impact is negligible.