### PR TITLE
improve rebalance flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Karafka Framework Changelog
 
 ## 2.4.16 (Unreleased)
+- [Enhancement] Improve post-rebalance revocation messages filtering.
 - [Enhancement] Introduce `Consumer#wrap` for connection pooling management and other wrapped operations.
 - [Enhancement] Guard transactional operations from marking beyond assignment ownership under some extreme edge-cases.
 - [Enhancement] Improve VPs work with transactional producers.
 - [Enhancement] Prevent non-transactional operations leakage into transactional managed offset management consumers.
 - [Fix] Prevent transactions from being marked with a non-transactional default producer when automatic offset management and other advanced features are on.
 - [Fix] Fix `kafka_format` `KeyError` that occurs when a non-hash is assigned to the kafka scope of the settings.
+- [Fix] Non cooperative-sticky transactional offset management can refetch reclaimed partitions.
 
 ## 2.4.15 (2024-12-04)
 - [Fix] Assignment tracker current state fetch during a rebalance loop can cause an error on multi CG setup.

--- a/spec/integrations/pro/consumption/transactions/post_revocation_cooperative_reclaim_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/post_revocation_cooperative_reclaim_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+# When a transactional consumer goes into a cooperative-sticky rebalance and gets the
+# partitions back, it should not have duplicated data.
+
+setup_karafka do |config|
+  config.kafka[:'transactional.id'] = SecureRandom.uuid
+  config.kafka[:'isolation.level'] = 'read_committed'
+  config.kafka[:'partition.assignment.strategy'] = 'cooperative-sticky'
+  config.max_messages = 1_000
+end
+
+DT[:all] = {}
+DT[:data] = {}
+
+class Consumer < Karafka::BaseConsumer
+  def initialized
+    @buffer = []
+  end
+
+  def consume
+    DT[:running] = true
+
+    transaction do
+      messages.each do |message|
+        DT[:all][partition] ||= []
+        DT[:all][partition] << message.offset
+
+        DT[:data][partition] ||= []
+        DT[:data][partition] << message.raw_payload.to_i
+
+        raise if @buffer.include?(message.offset)
+
+        @buffer << message.offset
+        produce_async(topic: DT.topics[1], payload: '1')
+      end
+
+      unless DT.key?(:marked)
+        mark_as_consumed(messages.last)
+        DT[:marked] = true
+      end
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    manual_offset_management(true)
+    consumer Consumer
+    config(partitions: 2)
+  end
+
+  topic DT.topics[1] do
+    active false
+  end
+end
+
+Thread.new do
+  base = -1
+
+  loop do
+    accu = []
+
+    100.times { accu << base += 1 }
+
+    accu.map!(&:to_s)
+
+    produce_many(DT.topic, accu, partition: 0)
+    produce_many(DT.topic, accu, partition: 1)
+
+    sleep(rand)
+  rescue WaterDrop::Errors::ProducerClosedError, Rdkafka::ClosedProducerError
+    break
+  end
+end
+
+other = Thread.new do
+  loop do
+    consumer = setup_rdkafka_consumer('partition.assignment.strategy': 'cooperative-sticky')
+    consumer.subscribe(DT.topic)
+
+    2.times { consumer.poll(1_000) }
+
+    consumer.close
+
+    DT[:attempts] << true
+
+    break if DT[:attempts].size >= 10
+  end
+end
+
+start_karafka_and_wait_until do
+  DT[:attempts].size >= 10
+end
+
+other.join
+
+# This ensures we do not skip over offsets
+DT[:all].each do |partition, offsets|
+  sorted = offsets.uniq.sort
+  previous = sorted.first - 1
+
+  sorted.each do |offset|
+    # We check for 2 or less because of the transactional markers
+    assert(
+      ((previous + 1) - offset) <= 1,
+      [previous, offset, partition]
+    )
+
+    previous = offset
+  end
+end
+
+# This ensures we do not skip over messages
+DT[:data].each do |partition, counters|
+  sorted = counters.uniq.sort
+  previous = sorted.first - 1
+
+  sorted.each do |count|
+    assert_equal(
+      previous + 1,
+      count,
+      [previous, count, partition]
+    )
+
+    previous = count
+  end
+end

