### PR TITLE
Stabilize more specs

### DIFF
--- a/spec/integrations/pro/consumption/transactions/post_revocation_non_cooperative_reclaim_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/post_revocation_non_cooperative_reclaim_spec.rb
@@ -73,15 +73,16 @@ Thread.new do
   end
 end
 
+consumer = setup_rdkafka_consumer
+
 other = Thread.new do
   loop do
-    consumer = setup_rdkafka_consumer
     consumer.subscribe(DT.topic)
     consumer.each { break }
 
     2.times { consumer.poll(1_000) }
 
-    consumer.close
+    consumer.unsubscribe
 
     DT[:attempts] << true
 
@@ -93,7 +94,9 @@ start_karafka_and_wait_until do
   DT[:attempts].size >= 10
 end
 
-other.join
+other.join(10) || raise
+
+consumer.close
 
 # This ensures we do not skip over offsets
 DT[:all].each do |partition, offsets|

--- a/spec/integrations/pro/rebalancing/transactions/revoke_reclaim_continuity_cooperative_spec.rb
+++ b/spec/integrations/pro/rebalancing/transactions/revoke_reclaim_continuity_cooperative_spec.rb
@@ -73,15 +73,16 @@ Thread.new do
   end
 end
 
+consumer = setup_rdkafka_consumer('partition.assignment.strategy': 'cooperative-sticky')
+
 other = Thread.new do
   loop do
-    consumer = setup_rdkafka_consumer('partition.assignment.strategy': 'cooperative-sticky')
     consumer.subscribe(DT.topic)
     consumer.each { break }
 
     2.times { consumer.poll(1_000) }
 
-    consumer.close
+    consumer.unsubscribe
 
     DT[:attempts] << true
 
@@ -93,7 +94,9 @@ start_karafka_and_wait_until do
   DT[:attempts].size >= 3
 end
 
-other.join
+other.join(10) || raise
+
+consumer.close
 
 # This ensures we do not skip over offsets
 # The +1 range is for the transactional marker

--- a/spec/integrations/pro/rebalancing/transactions/revoke_reclaim_continuity_spec.rb
+++ b/spec/integrations/pro/rebalancing/transactions/revoke_reclaim_continuity_spec.rb
@@ -72,15 +72,16 @@ Thread.new do
   end
 end
 
+consumer = setup_rdkafka_consumer
+
 other = Thread.new do
   loop do
-    consumer = setup_rdkafka_consumer
     consumer.subscribe(DT.topic)
     consumer.each { break }
 
     2.times { consumer.poll(1_000) }
 
-    consumer.close
+    consumer.unsubscribe
 
     DT[:attempts] << true
 
@@ -92,7 +93,9 @@ start_karafka_and_wait_until do
   DT[:attempts].size >= 4
 end
 
-other.join
+other.join(10) || raise
+
+consumer.close
 
 # This ensures we do not skip over offsets
 # The +1 range is for the transactional marker

--- a/spec/integrations/rebalancing/consecutive_reclaim_flow_cooperative_spec.rb
+++ b/spec/integrations/rebalancing/consecutive_reclaim_flow_cooperative_spec.rb
@@ -60,15 +60,16 @@ Thread.new do
   end
 end
 
+consumer = setup_rdkafka_consumer('partition.assignment.strategy': 'cooperative-sticky')
+
 other = Thread.new do
   loop do
-    consumer = setup_rdkafka_consumer('partition.assignment.strategy': 'cooperative-sticky')
     consumer.subscribe(DT.topic)
     consumer.each { break }
 
     2.times { consumer.poll(1_000) }
 
-    consumer.close
+    consumer.unsubscribe
 
     DT[:attempts] << true
 
@@ -80,7 +81,9 @@ start_karafka_and_wait_until do
   DT[:attempts].size >= 4
 end
 
-other.join
+other.join(10) || raise
+
+consumer.close
 
 # This ensures we do not skip over offsets
 DT[:all].each do |partition, offsets|

--- a/spec/integrations/rebalancing/revoke_reclaim_continuity_spec.rb
+++ b/spec/integrations/rebalancing/revoke_reclaim_continuity_spec.rb
@@ -69,15 +69,16 @@ Thread.new do
   end
 end
 
+consumer = setup_rdkafka_consumer
+
 other = Thread.new do
   loop do
-    consumer = setup_rdkafka_consumer
     consumer.subscribe(DT.topic)
     consumer.each { break }
 
     2.times { consumer.poll(1_000) }
 
-    consumer.close
+    consumer.unsubscribe
 
     DT[:attempts] << true
 
@@ -89,7 +90,9 @@ start_karafka_and_wait_until do
   DT[:attempts].size >= 4
 end
 
-other.join
+other.join(10) || raise
+
+consumer.close
 
 # This ensures we do not skip over offsets
 DT[:all].each do |partition, offsets|


### PR DESCRIPTION
We should not close librdkafka that often so instead to trigger rebalancing we re-use the same instance.
