### PR TITLE
Allow marking older offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Karafka Framework Changelog
 
 ## 2.4.18 (Unreleased)
+- [Enhancement] Introduce `#marking_cursor` API (defaults to `#cursor`) in the filtering API (Pro).
 - [Enhancement] Support multiple DLQ target topics via context aware strategies (Pro).
 - [Enhancement] Raise error when post-transactional committing of offset is done outside of the transaction (Pro).
 - [Enhancement] Include info level rebalance logger listener data.
 - [Enhancement] Include info level subscription start info.
 - [Enhancement] Make the generic error handling in the `LoggerListener` more descriptive by logging also the error class.
+- [Enhancement] Allow marking older offsets to support advanced rewind capabilities.
 - [Fix] WaterDrop level aborting transaction may cause seek offset to move (Pro).
 - [Fix] Fix inconsistency in the logs where `Karafka::Server` originating logs would not have server id reference.
 - [Fix] Fix inconsistency in the logs where OS signal originating logs would not have server id reference.

--- a/lib/karafka/pro/processing/coordinators/filters_applier.rb
+++ b/lib/karafka/pro/processing/coordinators/filters_applier.rb
@@ -98,6 +98,17 @@ module Karafka
             :mark_as_consumed
           end
 
+          # The first (lowest) message we want to mark as consumed in marking. By default it uses
+          #   same position as cursor in case user wants to mark same message as consumed as the
+          #   one on which cursor action is applied.
+          # @return [Karafka::Messages::Message, nil] cursor marking message or nil if none
+          # @note It should not return position in time format, only numerical offset
+          def marking_cursor
+            return nil unless active?
+
+            applied.map(&:marking_cursor).compact.min_by(&:offset)
+          end
+
           private
 
           # @return [Boolean] is filtering active

--- a/lib/karafka/pro/processing/filters/base.rb
+++ b/lib/karafka/pro/processing/filters/base.rb
@@ -23,6 +23,7 @@ module Karafka
           def initialize
             @applied = false
             @cursor = nil
+            @reset_offset = false
           end
 
           # @param messages [Array<Karafka::Messages::Message>] array with messages. Please keep
@@ -57,6 +58,12 @@ module Karafka
           #   marking is requested
           def marking_method
             :mark_as_consumed
+          end
+
+          # @return [Karafka::Messages::Message, nil] cursor message for marking or nil if no
+          #   marking
+          def marking_cursor
+            cursor
           end
         end
       end

--- a/lib/karafka/pro/processing/strategies/default.rb
+++ b/lib/karafka/pro/processing/strategies/default.rb
@@ -55,8 +55,11 @@ module Karafka
               # seek offset can be nil only in case `#seek` was invoked with offset reset request
               # In case like this we ignore marking
               return true if seek_offset.nil?
-              # Ignore earlier offsets than the one we already committed
-              return true if seek_offset > message.offset
+              # Ignore if it is the same offset as the one that is marked currently
+              # We ignore second marking because it changes nothing and in case of people using
+              # metadata storage but with automatic offset marking, this would cause metadata to be
+              # erased by automatic marking
+              return true if (seek_offset - 1) == message.offset
               return false if revoked?
 
               # If we are not inside a transaction but this is a transactional topic, we mark with
@@ -94,8 +97,11 @@ module Karafka
               # seek offset can be nil only in case `#seek` was invoked with offset reset request
               # In case like this we ignore marking
               return true if seek_offset.nil?
-              # Ignore earlier offsets than the one we already committed
-              return true if seek_offset > message.offset
+              # Ignore if it is the same offset as the one that is marked currently
+              # We ignore second marking because it changes nothing and in case of people using
+              # metadata storage but with automatic offset marking, this would cause metadata to be
+              # erased by automatic marking
+              return true if (seek_offset - 1) == message.offset
               return false if revoked?
 
               # If we are not inside a transaction but this is a transactional topic, we mark with
@@ -271,8 +277,11 @@ module Karafka
             # seek offset can be nil only in case `#seek` was invoked with offset reset request
             # In case like this we ignore marking
             return true if seek_offset.nil?