--- a/spec/integrations/pro/consumption/transactions/post_revocation_non_cooperative_reclaim_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/post_revocation_non_cooperative_reclaim_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+# When a transactional consumer goes into a non-cooperative-sticky rebalance and gets the
+# partitions back, it should not have duplicated data.
+
+setup_karafka do |config|
+  config.kafka[:'transactional.id'] = SecureRandom.uuid
+  config.kafka[:'isolation.level'] = 'read_committed'
+  config.max_messages = 1_000
+end
+
+DT[:all] = {}
+DT[:data] = {}
+
+class Consumer < Karafka::BaseConsumer
+  def initialized
+    @buffer = []
+  end
+
+  def consume
+    DT[:running] = true
+
+    transaction do
+      messages.each do |message|
+        DT[:all][partition] ||= []
+        DT[:all][partition] << message.offset
+
+        DT[:data][partition] ||= []
+        DT[:data][partition] << message.raw_payload.to_i
+
+        raise if @buffer.include?(message.offset)
+
+        @buffer << message.offset
+        produce_async(topic: DT.topics[1], payload: '1')
+      end
+
+      unless DT.key?(:marked)
+        mark_as_consumed(messages.last)
+        DT[:marked] = true
+      end
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    manual_offset_management(true)
+    consumer Consumer
+    config(partitions: 2)
+  end
+
+  topic DT.topics[1] do
+    active false
+  end
+end
+
+Thread.new do
+  base = -1
+
+  loop do
+    accu = []
+
+    100.times { accu << base += 1 }
+
+    accu.map!(&:to_s)
+
+    produce_many(DT.topic, accu, partition: 0)
+    produce_many(DT.topic, accu, partition: 1)
+
+    sleep(rand)
+  rescue WaterDrop::Errors::ProducerClosedError, Rdkafka::ClosedProducerError
+    break
+  end
+end
+
+other = Thread.new do
+  loop do
+    consumer = setup_rdkafka_consumer
+    consumer.subscribe(DT.topic)
+    consumer.each { break }
+
+    2.times { consumer.poll(1_000) }
+
+    consumer.close
+
+    DT[:attempts] << true
+
+    break if DT[:attempts].size >= 10
+  end
+end
+
+start_karafka_and_wait_until do
+  DT[:attempts].size >= 10
+end
+
+other.join
+
+# This ensures we do not skip over offsets
+DT[:all].each do |partition, offsets|
+  sorted = offsets.uniq.sort
+  previous = sorted.first - 1
+
+  sorted.each do |offset|
+    # We check for 2 or less because of the transactional markers
+    assert(
+      ((previous + 1) - offset) <= 1,
+      [previous, offset, partition]
+    )
+
+    previous = offset
+  end
+end
+
+# This ensures we do not skip over messages
+DT[:data].each do |partition, counters|
+  sorted = counters.uniq.sort
+  previous = sorted.first - 1
+
+  sorted.each do |count|
+    assert_equal(
+      previous + 1,
+      count,
+      [previous, count, partition]
+    )
+
+    previous = count
+  end
+end

