### PR TITLE
use sane value for long ago

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [Enhancement] Include Swarm node ID in the swarm process tags.
 - [Refactor] Introduce a `bin/integrations_clean_kafka` script to clean Kafka from temporary test-suite topics.
 - [Refactor] Make sure all temporary topics have a `it-` prefix in their name.
+- [Fix] Use more sane value in `Admin#seek_consumer_group` for long ago.
 - [Fix] Prevent multiplexing of 1:1 from routing.
 - [Fix] WaterDrop level aborting transaction may cause seek offset to move (Pro).
 - [Fix] Fix inconsistency in the logs where `Karafka::Server` originating logs would not have server id reference.

--- a/lib/karafka/admin.rb
+++ b/lib/karafka/admin.rb
@@ -10,11 +10,13 @@ module Karafka
   #   Cluster on which operations are performed can be changed via `admin.kafka` config, however
   #   there is no multi-cluster runtime support.
   module Admin
-    # More or less number of seconds of 25 years
-    # Used for time referencing that does not have to be accurate but needs to be big
-    LONG_TIME_AGO = 25 * 365.25 * 24 * 60 * 60
+    # 2010-01-01 00:00:00 - way before Kafka was released so no messages should exist prior to
+    # this date
+    LONG_TIME_AGO = Time.at(1_262_300_400)
 
-    private_constant :LONG_TIME_AGO
+    DAY_IN_SECONDS = 60 * 60 *24
+
+    private_constant :LONG_TIME_AGO, :DAY_IN_SECONDS
 
     class << self
       # Allows us to read messages from the topic
@@ -203,14 +205,14 @@ module Karafka
             # Earliest is not always 0. When compacting/deleting it can be much later, that's why
             # we fetch the oldest possible offset
             when 'earliest'
-              Time.now - LONG_TIME_AGO
+              LONG_TIME_AGO
             # Latest will always be the high-watermark offset and we can get it just by getting
             # a future position
             when 'latest'
-              Time.now + LONG_TIME_AGO
-            # Same as `'latest'`
+              Time.now + DAY_IN_SECONDS
+            # Same as `'earliest'`
             when false
-              Time.now - LONG_TIME_AGO
+              LONG_TIME_AGO
             # Regular offset case
             else
               position

--- a/lib/karafka/admin.rb
+++ b/lib/karafka/admin.rb
@@ -10,11 +10,11 @@ module Karafka
   #   Cluster on which operations are performed can be changed via `admin.kafka` config, however
   #   there is no multi-cluster runtime support.
   module Admin
-    # More or less number of seconds of 1 hundred years
+    # More or less number of seconds of 25 years
     # Used for time referencing that does not have to be accurate but needs to be big
-    HUNDRED_YEARS = 100 * 365.25 * 24 * 60 * 60
+    LONG_TIME_AGO = 25 * 365.25 * 24 * 60 * 60
 
-    private_constant :HUNDRED_YEARS
+    private_constant :LONG_TIME_AGO
 
     class << self
       # Allows us to read messages from the topic
@@ -203,14 +203,14 @@ module Karafka
             # Earliest is not always 0. When compacting/deleting it can be much later, that's why
             # we fetch the oldest possible offset
             when 'earliest'
-              Time.now - HUNDRED_YEARS
+              Time.now - LONG_TIME_AGO
             # Latest will always be the high-watermark offset and we can get it just by getting
             # a future position
             when 'latest'
-              Time.now + HUNDRED_YEARS
+              Time.now + LONG_TIME_AGO
             # Same as `'latest'`
             when false
-              Time.now - HUNDRED_YEARS
+              Time.now - LONG_TIME_AGO
             # Regular offset case
             else
               position

--- a/lib/karafka/admin.rb
+++ b/lib/karafka/admin.rb
@@ -14,7 +14,8 @@ module Karafka
     # this date
     LONG_TIME_AGO = Time.at(1_262_300_400)
 
-    DAY_IN_SECONDS = 60 * 60 *24
+    # one day in seconds for future time reference
+    DAY_IN_SECONDS = 60 * 60 * 24
 
     private_constant :LONG_TIME_AGO, :DAY_IN_SECONDS
 


### PR DESCRIPTION
100 years ago does not work with confluent kafka 7.9.0 so we use a shorter but still long enough value