-            # Ignore earlier offsets than the one we already committed
-            return true if seek_offset > message.offset
+            # Ignore if it is the same offset as the one that is marked currently
+            # We ignore second marking because it changes nothing and in case of people using
+            # metadata storage but with automatic offset marking, this would cause metadata to be
+            # erased by automatic marking
+            return true if (seek_offset - 1) == message.offset
             return false if revoked?
 
             # If we have already marked this successfully in a transaction that was running

--- a/lib/karafka/pro/processing/strategies/ftr/default.rb
+++ b/lib/karafka/pro/processing/strategies/ftr/default.rb
@@ -67,7 +67,7 @@ module Karafka
               if filter.mark_as_consumed?
                 send(
                   filter.marking_method,
-                  filter.cursor
+                  filter.marking_cursor
                 )
               end
 

--- a/lib/karafka/processing/strategies/default.rb
+++ b/lib/karafka/processing/strategies/default.rb
@@ -55,8 +55,8 @@ module Karafka
           # seek offset can be nil only in case `#seek` was invoked with offset reset request
           # In case like this we ignore marking
           return true if seek_offset.nil?
-          # Ignore earlier offsets than the one we already committed
-          return true if seek_offset > message.offset
+          # Ignore double markings of the same offset
+          return true if (seek_offset - 1) == message.offset
           return false if revoked?
           return revoked? unless client.mark_as_consumed(message)
 
@@ -74,8 +74,8 @@ module Karafka
           # seek offset can be nil only in case `#seek` was invoked with offset reset request
           # In case like this we ignore marking
           return true if seek_offset.nil?
-          # Ignore earlier offsets than the one we already committed
-          return true if seek_offset > message.offset
+          # Ignore double markings of the same offset
+          return true if (seek_offset - 1) == message.offset
           return false if revoked?
 
           return revoked? unless client.mark_as_consumed!(message)

--- a/spec/integrations/pro/consumption/offset_metadata/basic_automatic_flow_overwritten_last_marking_spec.rb
+++ b/spec/integrations/pro/consumption/offset_metadata/basic_automatic_flow_overwritten_last_marking_spec.rb
@@ -3,7 +3,8 @@
 # This code is part of Karafka Pro, a commercial component not licensed under LGPL.
 # See LICENSE for details.
 
-# When offset metadata is stored but a custom forced value is used, the forced on should be used.
+# When offset metadata is stored and we mark each, later marking as consumed on the same location
+# should not end up with us loosing metadata
 
 setup_karafka do |config|
   config.max_messages = 1
@@ -16,18 +17,13 @@ class Consumer < Karafka::BaseConsumer
 
     DT[:metadata] << offset_metadata(cache: false)
 
-    store_offset_metadata(messages.first.offset.to_s)
+    store_offset_metadata(messages.last.offset.to_s)
 
-    mark_as_consumed(messages.first, 'cs')
+    mark_as_consumed(messages.last, 'cs')
   end
 end
 
-draw_routes do
-  topic DT.topic do
-    consumer Consumer
-    manual_offset_management(true)
-  end
-end
+draw_routes(Consumer)
 
 produce_many(DT.topic, DT.uuids(10))
 

--- a/spec/integrations/seek/back_without_reset_and_mark_again_spec.rb
+++ b/spec/integrations/seek/back_without_reset_and_mark_again_spec.rb
@@ -7,7 +7,6 @@ setup_karafka
 class Consumer < Karafka::BaseConsumer
   def consume
     if @seeked && !@marked
-      mark_as_consumed!(messages.first)
       @marked = true
       DT[:done] = true
     end
@@ -15,7 +14,7 @@ class Consumer < Karafka::BaseConsumer
     return if @seeked
 
     messages.each do |message|
-      mark_as_consumed!(message)
+      mark_as_consumed!(message) unless @seeked
 
       next unless message.offset == 9
 


### PR DESCRIPTION
In order to be able to move offsets freely with marking (for rebalance persistence) without having to deal with forced seek, this PR aligns Karafka behaviour with librdkafka allowing for older offsets storage and persistence. No integration specs (aside one which was expected) were affected.

Aside from that a new `#marking_cursor` API for Filtering is introduced to further support Web UI development.

Without this change our ability to mark from filtering API would be tampered as the offset position after moving back could not be persisted.