--- a/spec/integrations/rebalancing/consecutive_reclaim_flow_cooperative_spec.rb
+++ b/spec/integrations/rebalancing/consecutive_reclaim_flow_cooperative_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+# When consumer reclaims messages, it should not skip and should not have duplicated
+# Marking should happen automatically
+# Cooperative should not collide with this.
+
+setup_karafka do |config|
+  config.max_messages = 1_000
+  config.kafka[:'partition.assignment.strategy'] = 'cooperative-sticky'
+end
+
+DT[:all] = {}
+DT[:data] = {}
+
+class Consumer < Karafka::BaseConsumer
+  def initialized
+    @buffer = []
+  end
+
+  def consume
+    DT[:running] = true
+
+    messages.each do |message|
+      DT[:all][partition] ||= []
+      DT[:all][partition] << message.offset
+
+      DT[:data][partition] ||= []
+      DT[:data][partition] << message.raw_payload.to_i
+
+      raise if @buffer.include?(message.offset)
+
+      @buffer << message.offset
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    config(partitions: 2)
+  end
+end
+
+Thread.new do
+  base = -1
+
+  loop do
+    accu = []
+
+    100.times { accu << base += 1 }
+
+    accu.map!(&:to_s)
+
+    produce_many(DT.topic, accu, partition: 0)
+    produce_many(DT.topic, accu, partition: 1)
+
+    sleep(rand)
+  rescue WaterDrop::Errors::ProducerClosedError, Rdkafka::ClosedProducerError
+    break
+  end
+end
+
+other = Thread.new do
+  loop do
+    consumer = setup_rdkafka_consumer('partition.assignment.strategy': 'cooperative-sticky')
+    consumer.subscribe(DT.topic)
+    consumer.each { break }
+
+    2.times { consumer.poll(1_000) }
+
+    consumer.close
+
+    DT[:attempts] << true
+
+    break if DT[:attempts].size >= 4
+  end
+end
+
+start_karafka_and_wait_until do
+  DT[:attempts].size >= 4
+end
+
+other.join
+
+# This ensures we do not skip over offsets
+DT[:all].each do |partition, offsets|
+  previous = offsets.first - 1
+
+  offsets.each do |offset|
+    assert_equal(
+      previous + 1,
+      offset,
+      [previous, offset, partition]
+    )
+
+    previous = offset
+  end
+end
+
+# This ensures we do not skip over messages
+DT[:data].each do |partition, counters|
+  previous = counters.first - 1
+
+  counters.each do |count|
+    assert_equal(
+      previous + 1,
+      count,
+      [previous, count, partition]
+    )
+
+    previous = count
+  end
+end

--- a/spec/integrations/rebalancing/consecutive_reclaim_flow_spec.rb
+++ b/spec/integrations/rebalancing/consecutive_reclaim_flow_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+# When consumer reclaims messages, it should not skip and should not have duplicated
+# Marking should happen automatically
+
+setup_karafka do |config|
+  config.max_messages = 1_000
+end
+
+DT[:all] = {}
+DT[:data] = {}
+
+class Consumer < Karafka::BaseConsumer
+  def initialized
+    @buffer = []
+  end
+
+  def consume
+    DT[:running] = true
+
+    messages.each do |message|
+      DT[:all][partition] ||= []
+      DT[:all][partition] << message.offset
+
+      DT[:data][partition] ||= []
+      DT[:data][partition] << message.raw_payload.to_i
+
+      raise if @buffer.include?(message.offset)
+
+      @buffer << message.offset
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    config(partitions: 2)
+  end
+end
+
+Thread.new do
+  base = -1
+
+  loop do
+    accu = []
+
+    100.times { accu << base += 1 }
+
+    accu.map!(&:to_s)
+
+    produce_many(DT.topic, accu, partition: 0)
+    produce_many(DT.topic, accu, partition: 1)
+
+    sleep(rand)
+  rescue WaterDrop::Errors::ProducerClosedError, Rdkafka::ClosedProducerError
+    break
+  end
+end
+
+other = Thread.new do
+  loop do
+    consumer = setup_rdkafka_consumer
+    consumer.subscribe(DT.topic)
+    consumer.each { break }
+
+    2.times { consumer.poll(1_000) }
+
+    consumer.close
+
+    DT[:attempts] << true
+
+    break if DT[:attempts].size >= 4
+  end
+end
+
+start_karafka_and_wait_until do
+  DT[:attempts].size >= 4
+end
+
+other.join
+
+# This ensures we do not skip over offsets
+DT[:all].each do |partition, offsets|
+  previous = offsets.first - 1
+
+  offsets.each do |offset|
+    assert_equal(
+      previous + 1,
+      offset,
+      [previous, offset, partition]
+    )
+
+    previous = offset
+  end
+end
+
+# This ensures we do not skip over messages
+DT[:data].each do |partition, counters|
+  previous = counters.first - 1
+
+  counters.each do |count|
+    assert_equal(
+      previous + 1,
+      count,
+      [previous, count, partition]
+    )
+
+    previous = count
+  end
+end

