### PR TITLE
align config topics naming convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka Framework Changelog
 
 ## 2.4.18 (Unreleased)
+- **[Breaking]** Rename scheduled jobs topics names in their config (Pro).
 - **[Feature]** Parallel Segments for concurrent processing of the same partition with more than partition count of processes (Pro).
 - [Enhancement] Make the error tracker for advanced DLQ strategies respond to `#topic` and `#partition` for context aware dispatches.
 - [Enhancement] Allow setting the workers thread priority and set it to -1 (50ms) by default.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     karafka (2.4.18)
       base64 (~> 0.2)
-      karafka-core (>= 2.4.9, < 2.5.0)
+      karafka-core (>= 2.4.11, < 2.5.0)
       karafka-rdkafka (>= 0.19.0)
       waterdrop (>= 2.7.3, < 3.0.0)
       zeitwerk (~> 2.3)
@@ -59,7 +59,7 @@ GEM
       activesupport (>= 6.1)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    karafka-core (2.4.10)
+    karafka-core (2.4.11)
       karafka-rdkafka (>= 0.17.6, < 0.20.0)
       logger (>= 1.6.0)
     karafka-rdkafka (0.19.0)

--- a/config/locales/pro_errors.yml
+++ b/config/locales/pro_errors.yml
@@ -122,8 +122,8 @@ en:
 
       recurring_tasks.consumer_class_format: 'needs to inherit from Karafka::BaseConsumer'
       recurring_tasks.group_id_format: 'needs to be a string with a Kafka accepted format'
-      recurring_tasks.topics.schedules_format: 'needs to be a string with a Kafka accepted format'
-      recurring_tasks.topics.logs_format: 'needs to be a string with a Kafka accepted format'
+      recurring_tasks.topics.schedules.name_format: 'needs to be a string with a Kafka accepted format'
+      recurring_tasks.topics.logs.name_format: 'needs to be a string with a Kafka accepted format'
       recurring_tasks.interval_format: 'needs to be equal or more than 1000 and an integer'
       recurring_tasks.deserializer_format: 'needs to be configured'
       recurring_tasks.logging_format: needs to be a boolean

--- a/karafka.gemspec
+++ b/karafka.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   DESC
 
   spec.add_dependency 'base64', '~> 0.2'
-  spec.add_dependency 'karafka-core', '>= 2.4.9', '< 2.5.0'
+  spec.add_dependency 'karafka-core', '>= 2.4.11', '< 2.5.0'
   spec.add_dependency 'karafka-rdkafka', '>= 0.19.0'
   spec.add_dependency 'waterdrop', '>= 2.7.3', '< 3.0.0'
   spec.add_dependency 'zeitwerk', '~> 2.3'

--- a/lib/karafka/pro/recurring_tasks/contracts/config.rb
+++ b/lib/karafka/pro/recurring_tasks/contracts/config.rb
@@ -29,12 +29,16 @@ module Karafka
             end
 
             nested(:topics) do
-              required(:schedules) do |val|
-                val.is_a?(String) && Karafka::Contracts::TOPIC_REGEXP.match?(val)
+              nested(:schedules) do
+                required(:name) do |val|
+                  val.is_a?(String) && Karafka::Contracts::TOPIC_REGEXP.match?(val)
+                end
               end
 
-              required(:logs) do |val|
-                val.is_a?(String) && Karafka::Contracts::TOPIC_REGEXP.match?(val)
+              nested(:logs) do
+                required(:name) do |val|
+                  val.is_a?(String) && Karafka::Contracts::TOPIC_REGEXP.match?(val)
+                end
               end
             end
           end

--- a/lib/karafka/pro/recurring_tasks/dispatcher.rb
+++ b/lib/karafka/pro/recurring_tasks/dispatcher.rb
@@ -12,7 +12,7 @@ module Karafka
           # Snapshots to Kafka current schedule state
           def schedule
             produce(
-              topics.schedules,
+              topics.schedules.name,
               'state:schedule',
               serializer.schedule(::Karafka::Pro::RecurringTasks.schedule)
             )
@@ -25,7 +25,7 @@ module Karafka
           #   because in the web ui we work with the full name and it is easier. Since
           def command(name, task_id)
             produce(
-              topics.schedules,
+              topics.schedules.name,
               "command:#{name}:#{task_id}",
               serializer.command(name, task_id)
             )
@@ -35,7 +35,7 @@ module Karafka
           # @param event [Karafka::Core::Monitoring::Event]
           def log(event)
             produce(
-              topics.logs,
+              topics.logs.name,
               event[:task].id,
               serializer.log(event)
             )

--- a/lib/karafka/pro/recurring_tasks/setup/config.rb
+++ b/lib/karafka/pro/recurring_tasks/setup/config.rb
@@ -32,8 +32,13 @@ module Karafka
           )
 
           setting(:topics) do
-            setting(:schedules, default: 'karafka_recurring_tasks_schedules')
-            setting(:logs, default: 'karafka_recurring_tasks_logs')
+            setting(:schedules) do
+              setting(:name, default: 'karafka_recurring_tasks_schedules')
+            end
+
+            setting(:logs) do
+              setting(:name, default: 'karafka_recurring_tasks_logs')
+            end
           end
 
           configure

--- a/lib/karafka/pro/routing/features/recurring_tasks/builder.rb
+++ b/lib/karafka/pro/routing/features/recurring_tasks/builder.rb
@@ -29,7 +29,7 @@ module Karafka
               consumer_group tasks_cfg.group_id do
                 # Registers the primary topic that we use to control schedules execution. This is
                 # the one that we use to trigger recurring tasks.
