### PR TITLE
improve spec debuggability

### DIFF
--- a/spec/integrations/pro/recurring_tasks/state_publishing_frequency_spec.rb
+++ b/spec/integrations/pro/recurring_tasks/state_publishing_frequency_spec.rb
@@ -31,11 +31,12 @@ end
 
 previous = nil
 
-Karafka::Admin
-  .read_topic(Karafka::App.config.recurring_tasks.topics.schedules, 0, 21)
-  .map(&:key)
-  .each do |event|
-    assert previous != event
+keys = Karafka::Admin
+       .read_topic(Karafka::App.config.recurring_tasks.topics.schedules, 0, 21)
+       .map(&:key)
 
-    previous = event
-  end
+keys.each do |event|
+  assert previous != event, keys
+
+  previous = event
+end


### PR DESCRIPTION
This spec sometimes fails on this assertion, but the assertion conditions are not printed. This PR does not fix the issue with this spec but adds better reporting.