--- a/spec/integrations/rebalancing/revoke_reclaim_continuity_spec.rb
+++ b/spec/integrations/rebalancing/revoke_reclaim_continuity_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+# When a consumer goes into a non-cooperative-sticky rebalance and gets the partitions back,
+# it should not have duplicated data.
+
+setup_karafka do |config|
+  config.max_messages = 1_000
+end
+
+DT[:all] = {}
+DT[:data] = {}
+
+class Consumer < Karafka::BaseConsumer
+  def initialized
+    @buffer = []
+  end
+
+  def consume
+    DT[:running] = true
+
+    messages.each do |message|
+      DT[:all][partition] ||= []
+      DT[:all][partition] << message.offset
+
+      DT[:data][partition] ||= []
+      DT[:data][partition] << message.raw_payload.to_i
+
+      raise if @buffer.include?(message.offset)
+
+      @buffer << message.offset
+      produce_async(topic: DT.topics[1], payload: message.raw_payload)
+    end
+
+    unless DT.key?(:marked)
+      mark_as_consumed(messages.last)
+      DT[:marked] = true
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    manual_offset_management(true)
+    consumer Consumer
+    config(partitions: 2)
+  end
+
+  topic DT.topics[1] do
+    active false
+  end
+end
+
+Thread.new do
+  base = -1
+
+  loop do
+    accu = []
+
+    100.times { accu << base += 1 }
+
+    accu.map!(&:to_s)
+
+    produce_many(DT.topic, accu, partition: 0)
+    produce_many(DT.topic, accu, partition: 1)
+
+    sleep(rand)
+  rescue WaterDrop::Errors::ProducerClosedError, Rdkafka::ClosedProducerError
+    break
+  end
+end
+
+other = Thread.new do
+  loop do
+    consumer = setup_rdkafka_consumer
+    consumer.subscribe(DT.topic)
+    consumer.each { break }
+
+    2.times { consumer.poll(1_000) }
+
+    consumer.close
+
+    DT[:attempts] << true
+
+    break if DT[:attempts].size >= 4
+  end
+end
+
+start_karafka_and_wait_until do
+  DT[:attempts].size >= 4
+end
+
+other.join
+
+# This ensures we do not skip over offsets
+DT[:all].each do |partition, offsets|
+  sorted = offsets.uniq.sort
+  previous = sorted.first - 1
+
+  sorted.each do |offset|
+    assert_equal(
+      previous + 1,
+      offset,
+      [previous, offset, partition]
+    )
+
+    previous = offset
+  end
+end
+
+# This ensures we do not skip over messages
+DT[:data].each do |partition, counters|
+  sorted = counters.uniq.sort
+  previous = sorted.first - 1
+
+  sorted.each do |count|
+    assert_equal(
+      previous + 1,
+      count,
+      [previous, count, partition]
+    )
+
+    previous = count
+  end
+end

