### PR TITLE
rename original_ to source_ in dlq and piping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Karafka Framework Changelog
 
 ## 2.4.18 (Unreleased)
+- **[Breaking]** Use DLQ and Piping prefix `source_` instead of `original_` to align with naming convention of Kafka Streams and Apache Flink for future usage.
 - **[Breaking]** Rename scheduled jobs topics names in their config (Pro).
 - **[Feature]** Parallel Segments for concurrent processing of the same partition with more than partition count of processes (Pro).
 - [Enhancement] Make the error tracker for advanced DLQ strategies respond to `#topic` and `#partition` for context aware dispatches.

--- a/lib/karafka/pro/processing/piping/consumer.rb
+++ b/lib/karafka/pro/processing/piping/consumer.rb
@@ -20,16 +20,16 @@ module Karafka
 
           # Pipes given message to the provided topic with expected details. Useful for
           # pass-through operations where deserialization is not needed. Upon usage it will include
-          # all the original headers + meta headers about the source of message.
+          # all the source headers + meta headers about the source of message.
           #
           # @param topic [String, Symbol] where we want to send the message
-          # @param message [Karafka::Messages::Message] original message to pipe
+          # @param message [Karafka::Messages::Message] source message to pipe
           #
           # @note It will NOT deserialize the payload so it is fast
           #
           # @note We assume that there can be different number of partitions in the target topic,
