### PR TITLE
Update BaseConsumer documentation to point to the correct class

### DIFF
--- a/lib/karafka/base_consumer.rb
+++ b/lib/karafka/base_consumer.rb
@@ -21,7 +21,7 @@ module Karafka
 
     # @return [String] id of the current consumer
     attr_reader :id
-    # @return [Karafka::Routing::Topic] topic to which a given consumer is subscribed
+    # @return [Karafka::Messages::Messages] current messages batch
     attr_accessor :messages
     # @return [Karafka::Connection::Client] kafka connection client
     attr_accessor :client


### PR DESCRIPTION
#1374 [removed](https://github.com/karafka/karafka/pull/1374/files#diff-f2298aa0c0eee8d69c0c9e9919ee5fd97e5bc5f343d13d41e51739a6141c60cdR16-R17) the wrong docs from the `messages` field.