### PR TITLE
Reorder VP jobs to use LJF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **[Breaking]** Use DLQ and Piping prefix `source_` instead of `original_` to align with naming convention of Kafka Streams and Apache Flink for future usage.
 - **[Breaking]** Rename scheduled jobs topics names in their config (Pro).
 - **[Feature]** Parallel Segments for concurrent processing of the same partition with more than partition count of processes (Pro).
+- [Enhancement] Improve Virtual Partitions partitioner to use LJF algorithm for work assignment (Pro).
 - [Enhancement] Make the error tracker for advanced DLQ strategies respond to `#topic` and `#partition` for context aware dispatches.
 - [Enhancement] Allow setting the workers thread priority and set it to -1 (50ms) by default.
 - [Enhancement] Enhance low-level `client.pause` event with timeout value (if provided).

--- a/lib/karafka/pro/processing/partitioner.rb
+++ b/lib/karafka/pro/processing/partitioner.rb
@@ -66,9 +66,14 @@ module Karafka
               groupings = { 0 => messages }
             end
 
-            groupings.each do |key, messages_group|
-              yield(key, messages_group)
-            end
+            # Will apply the LJF ordering for scheduling. In case of multi-topic or multi-partition
+            # work, this can improve the resources utilization by executing the longest (measured
+            # by number of messages) jobs first.
+            groupings
+              .sort_by { |_key, messages_group| -messages_group.size }
+              .each do |key, messages_group|
+                yield(key, messages_group)
+              end
           else
             # When no virtual partitioner, works as regular one
             yield(0, messages)


### PR DESCRIPTION
If the number of jobs is less than the number of available threads, the scheduling order doesn't matter much, because all jobs will start simultaneously - each job will get its dedicated thread.

However, the LJF (Longest Job First) algorithm starts to provide benefits precisely when you have more jobs than threads. In such cases:

- The longest jobs will start first
- Shorter jobs will run in parallel with longer ones or fill in "gaps" after completed jobs
- The total execution time (makespan) will be smaller than with random allocation

In a typical Karafka data processing scenario, you often have more message groups (jobs) than consumer threads, so LJF will be beneficial. This is especially noticeable in batch processing, where message groups arrive in large quantities.
Implementing LJF as the default strategy therefore makes sense - it doesn't harm in cases with a small number of jobs, and can significantly improve performance with a larger number.