--- a/spec/integrations/rebalancing/stored_reclaimed_continuity_cooperative_spec.rb
+++ b/spec/integrations/rebalancing/stored_reclaimed_continuity_cooperative_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+# When consumer looses the partition but later on gets it back, it should not have duplicates
+# as long as marking always happened (which is the case in this scenario)
+# There also should be no duplicates
+
+setup_karafka do |config|
+  config.max_messages = 1_000
+  config.kafka[:'partition.assignment.strategy'] = 'cooperative-sticky'
+end
+
+DT[:all] = { 0 => [], 1 => [] }
+DT[:data] = { 0 => [], 1 => [] }
+
+class Consumer < Karafka::BaseConsumer
+  def initialized
+    @buffer = []
+  end
+
+  def consume
+    DT[:running] = true
+
+    messages.each do |message|
+      DT[:all][partition] << message.offset
+      DT[:data][partition] << message.raw_payload.to_i
+
+      raise if @buffer.include?(message.offset)
+
+      @buffer << message.offset
+    end
+
+    mark_as_consumed(messages.last)
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    config(partitions: 2)
+  end
+end
+
+Thread.new do
+  base = -1
+
+  loop do
+    accu = []
+
+    100.times { accu << base += 1 }
+
+    accu.map!(&:to_s)
+
+    produce_many(DT.topic, accu, partition: 0)
+    produce_many(DT.topic, accu, partition: 1)
+
+    sleep(rand)
+  rescue WaterDrop::Errors::ProducerClosedError, Rdkafka::ClosedProducerError
+    break
+  end
+end
+
+other = Thread.new do
+  loop do
+    consumer = setup_rdkafka_consumer('partition.assignment.strategy': 'cooperative-sticky')
+    consumer.subscribe(DT.topic)
+
+    consumer.each do |message|
+      DT[:all][message.partition] << message.offset
+      DT[:data][message.partition] << message.payload.to_i
+
+      consumer.store_offset(message)
+      consumer.commit
+
+      break
+    end
+
+    consumer.close
+
+    DT[:attempts] << true
+
+    break if DT[:attempts].size >= 3
+  end
+end
+
+start_karafka_and_wait_until do
+  DT[:attempts].size >= 3
+end
+
+other.join
+
+# This ensures we do not skip over offsets
+DT[:all].each do |partition, offsets|
+  sorted = offsets.uniq.sort
+  previous = sorted.first - 1
+
+  sorted.each do |offset|
+    assert_equal(
+      previous + 1,
+      offset,
+      [previous, offset, partition]
+    )
+
+    previous = offset
+  end
+end
+
+# This ensures we do not skip over messages
+DT[:data].each do |partition, counters|
+  sorted = counters.uniq.sort
+  previous = sorted.first - 1
+
+  sorted.each do |count|
+    assert_equal(
+      previous + 1,
+      count,
+      [previous, count, partition]
+    )
+
+    previous = count
+  end
+end

--- a/spec/integrations/rebalancing/stored_reclaimed_continuity_spec.rb
+++ b/spec/integrations/rebalancing/stored_reclaimed_continuity_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+# When consumer looses the partition but later on gets it back, it should not have duplicates
+# as long as marking always happened (which is the case in this scenario)
+# There also should be no duplicates
+
+setup_karafka do |config|
+  config.max_messages = 1_000
+end
+
+DT[:all] = { 0 => [], 1 => [] }
+DT[:data] = { 0 => [], 1 => [] }
+
+class Consumer < Karafka::BaseConsumer
+  def initialized
+    @buffer = []
+  end
+
+  def consume
+    DT[:running] = true
+
+    messages.each do |message|
+      DT[:all][partition] << message.offset
+      DT[:data][partition] << message.raw_payload.to_i
+
+      raise if @buffer.include?(message.offset)
+
+      @buffer << message.offset
+    end
+
+    mark_as_consumed(messages.last)
+  end
+end
+
+draw_routes do
+  topic DT.topics[0] do
+    consumer Consumer
+    config(partitions: 2)
+  end
+end
+
+Thread.new do
+  base = -1
+
+  loop do
+    accu = []
+
+    100.times { accu << base += 1 }
+
+    accu.map!(&:to_s)
+
+    produce_many(DT.topic, accu, partition: 0)
+    produce_many(DT.topic, accu, partition: 1)
+
+    sleep(rand)
+  rescue WaterDrop::Errors::ProducerClosedError, Rdkafka::ClosedProducerError
+    break
+  end
+end
+
+other = Thread.new do
+  loop do
+    consumer = setup_rdkafka_consumer
+    consumer.subscribe(DT.topic)
+
+    consumer.each do |message|
+      DT[:all][message.partition] << message.offset
+      DT[:data][message.partition] << message.payload.to_i
+
+      consumer.store_offset(message)
+      consumer.commit
+
+      break
+    end
+
+    consumer.close
+
+    DT[:attempts] << true
+
+    break if DT[:attempts].size >= 4
+  end
+end
+
+start_karafka_and_wait_until do
+  DT[:attempts].size >= 4
+end
+
+other.join
+
+# This ensures we do not skip over offsets
+DT[:all].each do |partition, offsets|
+  previous = offsets.first - 1
+
+  offsets.each do |offset|
+    assert_equal(
+      previous + 1,
+      offset,
+      [previous, offset, partition]
+    )
+
+    previous = offset
+  end
+end
+
+# This ensures we do not skip over messages
+DT[:data].each do |partition, counters|
+  previous = counters.first - 1
+
+  counters.each do |count|
+    assert_equal(
+      previous + 1,
+      count,
+      [previous, count, partition]
+    )
+
+    previous = count
+  end
+end