-          #   this is why we use `key` based on the original topic key and not the partition id.
-          #   This will not utilize partitions beyond the number of partitions of original topic,
+          #   this is why we use `key` based on the source topic key and not the partition id.
+          #   This will not utilize partitions beyond the number of partitions of source topic,
           #   but will accommodate for topics with less partitions.
           def pipe_async(topic:, message:)
             produce_async(
@@ -40,7 +40,7 @@ module Karafka
           # Sync version of pipe for one message
           #
           # @param topic [String, Symbol] where we want to send the message
-          # @param message [Karafka::Messages::Message] original message to pipe
+          # @param message [Karafka::Messages::Message] source message to pipe
           # @see [#pipe_async]
           def pipe_sync(topic:, message:)
             produce_sync(
@@ -51,7 +51,7 @@ module Karafka
           # Async multi-message pipe
           #
           # @param topic [String, Symbol] where we want to send the message
-          # @param messages [Array<Karafka::Messages::Message>] original messages to pipe
+          # @param messages [Array<Karafka::Messages::Message>] source messages to pipe
           #
           # @note If transactional producer in use and dispatch is not wrapped with a transaction,
           #   it will automatically wrap the dispatch with a transaction
@@ -66,7 +66,7 @@ module Karafka
           # Sync multi-message pipe
           #
           # @param topic [String, Symbol] where we want to send the message
-          # @param messages [Array<Karafka::Messages::Message>] original messages to pipe
+          # @param messages [Array<Karafka::Messages::Message>] source messages to pipe
           #
           # @note If transactional producer in use and dispatch is not wrapped with a transaction,
           #   it will automatically wrap the dispatch with a transaction
@@ -81,7 +81,7 @@ module Karafka
           private
 
           # @param topic [String, Symbol] where we want to send the message
-          # @param message [Karafka::Messages::Message] original message to pipe
+          # @param message [Karafka::Messages::Message] source message to pipe
           # @return [Hash] hash with message to pipe.
           #
           # @note If you need to alter this, please define the `#enhance_pipe_message` method
@@ -90,17 +90,17 @@ module Karafka
               topic: topic,
               payload: message.raw_payload,
               headers: message.raw_headers.merge(
-                'original_topic' => message.topic,
-                'original_partition' => message.partition.to_s,
-                'original_offset' => message.offset.to_s,
-                'original_consumer_group' => self.topic.consumer_group.id
+                'source_topic' => message.topic,
+                'source_partition' => message.partition.to_s,
+                'source_offset' => message.offset.to_s,
+                'source_consumer_group' => self.topic.consumer_group.id
               )
             }
 
             # Use a key only if key was provided
             if message.raw_key
               pipe_message[:key] = message.raw_key
-            # Otherwise pipe creating a key that will assign it based on the original partition
+            # Otherwise pipe creating a key that will assign it based on the source partition
             # number
             else
               pipe_message[:key] = message.partition.to_s

--- a/lib/karafka/pro/processing/strategies/dlq/default.rb
+++ b/lib/karafka/pro/processing/strategies/dlq/default.rb
@@ -145,19 +145,19 @@ module Karafka
             # @param skippable_message [Array<Karafka::Messages::Message>]
             # @return [Hash] dispatch DLQ message
             def build_dlq_message(skippable_message)
-              original_partition = skippable_message.partition.to_s
+              source_partition = skippable_message.partition.to_s
 
               dlq_message = {
                 topic: @_dispatch_to_dlq_topic || topic.dead_letter_queue.topic,
-                key: original_partition,
+                key: source_partition,
                 payload: skippable_message.raw_payload,
                 headers: skippable_message.raw_headers.merge(
-                  'original_topic' => topic.name,
-                  'original_partition' => original_partition,
-                  'original_offset' => skippable_message.offset.to_s,
-                  'original_consumer_group' => topic.consumer_group.id,
-                  'original_key' => skippable_message.raw_key.to_s,
-                  'original_attempts' => attempt.to_s
+                  'source_topic' => topic.name,
+                  'source_partition' => source_partition,
+                  'source_offset' => skippable_message.offset.to_s,
+                  'source_consumer_group' => topic.consumer_group.id,
+                  'source_key' => skippable_message.raw_key.to_s,
+                  'source_attempts' => attempt.to_s
                 )
               }
 

--- a/spec/integrations/pro/consumption/parallel_segments/with_dlq/error_dispatching_flow_spec.rb
+++ b/spec/integrations/pro/consumption/parallel_segments/with_dlq/error_dispatching_flow_spec.rb
@@ -150,12 +150,12 @@ DT[:dlq_received].each do |record|
   # We need to check if we have processing data for this key first
   next unless DT[:key_segment_map].key?(key)
 
-  original_segment_id = DT[:key_segment_map][key]
+  source_segment_id = DT[:key_segment_map][key]
 
   assert_equal(
-    original_segment_id,
+    source_segment_id,
     dlq_segment_id,
-    "Message with key #{key} from #{original_segment_id} was sent to DLQ for #{dlq_segment_id}"
+    "Message with key #{key} from #{source_segment_id} was sent to DLQ for #{dlq_segment_id}"
   )
 end
 
@@ -191,12 +191,12 @@ end
     # Check if we have data for this key
     next unless DT[:key_segment_map].key?(key)
 
-    original_segment = DT[:key_segment_map][key]
+    source_segment = DT[:key_segment_map][key]
 
     assert_equal(
       segment_id,
-      original_segment,
-      "Key #{key} in DLQ topic #{dlq_topic} was originally processed by #{original_segment}"
+      source_segment,
+      "Key #{key} in DLQ topic #{dlq_topic} was originally processed by #{source_segment}"
     )
   end
 end

--- a/spec/integrations/pro/consumption/piping/with_key/transactional_with_marking_spec.rb
+++ b/spec/integrations/pro/consumption/piping/with_key/transactional_with_marking_spec.rb
@@ -65,10 +65,10 @@ end
 DT[:piped].each do |message|
   headers = message.headers
 
-  original_partition = headers['original_partition'].to_i
-  assert SETS[original_partition].include?(message.raw_payload)
-  assert [0, 1].include?(original_partition)
+  source_partition = headers['source_partition'].to_i
+  assert SETS[source_partition].include?(message.raw_payload)
+  assert [0, 1].include?(source_partition)
   assert %w[BBBBBBBBB AAAAAAAAA].include?(message.key)
-  assert_equal headers['original_topic'], DT.topics.first
-  assert_equal headers['original_consumer_group'], DT.consumer_group
+  assert_equal headers['source_topic'], DT.topics.first
+  assert_equal headers['source_consumer_group'], DT.consumer_group
 end

--- a/spec/integrations/pro/consumption/piping/with_key/with_alteration_to_headers_spec.rb
+++ b/spec/integrations/pro/consumption/piping/with_key/with_alteration_to_headers_spec.rb
@@ -63,13 +63,13 @@ end
 DT[:piped].each do |message|
   headers = message.headers
 
-  original_partition = headers['original_partition'].to_i
+  source_partition = headers['source_partition'].to_i
 
-  assert SETS[original_partition].include?(message.raw_payload)
-  assert [0, 1].include?(original_partition)
+  assert SETS[source_partition].include?(message.raw_payload)
+  assert [0, 1].include?(source_partition)
   assert %w[BBBBBBBBB AAAAAAAAA].include?(message.key)
-  assert_equal headers['original_topic'], DT.topics.first
-  assert_equal headers['original_topic'], DT.topics.first
+  assert_equal headers['source_topic'], DT.topics.first
+  assert_equal headers['source_topic'], DT.topics.first
   assert_equal headers['extra_data'], '1'
   assert_equal message.raw_payload, headers['extra_test']
 end

--- a/spec/integrations/pro/consumption/piping/with_key/without_any_changes_spec.rb
+++ b/spec/integrations/pro/consumption/piping/with_key/without_any_changes_spec.rb
@@ -56,11 +56,11 @@ end
 DT[:piped].each do |message|
   headers = message.headers
 
-  original_partition = headers['original_partition'].to_i
+  source_partition = headers['source_partition'].to_i
 
-  assert SETS[original_partition].include?(message.raw_payload)
-  assert [0, 1].include?(original_partition)
+  assert SETS[source_partition].include?(message.raw_payload)
+  assert [0, 1].include?(source_partition)
   assert %w[BBBBBBBBB AAAAAAAAA].include?(message.key)
-  assert_equal headers['original_topic'], DT.topics.first
-  assert_equal headers['original_consumer_group'], DT.consumer_group
+  assert_equal headers['source_topic'], DT.topics.first
+  assert_equal headers['source_consumer_group'], DT.consumer_group
 end

--- a/spec/integrations/pro/consumption/piping/with_key/without_any_changes_transactional_spec.rb
+++ b/spec/integrations/pro/consumption/piping/with_key/without_any_changes_transactional_spec.rb
@@ -62,10 +62,10 @@ end
 DT[:piped].each do |message|
   headers = message.headers
 
-  original_partition = headers['original_partition'].to_i
-  assert SETS[original_partition].include?(message.raw_payload)
-  assert [0, 1].include?(original_partition)
+  source_partition = headers['source_partition'].to_i
+  assert SETS[source_partition].include?(message.raw_payload)
+  assert [0, 1].include?(source_partition)
   assert %w[BBBBBBBBB AAAAAAAAA].include?(message.key)
-  assert_equal headers['original_topic'], DT.topics.first
-  assert_equal headers['original_consumer_group'], DT.consumer_group
+  assert_equal headers['source_topic'], DT.topics.first
+  assert_equal headers['source_consumer_group'], DT.consumer_group
 end

--- a/spec/integrations/pro/consumption/piping/without_key/with_alteration_to_headers_spec.rb
+++ b/spec/integrations/pro/consumption/piping/without_key/with_alteration_to_headers_spec.rb
@@ -63,13 +63,13 @@ end
 DT[:piped].each do |message|
   headers = message.headers
 
-  original_partition = headers['original_partition'].to_i
+  source_partition = headers['source_partition'].to_i
 
-  assert SETS[original_partition].include?(message.raw_payload)
-  assert [0, 1].include?(original_partition)
+  assert SETS[source_partition].include?(message.raw_payload)
+  assert [0, 1].include?(source_partition)
   assert %w[0 1].include?(message.key)
-  assert_equal headers['original_topic'], DT.topics.first
-  assert_equal headers['original_topic'], DT.topics.first
+  assert_equal headers['source_topic'], DT.topics.first
+  assert_equal headers['source_topic'], DT.topics.first
   assert_equal headers['extra_data'], '1'
   assert_equal message.raw_payload, headers['extra_test']
 end

--- a/spec/integrations/pro/consumption/piping/without_key/without_any_changes_spec.rb
+++ b/spec/integrations/pro/consumption/piping/without_key/without_any_changes_spec.rb
@@ -56,11 +56,11 @@ end
 DT[:piped].each do |message|
   headers = message.headers
 
-  original_partition = headers['original_partition'].to_i
+  source_partition = headers['source_partition'].to_i
 
-  assert SETS[original_partition].include?(message.raw_payload)
-  assert [0, 1].include?(original_partition)
+  assert SETS[source_partition].include?(message.raw_payload)
+  assert [0, 1].include?(source_partition)
   assert %w[0 1].include?(message.key)
-  assert_equal headers['original_topic'], DT.topics.first
-  assert_equal headers['original_consumer_group'], DT.consumer_group
+  assert_equal headers['source_topic'], DT.topics.first
+  assert_equal headers['source_consumer_group'], DT.consumer_group
 end

--- a/spec/integrations/pro/consumption/piping/without_key/without_any_changes_transactional_spec.rb
+++ b/spec/integrations/pro/consumption/piping/without_key/without_any_changes_transactional_spec.rb
@@ -62,11 +62,11 @@ end
 DT[:piped].each do |message|
   headers = message.headers
 
-  original_partition = headers['original_partition'].to_i
+  source_partition = headers['source_partition'].to_i
 
-  assert SETS[original_partition].include?(message.raw_payload)
-  assert [0, 1].include?(original_partition)
+  assert SETS[source_partition].include?(message.raw_payload)
+  assert [0, 1].include?(source_partition)
   assert %w[0 1].include?(message.key)
-  assert_equal headers['original_topic'], DT.topics.first
-  assert_equal headers['original_consumer_group'], DT.consumer_group
+  assert_equal headers['source_topic'], DT.topics.first
+  assert_equal headers['source_consumer_group'], DT.consumer_group
 end

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_lrj_mom/with_non_recoverable_job_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_lrj_mom/with_non_recoverable_job_error_spec.rb
@@ -18,7 +18,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original_offset'].to_i
+      DT[1] << message.headers['source_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_lrj_mom/with_recoverable_slow_jobs_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_lrj_mom/with_recoverable_slow_jobs_error_spec.rb
@@ -16,7 +16,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original_offset'].to_i
+      DT[1] << message.headers['source_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_lrj_mom_vp/with_non_recoverable_job_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_lrj_mom_vp/with_non_recoverable_job_error_spec.rb
@@ -20,7 +20,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original_offset'].to_i
+      DT[1] << message.headers['source_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_lrj_mom_vp/with_recoverable_slow_jobs_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_lrj_mom_vp/with_recoverable_slow_jobs_error_spec.rb
@@ -16,7 +16,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original_offset'].to_i
+      DT[1] << message.headers['source_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_mom/with_non_recoverable_job_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_mom/with_non_recoverable_job_error_spec.rb
@@ -15,7 +15,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original_offset'].to_i
+      DT[1] << message.headers['source_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_mom/with_recoverable_jobs_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_mom/with_recoverable_jobs_error_spec.rb
@@ -15,7 +15,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original_offset'].to_i
+      DT[1] << message.headers['source_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_mom_vp/with_non_recoverable_job_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_mom_vp/with_non_recoverable_job_error_spec.rb
@@ -15,7 +15,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original_offset'].to_i
+      DT[1] << message.headers['source_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_mom_vp/with_recoverable_jobs_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_mom_vp/with_recoverable_jobs_error_spec.rb
@@ -15,7 +15,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original_offset'].to_i
+      DT[1] << message.headers['source_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_lrj_mom/with_non_recoverable_slow_jobs_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_lrj_mom/with_non_recoverable_slow_jobs_error_spec.rb
@@ -21,7 +21,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original_offset'].to_i
+      DT[1] << message.headers['source_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_lrj_mom/with_recoverable_slow_jobs_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_lrj_mom/with_recoverable_slow_jobs_error_spec.rb
@@ -16,7 +16,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original_offset'].to_i
+      DT[1] << message.headers['source_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_lrj_mom_vp/with_non_recoverable_job_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_lrj_mom_vp/with_non_recoverable_job_error_spec.rb
@@ -19,7 +19,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original_offset'].to_i
+      DT[1] << message.headers['source_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_lrj_mom_vp/with_recoverable_slow_jobs_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_lrj_mom_vp/with_recoverable_slow_jobs_error_spec.rb
@@ -16,7 +16,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original_offset'].to_i
+      DT[1] << message.headers['source_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_mom/with_non_recoverable_job_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_mom/with_non_recoverable_job_error_spec.rb
@@ -21,7 +21,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original_offset'].to_i
+      DT[1] << message.headers['source_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_mom/with_recoverable_jobs_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_mom/with_recoverable_jobs_error_spec.rb
@@ -14,7 +14,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original_offset'].to_i
+      DT[1] << message.headers['source_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_mom_vp/with_non_recoverable_job_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_mom_vp/with_non_recoverable_job_error_spec.rb
@@ -21,7 +21,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original_offset'].to_i
+      DT[1] << message.headers['source_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_mom_vp/with_recoverable_jobs_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_mom_vp/with_recoverable_jobs_error_spec.rb
@@ -14,7 +14,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original_offset'].to_i
+      DT[1] << message.headers['source_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/default/details_dispatch_transfer_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/details_dispatch_transfer_spec.rb
@@ -50,10 +50,10 @@ end
 
   assert_equal dlq_message.raw_payload, elements[i]
   assert_equal dlq_message.headers["test#{i}"], (i + 1).to_s
-  assert_equal dlq_message.headers.fetch('original_topic'), DT.topic
-  assert_equal dlq_message.headers.fetch('original_partition'), 0.to_s
-  assert_equal dlq_message.headers.fetch('original_offset'), i.to_s
-  assert_equal dlq_message.headers.fetch('original_attempts'), '1'
-  assert_equal dlq_message.headers.fetch('original_consumer_group'), cg
-  assert_equal dlq_message.headers.fetch('original_key'), i.to_s
+  assert_equal dlq_message.headers.fetch('source_topic'), DT.topic
+  assert_equal dlq_message.headers.fetch('source_partition'), 0.to_s
+  assert_equal dlq_message.headers.fetch('source_offset'), i.to_s
+  assert_equal dlq_message.headers.fetch('source_attempts'), '1'
+  assert_equal dlq_message.headers.fetch('source_consumer_group'), cg
+  assert_equal dlq_message.headers.fetch('source_key'), i.to_s
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/default/details_dispatch_transfer_with_enhancement_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/details_dispatch_transfer_with_enhancement_spec.rb
@@ -60,9 +60,9 @@ end
 
   assert_equal dlq_message.raw_payload, expected_payload
   assert_equal dlq_message.headers["test#{i}"], (i + 1).to_s
-  assert_equal dlq_message.headers.fetch('original_topic'), DT.topic
-  assert_equal dlq_message.headers.fetch('original_partition'), 0.to_s
-  assert_equal dlq_message.headers.fetch('original_offset'), i.to_s
-  assert_equal dlq_message.headers.fetch('original_consumer_group'), cg
+  assert_equal dlq_message.headers.fetch('source_topic'), DT.topic
+  assert_equal dlq_message.headers.fetch('source_partition'), 0.to_s
+  assert_equal dlq_message.headers.fetch('source_offset'), i.to_s
+  assert_equal dlq_message.headers.fetch('source_consumer_group'), cg
   assert_equal dlq_message.headers.fetch('total-remap'), 'yes'
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/default/manual_dispatch_to_dlq_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/manual_dispatch_to_dlq_spec.rb
@@ -50,7 +50,7 @@ assert_equal DT[:broken].size, 1, DT.data
 broken = DT[:broken].first
 
 assert_equal elements[0], broken.raw_payload, DT.data
-assert_equal broken.headers['original_topic'], DT.topic
-assert_equal broken.headers['original_partition'], '0'
-assert_equal broken.headers['original_offset'], '0'
-assert_equal broken.headers['original_consumer_group'], Karafka::App.consumer_groups.first.id
+assert_equal broken.headers['source_topic'], DT.topic
+assert_equal broken.headers['source_partition'], '0'
+assert_equal broken.headers['source_offset'], '0'
+assert_equal broken.headers['source_consumer_group'], Karafka::App.consumer_groups.first.id

--- a/spec/integrations/pro/consumption/strategies/dlq/default/multi_partition_source_target_flow_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/multi_partition_source_target_flow_spec.rb
@@ -21,7 +21,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT["broken-#{message.partition}"] << message.headers['original_partition']
+      DT["broken-#{message.partition}"] << message.headers['source_partition']
     end
   end
 end
@@ -55,9 +55,9 @@ samples = {}
 DT.data.each do |k, v|
   next if k == :partitions
 
-  v.each do |original_partition|
-    samples[original_partition] ||= []
-    samples[original_partition] << k
+  v.each do |source_partition|
+    samples[source_partition] ||= []
+    samples[source_partition] << k
   end
 end
 

--- a/spec/integrations/pro/consumption/strategies/dlq/default/multi_topic_one_target_multi_partitions_flow_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/multi_topic_one_target_multi_partitions_flow_spec.rb
@@ -17,7 +17,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[0] << [message.key, message.headers['original_partition']]
+      DT[0] << [message.key, message.headers['source_partition']]
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/default/original_offset_tracking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/original_offset_tracking_spec.rb
@@ -22,7 +22,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[:broken] << message.headers['original_offset']
+      DT[:broken] << message.headers['source_offset']
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/default/raw_headers_dispatch_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/raw_headers_dispatch_spec.rb
@@ -55,10 +55,10 @@ end
 
   assert_equal dlq_message.raw_payload, elements[i]
   assert_equal dlq_message.headers["test#{i}"], (i + 1).to_s
-  assert_equal dlq_message.headers.fetch('original_topic'), DT.topic
-  assert_equal dlq_message.headers.fetch('original_partition'), 0.to_s
-  assert_equal dlq_message.headers.fetch('original_offset'), i.to_s
-  assert_equal dlq_message.headers.fetch('original_attempts'), '1'
-  assert_equal dlq_message.headers.fetch('original_consumer_group'), cg
-  assert_equal dlq_message.headers.fetch('original_key'), i.to_s
+  assert_equal dlq_message.headers.fetch('source_topic'), DT.topic
+  assert_equal dlq_message.headers.fetch('source_partition'), 0.to_s
+  assert_equal dlq_message.headers.fetch('source_offset'), i.to_s
+  assert_equal dlq_message.headers.fetch('source_attempts'), '1'
+  assert_equal dlq_message.headers.fetch('source_consumer_group'), cg
+  assert_equal dlq_message.headers.fetch('source_key'), i.to_s
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj/fast_with_non_recoverable_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj/fast_with_non_recoverable_errors_spec.rb
@@ -25,7 +25,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << [message.headers['original_offset'].to_i, message.offset]
+      DT[1] << [message.headers['source_offset'].to_i, message.offset]
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj/with_non_recoverable_slow_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj/with_non_recoverable_slow_error_spec.rb
@@ -35,7 +35,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original_offset'].to_i
+      DT[1] << message.headers['source_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_mom/with_non_recoverable_slow_no_marking_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_mom/with_non_recoverable_slow_no_marking_error_spec.rb
@@ -34,7 +34,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original_offset'].to_i
+      DT[1] << message.headers['source_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_vp/fast_with_non_recoverable_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_vp/fast_with_non_recoverable_errors_spec.rb
@@ -25,7 +25,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << [message.headers['original_offset'].to_i, message.offset]
+      DT[1] << [message.headers['source_offset'].to_i, message.offset]
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_vp/with_non_recoverable_slow_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_vp/with_non_recoverable_slow_error_spec.rb
@@ -34,7 +34,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original_offset'].to_i
+      DT[1] << message.headers['source_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj/fast_with_non_recoverable_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj/fast_with_non_recoverable_errors_spec.rb
@@ -25,7 +25,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << [message.headers['original_offset'].to_i, message.offset]
+      DT[1] << [message.headers['source_offset'].to_i, message.offset]
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj/with_non_recoverable_slow_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj/with_non_recoverable_slow_error_spec.rb
@@ -35,7 +35,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original_offset'].to_i
+      DT[1] << message.headers['source_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/with_non_recoverable_slow_no_marking_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/with_non_recoverable_slow_no_marking_error_spec.rb
@@ -36,7 +36,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original_offset'].to_i
+      DT[1] << message.headers['source_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj_mom_vp/with_non_recoverable_slow_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj_mom_vp/with_non_recoverable_slow_error_spec.rb
@@ -40,7 +40,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original_offset'].to_i
+      DT[1] << message.headers['source_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj_vp/with_non_recoverable_slow_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj_vp/with_non_recoverable_slow_error_spec.rb
@@ -40,7 +40,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[1] << message.headers['original_offset'].to_i
+      DT[1] << message.headers['source_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/at_most_once_skipping_on_error_poll_one_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/at_most_once_skipping_on_error_poll_one_spec.rb
@@ -25,7 +25,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[:broken] << message.headers['original_offset'].to_i
+      DT[:broken] << message.headers['source_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/at_most_once_skipping_on_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/at_most_once_skipping_on_error_spec.rb
@@ -25,7 +25,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[:broken] << message.headers['original_offset'].to_i
+      DT[:broken] << message.headers['source_offset'].to_i
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/mom_vp/skip_after_collapse_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom_vp/skip_after_collapse_spec.rb
@@ -69,7 +69,7 @@ end
 assert(DT[:flow].none? { |row| row.first == 5 })
 
 # It should be moved to DLQ
-assert_equal 5, DT[:dlq].first.headers['original_offset'].to_i
+assert_equal 5, DT[:dlq].first.headers['source_offset'].to_i
 
 # One message should be moved
 assert_equal 1, DT[:dlq].size

--- a/spec/integrations/pro/consumption/strategies/dlq/vp/skip_after_collapse_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/vp/skip_after_collapse_spec.rb
@@ -68,7 +68,7 @@ end
 assert(DT[:flow].none? { |row| row.first == 5 })
 
 # It should be moved to DLQ
-assert_equal 5, DT[:dlq].first.headers['original_offset'].to_i
+assert_equal 5, DT[:dlq].first.headers['source_offset'].to_i
 
 # One message should be moved
 assert_equal 1, DT[:dlq].size

--- a/spec/integrations/pro/consumption/transactions/dlq/with_transactional_dispatch_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/dlq/with_transactional_dispatch_spec.rb
@@ -24,7 +24,7 @@ end
 class DlqConsumer < Karafka::BaseConsumer
   def consume
     messages.each do |message|
-      DT[:broken] << message.headers['original_offset']
+      DT[:broken] << message.headers['source_offset']
     end
   end
 end


### PR DESCRIPTION
In the Kafka ecosystem, both "source_" and "original_" prefixes are used, but "source_" tends to be slightly more common and aligns better with Kafka's architectural concepts.
When examining various Kafka frameworks, connectors, and tools:

Kafka Connect often uses "source_" in its configuration and metadata to indicate the origin of records (e.g., source_cluster, source_topic)
Kafka Streams and similar processing libraries tend to use "source_" when referring to origin topics in transformations and joins
The term "source" is aligned with Kafka's own terminology where producers are sometimes referred to as "sources" and consumers as "sinks"
Many stream processing frameworks built on Kafka (like Apache Flink) use "source_" in their configurations when interfacing with Kafka

The term "source_" also conveys a sense of data lineage and provenance, which is important in messaging systems. It suggests the idea of where data originated from, which is precisely what you're capturing in those headers.