### PR TITLE
expose coordinators from listener

### DIFF
--- a/lib/karafka/connection/listener.rb
+++ b/lib/karafka/connection/listener.rb
@@ -19,6 +19,11 @@ module Karafka
       # @return [Karafka::Routing::SubscriptionGroup] subscription group that this listener handles
       attr_reader :subscription_group
 
+      # @return [Processing::CoordinatorsBuffer] coordinator buffers that can be used directly in
+      #   advanced cases of changes to the polling flow (like triggered seek back without messages
+      #   ahead in the topic)
+      attr_reader :coordinators
+
       # How long to wait in the initial events poll. Increases chances of having the initial events
       # immediately available
       INITIAL_EVENTS_POLL_TIMEOUT = 100

--- a/lib/karafka/processing/coordinators_buffer.rb
+++ b/lib/karafka/processing/coordinators_buffer.rb
@@ -22,6 +22,7 @@ module Karafka
 
       # @param topic_name [String] topic name
       # @param partition [Integer] partition number
+      # @return [Karafka::Processing::Coordinator] found or created coordinator
       def find_or_create(topic_name, partition)
         @coordinators[topic_name][partition] ||= begin
           routing_topic = @topics.find(topic_name)


### PR DESCRIPTION
This PR exposes the coordinators for my low-level internal APIs needs.