--- a/spec/lib/karafka/connection/rebalance_manager_spec.rb
+++ b/spec/lib/karafka/connection/rebalance_manager_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe_current do
-  subject(:manager) { described_class.new(subscription_group_id, on_revoked: ->(_) {}) }
+  subject(:manager) { described_class.new(subscription_group_id, buffer) }
 
   let(:partition1) { Rdkafka::Consumer::Partition.new(1, 'topic_name') }
   let(:partition2) { Rdkafka::Consumer::Partition.new(4, 'topic_name') }
@@ -9,10 +9,9 @@ RSpec.describe_current do
   let(:subscription_group) { build(:routing_subscription_group) }
   let(:subscription_group_id) { subscription_group.id }
   let(:event) { { subscription_group_id: subscription_group_id, tpl: partitions } }
+  let(:buffer) { Karafka::Connection::RawMessagesBuffer.new }
 
-  describe(
-    '#revoked_partitions, #on_rebalance_partitions_revoked and #changed?'
-  ) do
+  describe '#revoked_partitions, #on_rebalance_partitions_revoked and #changed?' do
     it { expect(manager.active?).to eq(false) }
 
     context 'when there are no revoked partitions' do

--- a/spec/lib/karafka/connection/rebalance_manager_spec.rb
+++ b/spec/lib/karafka/connection/rebalance_manager_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe_current do
-  subject(:manager) { described_class.new(subscription_group_id) }
+  subject(:manager) { described_class.new(subscription_group_id, on_revoked: ->(_) {}) }
 
   let(:partition1) { Rdkafka::Consumer::Partition.new(1, 'topic_name') }
   let(:partition2) { Rdkafka::Consumer::Partition.new(4, 'topic_name') }
@@ -11,7 +11,7 @@ RSpec.describe_current do
   let(:event) { { subscription_group_id: subscription_group_id, tpl: partitions } }
 
   describe(
-    '#revoked_partitions, #on_rebalance_partitions_revoked, #lost_partitions and #changed?'
+    '#revoked_partitions, #on_rebalance_partitions_revoked and #changed?'
   ) do
     it { expect(manager.active?).to eq(false) }
 
@@ -60,10 +60,6 @@ RSpec.describe_current do
 
       it { expect(manager.active?).to eq(true) }
 
-      it 'expect not to include them in the lost partitions back' do
-        expect(manager.lost_partitions).to eq({ 'topic_name' => [partition2.partition] })
-      end
-
       it 'expect to include them in the revoked partitions back' do
         expected_partitions = [partition1.partition, partition2.partition]
         expect(manager.revoked_partitions).to eq({ 'topic_name' => expected_partitions })
@@ -89,10 +85,6 @@ RSpec.describe_current do
       end
 
       it { expect(manager.active?).to eq(false) }
-
-      it 'expect not to include them in the lost partitions back' do
-        expect(manager.lost_partitions).to eq({})
-      end
 
       it 'expect to include them in the revoked partitions back' do
         expect(manager.revoked_partitions).to eq({})


### PR DESCRIPTION
This PR moves the post-revoked data revocation closer to the revocation event and removes no longer needed (because of this change) diffing of post-revoked messages via `lost_partitions`. Because we do cleanup now right after the revocation, we don't have to compute lost partitions anymore. Aside from fixing the below bug in transactional flows it also improves the general flow.

close https://github.com/karafka/karafka/issues/2370

A lot of extra specs are added just to cover various cases.
