### PR TITLE
Granular cleaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Karafka Framework Changelog
 
 ## 2.4.17 (Unreleased)
-- [Enhancement] Clean message key and headers when cleaning messages via the cleaner API.
+- [Enhancement] Clean message key and headers when cleaning messages via the cleaner API (Pro).
+- [Enhancement] Allow for setting `metadata: false` in the cleaner API for granular cleaning control (Pro)
 
 ## 2.4.16 (2024-12-27)
 - [Enhancement] Improve post-rebalance revocation messages filtering.

--- a/lib/karafka/pro/cleaner/messages/message.rb
+++ b/lib/karafka/pro/cleaner/messages/message.rb
@@ -35,12 +35,19 @@ module Karafka
           # After the message content is no longer needed, it can be removed so it does not consume
           # space anymore.
           #
+          # @param metadata [Boolean] should we also clean metadata alongside the payload. This can
+          #   be useful when working with iterator and other things that may require only metadata
+          #   available, while not payload. `true` by default.
+          #
           # @note Cleaning of message means we also clean its metadata (headers and key)
-          def clean!
+          # @note Metadata cleaning (headers and key) can be disabled by setting the `metadata`
+          #   argument to `false`.
+          def clean!(metadata: true)
             @deserialized = false
             @raw_payload = false
             @payload = nil
-            @metadata.clean!
+
+            @metadata.clean! if metadata
           end
         end
       end

--- a/spec/integrations/pro/consumption/cleaner/without_metadata_spec.rb
+++ b/spec/integrations/pro/consumption/cleaner/without_metadata_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# We should be able to clean only payload when needed
+
+setup_karafka
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      message.payload if (message.offset % 2).zero?
+
+      message.clean!(metadata: false)
+
+      # We should fail if we try to deserialize a cleaned message
+      if message.offset == 5
+        begin
+          message.payload
+        rescue Karafka::Pro::Cleaner::Errors::MessageCleanedError
+          DT[1] = true
+        end
+
+        message.key
+        message.headers
+      end
+
+      DT[0] << true
+    end
+  end
+end
+
+draw_routes(Consumer)
+
+elements = DT.uuids(100).map { |val| { val: val }.to_json }
+produce_many(DT.topic, elements)
+
+start_karafka_and_wait_until do
+  DT[0].size >= 100
+end
+
+assert DT.key?(1)
+assert !DT.key?(2)
+assert !DT.key?(3)

--- a/spec/integrations/pro/iterator/with_granular_cleaning_spec.rb
+++ b/spec/integrations/pro/iterator/with_granular_cleaning_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# We should be able to clean messages while keeping the metadata
+
+setup_karafka
+
+draw_routes do
+  topic DT.topic do
+    active false
+  end
+end
+
+elements = DT.uuids(20).map { |data| { value: data }.to_json }
+produce_many(DT.topic, elements)
+
+# From beginning till the end
+iterator = Karafka::Pro::Iterator.new(DT.topic)
+i = 0
+iterator.each do |message|
+  assert_equal i, message.offset
+  assert_equal message.raw_payload, elements[i]
+
+  message.payload
+  message.clean!(metadata: false)
+  # If all would be cleaned, below would fail
+  message.key
+  message.headers
+
+  i += 1
+end
+
+assert_equal 20, i
+
+# From middle till the end
+i = 9
+iterator = Karafka::Pro::Iterator.new(
+  {
+    DT.topic => { 0 => 9 }
+  }
+)
+
+iterator.each do |message|
+  assert_equal i, message.offset
+  assert_equal message.raw_payload, elements[i]
+
+  message.payload
+
+  i += 1
+end
+
+assert_equal 20, i

--- a/spec/lib/karafka/pro/cleaner/messages/message_spec.rb
+++ b/spec/lib/karafka/pro/cleaner/messages/message_spec.rb
@@ -33,6 +33,17 @@ RSpec.describe_current do
       it { expect(message.metadata.cleaned?).to be(true) }
     end
 
+    context 'when message was cleaned with metadata cleaning disabled' do
+      before { message.clean!(metadata: false) }
+
+      it { expect(message.cleaned?).to be(true) }
+      it { expect(message.deserialized?).to be(false) }
+      it { expect(message.raw_payload).to be(false) }
+      it { expect(message.metadata.cleaned?).to be(false) }
+      it { expect(message.metadata.key).to be_nil }
+      it { expect(message.metadata.headers).to eq({}) }
+    end
+
     context 'when message was deserialized and cleaned' do
       before do
         message.payload


### PR DESCRIPTION
This PR allows for control what should be cleaned. Useful when metadata may still be needed but not the payload.