-                schedules_topic = topic(topics_cfg.schedules) do
+                schedules_topic = topic(topics_cfg.schedules.name) do
                   consumer tasks_cfg.consumer_class
                   deserializer tasks_cfg.deserializer
                   # Because the topic method name as well as builder proxy method name is the same
@@ -83,7 +83,7 @@ module Karafka
 
                 # This topic is to store logs that we can then inspect either from the admin or via
                 # the Web UI
-                logs_topic = topic(topics_cfg.logs) do
+                logs_topic = topic(topics_cfg.logs.name) do
                   active(false)
                   deserializer tasks_cfg.deserializer
                   target.recurring_tasks(true)

--- a/spec/integrations/pro/recurring_tasks/logging_data_published_on_errors_spec.rb
+++ b/spec/integrations/pro/recurring_tasks/logging_data_published_on_errors_spec.rb
@@ -21,7 +21,7 @@ draw_routes do
     max_wait_time 500
   end
 
-  topic Karafka::App.config.recurring_tasks.topics.logs do
+  topic Karafka::App.config.recurring_tasks.topics.logs.name do
     consumer CountConsumer
     deserializer Karafka::App.config.recurring_tasks.deserializer
   end

--- a/spec/integrations/pro/recurring_tasks/logging_data_published_spec.rb
+++ b/spec/integrations/pro/recurring_tasks/logging_data_published_spec.rb
@@ -21,7 +21,7 @@ draw_routes do
     max_wait_time 500
   end
 
-  topic Karafka::App.config.recurring_tasks.topics.logs do
+  topic Karafka::App.config.recurring_tasks.topics.logs.name do
     consumer CountConsumer
     deserializer Karafka::App.config.recurring_tasks.deserializer
   end

--- a/spec/integrations/pro/recurring_tasks/routes_creation_spec.rb
+++ b/spec/integrations/pro/recurring_tasks/routes_creation_spec.rb
@@ -13,7 +13,7 @@ end
 
 # Should not fail as the topic should exist
 schedules = Karafka::Admin.read_topic(
-  Karafka::App.config.recurring_tasks.topics.schedules,
+  Karafka::App.config.recurring_tasks.topics.schedules.name,
   0,
   1
 )
@@ -22,7 +22,7 @@ assert_equal schedules, []
 
 # Should not fail as the topic should exist
 logs = Karafka::Admin.read_topic(
-  Karafka::App.config.recurring_tasks.topics.logs,
+  Karafka::App.config.recurring_tasks.topics.logs.name,
   0,
   1
 )

--- a/spec/integrations/pro/recurring_tasks/state_publishing_frequency_spec.rb
+++ b/spec/integrations/pro/recurring_tasks/state_publishing_frequency_spec.rb
@@ -35,7 +35,7 @@ end
 previous = nil
 
 keys = Karafka::Admin
-       .read_topic(Karafka::App.config.recurring_tasks.topics.schedules, 0, 21)
+       .read_topic(Karafka::App.config.recurring_tasks.topics.schedules.name, 0, 21)
        .map(&:key)
 
 assert keys.count('state:schedule') >= 10

--- a/spec/integrations/pro/recurring_tasks/state_structure_spec.rb
+++ b/spec/integrations/pro/recurring_tasks/state_structure_spec.rb
@@ -31,7 +31,7 @@ start_karafka_and_wait_until do
   DT.key?(:done)
 end
 
-topic_name = Karafka::App.config.recurring_tasks.topics.schedules
+topic_name = Karafka::App.config.recurring_tasks.topics.schedules.name
 state_message = Karafka::Admin.read_topic(topic_name, 0, 1).last
 payload = state_message.payload
 

--- a/spec/integrations_helper.rb
+++ b/spec/integrations_helper.rb
@@ -73,8 +73,8 @@ def setup_karafka(
     if Karafka.pro?
       # Do not redefine topics locations if re-configured
       unless @setup_karafka_first_run
-        config.recurring_tasks.topics.schedules = "it-#{SecureRandom.uuid}"
-        config.recurring_tasks.topics.logs = "it-#{SecureRandom.uuid}"
+        config.recurring_tasks.topics.schedules.name = "it-#{SecureRandom.uuid}"
+        config.recurring_tasks.topics.logs.name = "it-#{SecureRandom.uuid}"
         # Run often so we do not wait on the first run
         config.recurring_tasks.interval = 1_000
 

--- a/spec/lib/karafka/pro/recurring_tasks/contracts/config_spec.rb
+++ b/spec/lib/karafka/pro/recurring_tasks/contracts/config_spec.rb
@@ -15,8 +15,12 @@ RSpec.describe_current do
         logging: true,
         interval: 5_000,
         topics: {
-          schedules: 'valid_schedule_topic',
-          logs: 'valid_log_topic'
+          schedules: {
+            name: 'valid_schedule_topic'
+          },
+          logs: {
+            name: 'valid_log_topic'
+          }
         }
       }
     }
@@ -66,13 +70,13 @@ RSpec.describe_current do
   end
 
   context 'when schedules topic does not match the required format' do
-    before { recurring_tasks[:topics][:schedules] = 'invalid schedule topic' }
+    before { recurring_tasks[:topics][:schedules][:name] = 'invalid schedule topic' }
 
     it { expect(contract.call(config)).not_to be_success }
   end
 
   context 'when logs topic does not match the required format' do
-    before { recurring_tasks[:topics][:logs] = 'invalid log topic' }
+    before { recurring_tasks[:topics][:logs][:name] = 'invalid log topic' }
 
     it { expect(contract.call(config)).not_to be_success }
   end


### PR DESCRIPTION
Because we're namespacing topics in web ui (topic.name) I wanted to align it first in karafka as well.

I guess this will force us to do 2.5 release but I don't see it as a problem because of the scope of stuff released (a lot)