### PR TITLE
enhance low level client.pause event with a timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka Framework Changelog
 
 ## 2.4.18 (Unreleased)
+- [Enhancement] Enhance low-level `client.pause` event with timeout value (if provided).
 - [Enhancement] Introduce `#marking_cursor` API (defaults to `#cursor`) in the filtering API (Pro).
 - [Enhancement] Support multiple DLQ target topics via context aware strategies (Pro).
 - [Enhancement] Raise error when post-transactional committing of offset is done outside of the transaction (Pro).

--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -304,7 +304,12 @@ module Karafka
 
       offset = nil if offset == :consecutive
 
-      client.pause(topic.name, partition, offset)
+      client.pause(
+        topic.name,
+        partition,
+        offset,
+        coordinator.pause_tracker.current_timeout
+      )
 
       # Indicate, that user took a manual action of pausing
       coordinator.manual_pause if manual_pause

--- a/spec/lib/karafka/base_consumer_spec.rb
+++ b/spec/lib/karafka/base_consumer_spec.rb
@@ -119,7 +119,10 @@ RSpec.describe_current do
 
       it 'expect to pause based on the first message ever received' do
         consume_with_after.call
-        expect(client).to have_received(:pause).with(topic.name, first_message.partition, offset)
+
+        expect(client)
+          .to have_received(:pause)
+          .with(topic.name, first_message.partition, offset, 500)
       end
 
       it 'expect to pause with time tracker' do
@@ -421,7 +424,8 @@ RSpec.describe_current do
         [
           messages.metadata.topic,
           messages.metadata.partition,
-          100
+          100,
+          500
         ]
       end
 
@@ -438,7 +442,8 @@ RSpec.describe_current do
         [
           messages.metadata.topic,
           messages.metadata.partition,
-          100
+          100,
+          500
         ]
       end
 

--- a/spec/lib/karafka/pro/base_consumer_spec.rb
+++ b/spec/lib/karafka/pro/base_consumer_spec.rb
@@ -155,7 +155,10 @@ RSpec.describe Karafka::BaseConsumer, type: :pro do
 
       it 'expect to pause based on the message offset' do
         consume_with_after.call
-        expect(client).to have_received(:pause).with(topic.name, first_message.partition, offset)
+
+        expect(client)
+          .to have_received(:pause)
+          .with(topic.name, first_message.partition, offset, 500)
       end
 
       it 'expect to pause with time tracker' do
@@ -218,7 +221,10 @@ RSpec.describe Karafka::BaseConsumer, type: :pro do
 
       it 'expect to pause based on the message offset' do
         consume_with_after.call
-        expect(client).to have_received(:pause).with(topic.name, first_message.partition, offset)
+
+        expect(client)
+          .to have_received(:pause)
+          .with(topic.name, first_message.partition, offset, 500)
       end
 
       it 'expect to pause with time tracker' do
@@ -247,7 +253,10 @@ RSpec.describe Karafka::BaseConsumer, type: :pro do
 
     it 'expect not to pause the partition' do
       consumer.on_before_schedule_consume
-      expect(client).to have_received(:pause).with(topic.name, 0, nil)
+
+      expect(client)
+        .to have_received(:pause)
+        .with(topic.name, 0, nil, 1_000_000_000_000)
     end
   end
 
@@ -324,7 +333,7 @@ RSpec.describe Karafka::BaseConsumer, type: :pro do
 
         expect(client)
           .to have_received(:pause)
-          .with(topic.name, first_message.partition, offset)
+          .with(topic.name, first_message.partition, offset, 500)
       end
 
       it 'expect to pause with time tracker' do
@@ -388,7 +397,7 @@ RSpec.describe Karafka::BaseConsumer, type: :pro do
 
         expect(client)
           .to have_received(:pause)
-          .with(topic.name, first_message.partition, nil)
+          .with(topic.name, first_message.partition, nil, 1_000_000_000_000)
       end
 
       it 'expect to pause with time tracker' do


### PR DESCRIPTION
Since we're going to introduce low-level consumer bypassing flow controls into web UI, this had to be aligned so the listeners can get cohesive pause/resume data.