### PR TITLE
replace useless count with size

### DIFF
--- a/lib/karafka/active_job/current_attributes.rb
+++ b/lib/karafka/active_job/current_attributes.rb
@@ -29,7 +29,7 @@ module Karafka
           # Prevent registering same klass multiple times
           next if Dispatcher._cattr_klasses.value?(stringified_klass)
 
-          key = "cattr_#{Dispatcher._cattr_klasses.count}"
+          key = "cattr_#{Dispatcher._cattr_klasses.size}"
 
           Dispatcher._cattr_klasses[key] = stringified_klass
           Consumer._cattr_klasses[key] = stringified_klass

--- a/lib/karafka/admin.rb
+++ b/lib/karafka/admin.rb
@@ -58,7 +58,7 @@ module Karafka
           possible_range = requested_range.select { |offset| available_range.include?(offset) }
 
           start_offset = possible_range.first
-          count = possible_range.count
+          count = possible_range.size
 
           tpl.add_topic_and_partitions_with_offsets(name, partition => start_offset)
           consumer.assign(tpl)

--- a/lib/karafka/connection/messages_buffer.rb
+++ b/lib/karafka/connection/messages_buffer.rb
@@ -45,7 +45,7 @@ module Karafka
         last_polled_at = raw_messages_buffer.last_polled_at
 
         raw_messages_buffer.each do |topic, partition, messages, eof|
-          @size += messages.count
+          @size += messages.size
 
           ktopic = @subscription_group.topics.find(topic)
 

--- a/lib/karafka/contracts/topic.rb
+++ b/lib/karafka/contracts/topic.rb
@@ -70,7 +70,7 @@ module Karafka
         next unless ::Karafka::App.config.strict_topics_namespacing
 
         value = data.fetch(:name)
-        namespacing_chars_count = value.chars.find_all { |c| ['.', '_'].include?(c) }.uniq.count
+        namespacing_chars_count = value.chars.find_all { |c| ['.', '_'].include?(c) }.uniq.size
 
         next if namespacing_chars_count <= 1
 

--- a/lib/karafka/instrumentation/vendors/datadog/metrics_listener.rb
+++ b/lib/karafka/instrumentation/vendors/datadog/metrics_listener.rb
@@ -131,11 +131,11 @@ module Karafka
             tags = consumer_tags(consumer)
             tags.concat(default_tags)
 
-            count('consumer.messages', messages.count, tags: tags)
+            count('consumer.messages', messages.size, tags: tags)
             count('consumer.batches', 1, tags: tags)
             gauge('consumer.offset', metadata.last_offset, tags: tags)
             histogram('consumer.consumed.time_taken', event[:time], tags: tags)
-            histogram('consumer.batch_size', messages.count, tags: tags)
+            histogram('consumer.batch_size', messages.size, tags: tags)
             histogram('consumer.processing_lag', metadata.processing_lag, tags: tags)
             histogram('consumer.consumption_lag', metadata.consumption_lag, tags: tags)
           end

--- a/lib/karafka/messages/builders/batch_metadata.rb
+++ b/lib/karafka/messages/builders/batch_metadata.rb
@@ -18,7 +18,7 @@ module Karafka
           #   picked up for processing.
           def call(messages, topic, partition, scheduled_at)
             Karafka::Messages::BatchMetadata.new(
-              size: messages.count,
+              size: messages.size,
               first_offset: messages.first&.offset || -1001,
               last_offset: messages.last&.offset || -1001,
               deserializers: topic.deserializers,

--- a/lib/karafka/pro/cli/parallel_segments/collapse.rb
+++ b/lib/karafka/pro/cli/parallel_segments/collapse.rb
@@ -22,7 +22,7 @@ module Karafka
           def call
             puts 'Starting parallel segments collapse...'
 
-            segments_count = applicable_groups.count
+            segments_count = applicable_groups.size
 
             if segments_count.zero?
               puts "#{red('No')} consumer groups with parallel segments configuration found"

--- a/lib/karafka/pro/cli/parallel_segments/distribute.rb
+++ b/lib/karafka/pro/cli/parallel_segments/distribute.rb
@@ -29,7 +29,7 @@ module Karafka
           def call
             puts 'Starting parallel segments distribution...'
 
-            segments_count = applicable_groups.count
+            segments_count = applicable_groups.size
 
             if segments_count.zero?
               puts "#{red('No')} consumer groups with parallel segments configuration found"

--- a/lib/karafka/pro/instrumentation/performance_tracker.rb
+++ b/lib/karafka/pro/instrumentation/performance_tracker.rb
@@ -50,7 +50,7 @@ module Karafka
           partition = messages.metadata.partition
 
           samples = @processing_times[topic][partition]
-          samples << event[:time] / messages.count
+          samples << event[:time] / messages.size
 
           return unless samples.size > SAMPLES_COUNT
 

--- a/lib/karafka/pro/iterator/expander.rb
+++ b/lib/karafka/pro/iterator/expander.rb
@@ -80,7 +80,7 @@ module Karafka
             .find { |topic| topic.fetch(:topic_name) == name }
             .tap { |topic| topic || raise(Errors::TopicNotFoundError, name) }
             .fetch(:partitions)
-            .count
+            .size
         end
       end
     end

--- a/spec/integrations/consumption/at_most_once_on_error_spec.rb
+++ b/spec/integrations/consumption/at_most_once_on_error_spec.rb
@@ -22,7 +22,7 @@ draw_routes(Consumer)
 produce_many(DT.topic, DT.uuids(10))
 
 start_karafka_and_wait_until do
-  DT[:offsets].count >= 9
+  DT[:offsets].size >= 9
 end
 
 assert !DT[:offsets].include?(5)

--- a/spec/integrations/consumption/inflight_topic_removal_without_auto_create_spec.rb
+++ b/spec/integrations/consumption/inflight_topic_removal_without_auto_create_spec.rb
@@ -27,7 +27,7 @@ draw_routes(Consumer)
 produce_many(DT.topic, DT.uuids(1))
 
 start_karafka_and_wait_until do
-  DT[:errors].count >= 1
+  DT[:errors].size >= 1
 end
 
 DT[:errors].each do |error|

--- a/spec/integrations/consumption/rate_limited_spec.rb
+++ b/spec/integrations/consumption/rate_limited_spec.rb
@@ -73,4 +73,4 @@ end
 assert (Time.now.to_f - started_at) >= 9
 assert_equal elements, DT[0]
 # We should pause 10 times, once every 5 messages
-assert_equal 10, DT[:pauses].count
+assert_equal 10, DT[:pauses].size

--- a/spec/integrations/consumption/retrying_flow_spec.rb
+++ b/spec/integrations/consumption/retrying_flow_spec.rb
@@ -17,7 +17,7 @@ draw_routes(Consumer)
 produce_many(DT.topic, DT.uuids(10))
 
 start_karafka_and_wait_until do
-  DT[0].count >= 5
+  DT[0].size >= 5
 end
 
 DT[0].each_with_index do |aggro, index|

--- a/spec/integrations/consumption/strategies/default/non_critical_error_pause_no_marking_spec.rb
+++ b/spec/integrations/consumption/strategies/default/non_critical_error_pause_no_marking_spec.rb
@@ -14,7 +14,7 @@ class Consumer < Karafka::BaseConsumer
     end
 
     # We need more messages to check this and sometimes we get one and then more
-    return if messages.count <= 1
+    return if messages.size <= 1
 
     @count ||= 0
     @count += 1

--- a/spec/integrations/consumption/strategies/default/non_critical_error_pause_position_marking_spec.rb
+++ b/spec/integrations/consumption/strategies/default/non_critical_error_pause_position_marking_spec.rb
@@ -15,7 +15,7 @@ class Consumer < Karafka::BaseConsumer
     end
 
     # We need more messages to check this and sometimes we get one and then more
-    return if messages.count <= 1
+    return if messages.size <= 1
 
     @count ||= 0
     @count += 1

--- a/spec/integrations/consumption/strategies/default/non_critical_error_post_error_action_spec.rb
+++ b/spec/integrations/consumption/strategies/default/non_critical_error_post_error_action_spec.rb
@@ -60,4 +60,4 @@ assert_equal DT[:cleans].uniq, DT[:threads].uniq
 assert_equal 1, DT[:cleans].uniq.size
 assert_equal 1, DT[:threads].uniq.size
 # Two subscribers mean twice the cleaning
-assert_equal DT[:cleans].count, DT[:threads].count * 2
+assert_equal DT[:cleans].size, DT[:threads].size * 2

--- a/spec/integrations/consumption/strategies/default/of_many_partitions_with_error_spec.rb
+++ b/spec/integrations/consumption/strategies/default/of_many_partitions_with_error_spec.rb
@@ -52,6 +52,6 @@ end
 # 10 partitions are expected
 assert_equal 10, DT.data.size
 # In 11 messages are expected as insert in one will be retried due to error
-assert_equal 11, DT.data.values.flatten.count
+assert_equal 11, DT.data.values.flatten.size
 # We sent 10, we expect 10
-assert_equal 10, DT.data.values.flatten.uniq.count
+assert_equal 10, DT.data.values.flatten.uniq.size

--- a/spec/integrations/consumption/strategies/default/of_many_partitions_with_many_workers_spec.rb
+++ b/spec/integrations/consumption/strategies/default/of_many_partitions_with_many_workers_spec.rb
@@ -61,4 +61,4 @@ end
 # 10 partitions are expected
 assert_equal 10, DT.data.size
 # In 10 threads due to sleep
-assert_equal 10, DT.data.values.flatten.uniq.count
+assert_equal 10, DT.data.values.flatten.uniq.size

--- a/spec/integrations/consumption/strategies/dlq/multi_partition_source_target_flow_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/multi_partition_source_target_flow_spec.rb
@@ -43,8 +43,8 @@ end
 end
 
 start_karafka_and_wait_until do
-  DT[:partitions].uniq.count >= 2 &&
-    DT[:broken].uniq.count >= 5
+  DT[:partitions].uniq.size >= 2 &&
+    DT[:broken].uniq.size >= 5
 end
 
 # No need for any assertions as if it would pipe only to one, it would hang and crash via timeout

--- a/spec/integrations/consumption/strategies/dlq/multi_partition_target_flow_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/multi_partition_target_flow_spec.rb
@@ -36,7 +36,7 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:broken].uniq.count >= 5
+  DT[:broken].uniq.size >= 5
 end
 
 # No need for any assertions as if it would pipe only to one, it would hang and crash via timeout

--- a/spec/integrations/consumption/strategies/dlq/with_custom_producer_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/with_custom_producer_spec.rb
@@ -59,7 +59,7 @@ Karafka::App.config.producer = WaterDrop::Producer.new do |config|
 end
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count > 1
+  DT[:offsets].uniq.size > 1
 end
 
 assert_equal DT[:offsets], (1..4).to_a

--- a/spec/integrations/consumption/strategies/dlq/with_first_crashing_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/with_first_crashing_spec.rb
@@ -40,7 +40,7 @@ elements = DT.uuids(5)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count > 1
+  DT[:offsets].uniq.size > 1
 end
 
 assert_equal DT[:offsets], (1..4).to_a

--- a/spec/integrations/consumption/strategies/dlq/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/with_non_recoverable_error_with_retries_spec.rb
@@ -46,11 +46,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # first error and two errors on retries prior to moving on
-assert_equal 3, DT[:errors].count
+assert_equal 3, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..99).to_a - [10], DT[:offsets]

--- a/spec/integrations/consumption/strategies/dlq/with_non_recoverable_error_without_retries_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/with_non_recoverable_error_without_retries_spec.rb
@@ -46,11 +46,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # One error should occur, without retrying
-assert_equal 1, DT[:errors].count
+assert_equal 1, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..99).to_a - [10], DT[:offsets]

--- a/spec/integrations/consumption/strategies/dlq/with_non_recoverable_first_message_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/with_non_recoverable_first_message_spec.rb
@@ -46,11 +46,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # first error and two errors on retries prior to moving on
-assert_equal 3, DT[:errors].count
+assert_equal 3, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..99).to_a - [0], DT[:offsets]

--- a/spec/integrations/consumption/strategies/dlq/with_non_recoverable_last_message_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/with_non_recoverable_last_message_spec.rb
@@ -47,16 +47,16 @@ produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
   # Send one more when we reached all
-  if DT[:offsets].uniq.count == 99 && DT[:extra].empty?
+  if DT[:offsets].uniq.size == 99 && DT[:extra].empty?
     DT[:extra] << true
     produce(DT.topic, SecureRandom.hex(6))
   end
 
-  DT[:offsets].uniq.count >= 100 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 100 && DT.key?(:broken)
 end
 
 # first error and two errors on retries prior to moving on
-assert_equal 3, DT[:errors].count
+assert_equal 3, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..100).to_a - [99], DT[:offsets]

--- a/spec/integrations/consumption/strategies/dlq/with_recoverable_error_on_retry_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/with_recoverable_error_on_retry_spec.rb
@@ -49,11 +49,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 100
+  DT[:offsets].uniq.size >= 100
 end
 
 # first error and two errors on retries prior to moving on
-assert_equal 1, DT[:errors].count
+assert_equal 1, DT[:errors].size
 
 # All should be present
 assert_equal (0..99).to_a, DT[:offsets]

--- a/spec/integrations/consumption/strategies/dlq/with_sync_dispatch_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/with_sync_dispatch_spec.rb
@@ -43,7 +43,7 @@ elements = DT.uuids(5)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count > 1
+  DT[:offsets].uniq.size > 1
 end
 
 assert_equal DT[:offsets], (1..4).to_a

--- a/spec/integrations/consumption/strategies/dlq/with_sync_marking_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/with_sync_marking_spec.rb
@@ -43,7 +43,7 @@ elements = DT.uuids(5)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count > 1
+  DT[:offsets].uniq.size > 1
 end
 
 assert_equal DT[:offsets], (1..4).to_a

--- a/spec/integrations/consumption/strategies/dlq/without_any_errors_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/without_any_errors_spec.rb
@@ -43,11 +43,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 100
+  DT[:offsets].uniq.size >= 100
 end
 
 # No errors
-assert_equal 0, DT[:errors].count
+assert_equal 0, DT[:errors].size
 
 # All messages consumed
 assert_equal (0..99).to_a, DT[:offsets]

--- a/spec/integrations/consumption/strategies/dlq/without_intermediate_marking_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/without_intermediate_marking_spec.rb
@@ -54,15 +54,15 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 &&
+  DT[:offsets].uniq.size >= 99 &&
     !DT[:broken].empty? &&
     DT[:broken].last[1] == elements[10] &&
     DT[:broken].size >= 2 &&
-    DT[:errors].count >= 3
+    DT[:errors].size >= 3
 end
 
 # first error, retry and same for more messages from batch previous to failing
-assert DT[:errors].count > 3
+assert DT[:errors].size > 3
 
 # we should not have the message that was failing
 assert_equal (0..99).to_a - [10], DT[:offsets].uniq

--- a/spec/integrations/consumption/strategies/dlq_mom/multi_partition_source_target_flow_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/multi_partition_source_target_flow_spec.rb
@@ -43,8 +43,8 @@ end
 end
 
 start_karafka_and_wait_until do
-  DT[:partitions].uniq.count >= 2 &&
-    DT[:broken].uniq.count >= 5
+  DT[:partitions].uniq.size >= 2 &&
+    DT[:broken].uniq.size >= 5
 end
 
 # No need for any assertions as if it would pipe only to one, it would hang and crash via timeout

--- a/spec/integrations/consumption/strategies/dlq_mom/multi_partition_target_flow_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/multi_partition_target_flow_spec.rb
@@ -36,7 +36,7 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:broken].uniq.count >= 5
+  DT[:broken].uniq.size >= 5
 end
 
 # No need for any assertions as if it would pipe only to one, it would hang and crash via timeout

--- a/spec/integrations/consumption/strategies/dlq_mom/with_first_crashing_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_first_crashing_spec.rb
@@ -39,7 +39,7 @@ elements = DT.uuids(5)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count > 1
+  DT[:offsets].uniq.size > 1
 end
 
 assert_equal DT[:offsets].uniq, [0, 1]

--- a/spec/integrations/consumption/strategies/dlq_mom/with_marking_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_marking_spec.rb
@@ -54,7 +54,7 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99
+  DT[:offsets].uniq.size >= 99
 end
 
 # The skipped one should have never been processed

--- a/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_error_with_retries_spec.rb
@@ -47,11 +47,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # first error and two errors on retries prior to moving on
-assert_equal 3, DT[:errors].count
+assert_equal 3, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..99).to_a - [10], DT[:offsets]

--- a/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_error_without_retries_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_error_without_retries_spec.rb
@@ -47,11 +47,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # One error should occur, without retrying
-assert_equal 1, DT[:errors].count
+assert_equal 1, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..99).to_a - [10], DT[:offsets]

--- a/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_first_message_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_first_message_spec.rb
@@ -47,11 +47,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # first error and two errors on retries prior to moving on
-assert_equal 3, DT[:errors].count
+assert_equal 3, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..99).to_a - [0], DT[:offsets]

--- a/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_last_message_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_last_message_spec.rb
@@ -48,16 +48,16 @@ produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
   # Send one more when we reached all
-  if DT[:offsets].uniq.count == 99 && DT[:extra].empty?
+  if DT[:offsets].uniq.size == 99 && DT[:extra].empty?
     DT[:extra] << true
     produce(DT.topic, SecureRandom.hex(6))
   end
 
-  DT[:offsets].uniq.count >= 100 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 100 && DT.key?(:broken)
 end
 
 # first error and two errors on retries prior to moving on
-assert_equal 3, DT[:errors].count
+assert_equal 3, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..100).to_a - [99], DT[:offsets]

--- a/spec/integrations/consumption/strategies/dlq_mom/with_recoverable_error_on_retry_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_recoverable_error_on_retry_spec.rb
@@ -49,11 +49,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 100
+  DT[:offsets].uniq.size >= 100
 end
 
 # first error and two errors on retries prior to moving on
-assert_equal 1, DT[:errors].count
+assert_equal 1, DT[:errors].size
 
 # All should be present
 assert_equal (0..99).to_a, DT[:offsets]

--- a/spec/integrations/consumption/strategies/dlq_mom/without_any_errors_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/without_any_errors_spec.rb
@@ -43,11 +43,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 100
+  DT[:offsets].uniq.size >= 100
 end
 
 # No errors
-assert_equal 0, DT[:errors].count
+assert_equal 0, DT[:errors].size
 
 # All messages consumed
 assert_equal (0..99).to_a, DT[:offsets]

--- a/spec/integrations/consumption/strategies/dlq_mom/without_intermediate_marking_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/without_intermediate_marking_spec.rb
@@ -48,7 +48,7 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].count >= 20
+  DT[:offsets].size >= 20
 end
 
 # None of the offsets should have been committed

--- a/spec/integrations/consumption/with_mixed_performance_in_subscription_group_spec.rb
+++ b/spec/integrations/consumption/with_mixed_performance_in_subscription_group_spec.rb
@@ -51,7 +51,7 @@ end
 Karafka.producer.produce_many_sync(messages)
 
 start_karafka_and_wait_until do
-  DT[:clients].uniq.count >= 5 && sleep(5)
+  DT[:clients].uniq.size >= 5 && sleep(5)
 end
 
 $stdout = proper_stdout

--- a/spec/integrations/consumption/with_mixed_subscription_groups_spec.rb
+++ b/spec/integrations/consumption/with_mixed_subscription_groups_spec.rb
@@ -34,7 +34,7 @@ end
 Karafka.producer.produce_many_sync(messages)
 
 start_karafka_and_wait_until do
-  DT[:clients].uniq.count >= 5 && sleep(5)
+  DT[:clients].uniq.size >= 5 && sleep(5)
 end
 
 assert_equal 5, DT[:clients].uniq.size

--- a/spec/integrations/consumption/with_non_existing_topics_auto_create_spec.rb
+++ b/spec/integrations/consumption/with_non_existing_topics_auto_create_spec.rb
@@ -31,7 +31,7 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[0].count >= 100 && sleep(5)
+  DT[0].size >= 100 && sleep(5)
 end
 
 assert_equal elements, DT[0]

--- a/spec/integrations/consumption/with_separate_subscription_groups_spec.rb
+++ b/spec/integrations/consumption/with_separate_subscription_groups_spec.rb
@@ -30,7 +30,7 @@ end
 Karafka.producer.produce_many_sync(messages)
 
 start_karafka_and_wait_until do
-  DT[:clients].uniq.count >= 10
+  DT[:clients].uniq.size >= 10
 end
 
 assert_equal 10, DT[:clients].uniq.size

--- a/spec/integrations/instrumentation/consumer_seeking_spec.rb
+++ b/spec/integrations/instrumentation/consumer_seeking_spec.rb
@@ -25,7 +25,7 @@ start_karafka_and_wait_until do
 end
 
 assert_equal DT[:messages].uniq, [0]
-assert DT[:seeks].count >= 4
+assert DT[:seeks].size >= 4
 
 assert DT[:seeks].first[:caller].is_a?(Consumer)
 assert_equal DT[:seeks].first[:topic], DT.topic

--- a/spec/integrations/instrumentation/consumers_runtime_tagging_spec.rb
+++ b/spec/integrations/instrumentation/consumers_runtime_tagging_spec.rb
@@ -43,4 +43,4 @@ start_karafka_and_wait_until do
   DT[:offsets].uniq.size >= 5
 end
 
-assert DT[:offsets].uniq.count > 0
+assert !DT[:offsets].uniq.empty?

--- a/spec/integrations/instrumentation/consumption_event_vs_processing_spec.rb
+++ b/spec/integrations/instrumentation/consumption_event_vs_processing_spec.rb
@@ -9,16 +9,16 @@ class Consumer < Karafka::BaseConsumer
   def consume
     DT[:assignments] = Karafka::App.assignments
 
-    DT[0] << messages.count
+    DT[0] << messages.size
   end
 end
 
 Karafka::App.monitor.subscribe('consumer.consume') do |event|
-  DT[2] << event[:caller].messages.count
+  DT[2] << event[:caller].messages.size
 end
 
 Karafka::App.monitor.subscribe('consumer.consumed') do |event|
-  DT[1] << event[:caller].messages.count
+  DT[1] << event[:caller].messages.size
 end
 
 draw_routes do

--- a/spec/integrations/instrumentation/post_mutation_messages_count_reporting_spec.rb
+++ b/spec/integrations/instrumentation/post_mutation_messages_count_reporting_spec.rb
@@ -13,7 +13,7 @@ class Consumer < Karafka::BaseConsumer
 end
 
 Karafka::App.monitor.subscribe('consumer.consume') do |event|
-  DT[0] << event[:caller].messages.count
+  DT[0] << event[:caller].messages.size
 end
 
 Karafka::App.monitor.subscribe('consumer.consumed') do |event|
@@ -28,7 +28,7 @@ end
 
 start_karafka_and_wait_until do
   produce(DT.topic, rand.to_s)
-  DT[0].count >= 10 && DT[1].count >= 10
+  DT[0].size >= 10 && DT[1].size >= 10
 end
 
 assert_equal DT[0].sum, DT[1].sum

--- a/spec/integrations/instrumentation/vendors/kubernetes/consuming_liveness_parallel_regular_flow_spec.rb
+++ b/spec/integrations/instrumentation/vendors/kubernetes/consuming_liveness_parallel_regular_flow_spec.rb
@@ -51,7 +51,7 @@ draw_routes do
 end
 
 start_karafka_and_wait_until do
-  if DT[0].count >= 20
+  if DT[0].size >= 20
     true
   else
     sleep(0.1)

--- a/spec/integrations/instrumentation/vendors/kubernetes/consuming_liveness_parallel_timeout_flow_spec.rb
+++ b/spec/integrations/instrumentation/vendors/kubernetes/consuming_liveness_parallel_timeout_flow_spec.rb
@@ -58,7 +58,7 @@ produce_many(DT.topics[0], DT.uuids(1))
 produce_many(DT.topics[1], DT.uuids(1))
 
 start_karafka_and_wait_until do
-  DT[:probing].uniq.count >= 2
+  DT[:probing].uniq.size >= 2
 end
 
 assert DT[:probing].include?('204')

--- a/spec/integrations/offset_management/with_marking_older_message_spec.rb
+++ b/spec/integrations/offset_management/with_marking_older_message_spec.rb
@@ -60,4 +60,4 @@ start_karafka_and_wait_until do
   DT[:offsets].size >= 60
 end
 
-assert_equal DT[:offsets].uniq.count, DT[:offsets].count
+assert_equal DT[:offsets].uniq.size, DT[:offsets].size

--- a/spec/integrations/pausing/overwrite_one_pause_with_another_spec.rb
+++ b/spec/integrations/pausing/overwrite_one_pause_with_another_spec.rb
@@ -22,7 +22,7 @@ produce_many(DT.topic, DT.uuids(5))
 started_at = Time.now.to_f
 
 start_karafka_and_wait_until do
-  DT[:tick].count >= 2
+  DT[:tick].size >= 2
 end
 
 # Just a precaution. If the long pause would supersede the short, it would never finish and timeout

--- a/spec/integrations/pausing/using_manual_pause_with_backoff_defaults_spec.rb
+++ b/spec/integrations/pausing/using_manual_pause_with_backoff_defaults_spec.rb
@@ -32,7 +32,7 @@ end
 
 previous = nil
 
-assert_equal 5, DT[:pauses].count
+assert_equal 5, DT[:pauses].size
 
 previous = nil
 

--- a/spec/integrations/pausing/using_manual_pause_with_non_backoff_defaults_spec.rb
+++ b/spec/integrations/pausing/using_manual_pause_with_non_backoff_defaults_spec.rb
@@ -26,7 +26,7 @@ start_karafka_and_wait_until do
   DT[:pauses].size >= 5
 end
 
-assert_equal 5, DT[:pauses].count
+assert_equal 5, DT[:pauses].size
 
 previous = nil
 

--- a/spec/integrations/pausing/with_manual_pause_and_other_partitions_working_spec.rb
+++ b/spec/integrations/pausing/with_manual_pause_and_other_partitions_working_spec.rb
@@ -58,4 +58,4 @@ start_karafka_and_wait_until do
 end
 
 assert_equal [1], DT[:partitions].uniq
-assert DT[:ticks].count > 1
+assert DT[:ticks].size > 1

--- a/spec/integrations/pro/consumption/at_most_once_on_error_spec.rb
+++ b/spec/integrations/pro/consumption/at_most_once_on_error_spec.rb
@@ -25,7 +25,7 @@ draw_routes(Consumer)
 produce_many(DT.topic, DT.uuids(10))
 
 start_karafka_and_wait_until do
-  DT[:offsets].count >= 9
+  DT[:offsets].size >= 9
 end
 
 assert !DT[:offsets].include?(5)

--- a/spec/integrations/pro/consumption/direct_assignments/from_earliest_spec.rb
+++ b/spec/integrations/pro/consumption/direct_assignments/from_earliest_spec.rb
@@ -36,4 +36,4 @@ start_karafka_and_wait_until do
   DT[:partitions].size >= 2
 end
 
-assert_equal 2, DT[:shutdowns].count
+assert_equal 2, DT[:shutdowns].size

--- a/spec/integrations/pro/consumption/multiplexing/with_patterns_spec.rb
+++ b/spec/integrations/pro/consumption/multiplexing/with_patterns_spec.rb
@@ -44,7 +44,7 @@ start_karafka_and_wait_until do
 
   sleep(1)
 
-  DT[:clients].uniq.count >= 5 && DT[:consumers].uniq.count >= 5
+  DT[:clients].uniq.size >= 5 && DT[:consumers].uniq.size >= 5
 end
 
 assert_equal 5, DT[:clients].uniq.size

--- a/spec/integrations/pro/consumption/multiplexing/with_same_topic_in_multiple_subscription_groups_spec.rb
+++ b/spec/integrations/pro/consumption/multiplexing/with_same_topic_in_multiple_subscription_groups_spec.rb
@@ -35,7 +35,7 @@ start_karafka_and_wait_until do
 
   sleep(1)
 
-  DT[:clients].uniq.count >= 5 && DT[:consumers].uniq.count >= 5
+  DT[:clients].uniq.size >= 5 && DT[:consumers].uniq.size >= 5
 end
 
 assert_equal 5, DT[:clients].uniq.size

--- a/spec/integrations/pro/consumption/parallel_segments/with_dynamic_partitioner_spec.rb
+++ b/spec/integrations/pro/consumption/parallel_segments/with_dynamic_partitioner_spec.rb
@@ -212,4 +212,4 @@ end
 payload_based_pattern.compact!
 
 # There should be evidence that distribution changed
-assert key_based_pattern.count > 0, 'No key-based distribution detected'
+assert !key_based_pattern.empty?, 'No key-based distribution detected'

--- a/spec/integrations/pro/consumption/parallel_segments/with_transactions/with_aborted_transaction_spec.rb
+++ b/spec/integrations/pro/consumption/parallel_segments/with_transactions/with_aborted_transaction_spec.rb
@@ -70,7 +70,7 @@ class Consumer < Karafka::BaseConsumer
 
         # Track successful processing
         DT[:normal_processed] << {
-          count: messages.count,
+          count: messages.size,
           segment_id: segment_id
         }
       end

--- a/spec/integrations/pro/consumption/parallel_segments/with_virtual_partitions/nested_partitioning_spec.rb
+++ b/spec/integrations/pro/consumption/parallel_segments/with_virtual_partitions/nested_partitioning_spec.rb
@@ -20,7 +20,7 @@ class Consumer < Karafka::BaseConsumer
       batch_id: batch_id,
       thread_id: processing_thread,
       time: Time.now.to_f,
-      messages: messages.count,
+      messages: messages.size,
       vp_keys: messages.map { |m| extract_vp_key(m) }.uniq
     }
 

--- a/spec/integrations/pro/consumption/periodic_jobs/filtering/on_constant_idle_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/filtering/on_constant_idle_spec.rb
@@ -63,7 +63,7 @@ end
 start_karafka_and_wait_until do
   produce_many(DT.topic, DT.uuids(1))
 
-  DT[:seeks].count >= 50
+  DT[:seeks].size >= 50
 end
 
 assert DT[:ticks].size <= 5

--- a/spec/integrations/pro/consumption/periodic_jobs/filtering/on_idle_and_nothing_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/filtering/on_idle_and_nothing_spec.rb
@@ -64,5 +64,5 @@ start_karafka_and_wait_until do
   produce_many(DT.topic, DT.uuids(1)) unless DT.key?(:done)
 
   # This will hang if something is not working, so no assertions needed
-  DT[:ticks].count >= 2
+  DT[:ticks].size >= 2
 end

--- a/spec/integrations/pro/consumption/periodic_jobs/long_running_jobs/no_parallel_ticking_when_not_during_pause_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/long_running_jobs/no_parallel_ticking_when_not_during_pause_spec.rb
@@ -31,7 +31,7 @@ draw_routes do
 end
 
 start_karafka_and_wait_until do
-  DT[:ticks].count >= 5
+  DT[:ticks].size >= 5
 end
 
 # There should be at least one tick parallel to consumption

--- a/spec/integrations/pro/consumption/periodic_jobs/long_running_jobs/parallel_ticking_when_during_pause_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/long_running_jobs/parallel_ticking_when_during_pause_spec.rb
@@ -30,7 +30,7 @@ draw_routes do
 end
 
 start_karafka_and_wait_until do
-  DT[:ticks].count >= 5
+  DT[:ticks].size >= 5
 end
 
 # There should be at least one tick parallel to consumption

--- a/spec/integrations/pro/consumption/periodic_jobs/marking_from_ticking_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/marking_from_ticking_spec.rb
@@ -32,7 +32,7 @@ end
 produce_many(DT.topic, DT.uuids(100))
 
 start_karafka_and_wait_until do
-  DT[:ticks].count >= 2
+  DT[:ticks].size >= 2
 end
 
 assert_equal fetch_next_offset - 1, DT[:marked].last

--- a/spec/integrations/pro/consumption/periodic_jobs/partially_periodic_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/partially_periodic_spec.rb
@@ -31,7 +31,7 @@ draw_routes do
 end
 
 start_karafka_and_wait_until do
-  DT[:ticks].count >= 6
+  DT[:ticks].size >= 6
 end
 
 assert_equal 1, DT[:ticks].uniq.size

--- a/spec/integrations/pro/consumption/periodic_jobs/pause_from_tick_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/pause_from_tick_spec.rb
@@ -29,5 +29,5 @@ draw_routes do
 end
 
 start_karafka_and_wait_until do
-  DT[:ticks].count >= 3
+  DT[:ticks].size >= 3
 end

--- a/spec/integrations/pro/consumption/periodic_jobs/pause_resume_flow_from_tick_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/pause_resume_flow_from_tick_spec.rb
@@ -35,7 +35,7 @@ draw_routes do
 end
 
 start_karafka_and_wait_until do
-  DT[:consume].count >= 3
+  DT[:consume].size >= 3
 end
 
 assert_equal [0, 1, 2], DT[:consume][0..2]

--- a/spec/integrations/pro/consumption/periodic_jobs/resume_from_tick_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/resume_from_tick_spec.rb
@@ -33,7 +33,7 @@ produce_many(DT.topic, DT.uuids(10))
 
 # If resume from ticking will not work, this will hang
 start_karafka_and_wait_until do
-  DT[:consume].count >= 3
+  DT[:consume].size >= 3
 end
 
 assert_equal [0, 1, 2], DT[:consume][0..2]

--- a/spec/integrations/pro/consumption/periodic_jobs/seek_from_tick_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/seek_from_tick_spec.rb
@@ -30,5 +30,5 @@ produce_many(DT.topic, DT.uuids(1))
 
 # If seeking from ticking would not work, this would hang
 start_karafka_and_wait_until do
-  DT[:consume].count >= 5
+  DT[:consume].size >= 5
 end

--- a/spec/integrations/pro/consumption/periodic_jobs/virtual_partitions/with_not_used_virtual_partitions_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/virtual_partitions/with_not_used_virtual_partitions_spec.rb
@@ -31,7 +31,7 @@ draw_routes do
 end
 
 start_karafka_and_wait_until do
-  DT[:ticks].count >= 5
+  DT[:ticks].size >= 5
 end
 
 assert_equal 1, DT[:ticks].uniq.size

--- a/spec/integrations/pro/consumption/periodic_jobs/with_constant_short_poll_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/with_constant_short_poll_spec.rb
@@ -36,7 +36,7 @@ Thread.new do
 end
 
 start_karafka_and_wait_until do
-  DT[1].count >= 5
+  DT[1].size >= 5
 end
 
 previous = nil

--- a/spec/integrations/pro/consumption/periodic_jobs/with_constant_stream_of_messages_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/with_constant_stream_of_messages_spec.rb
@@ -41,5 +41,5 @@ Thread.new do
 end
 
 start_karafka_and_wait_until do
-  DT[:consume].count >= 10
+  DT[:consume].size >= 10
 end

--- a/spec/integrations/pro/consumption/periodic_jobs/with_eof_status_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/with_eof_status_spec.rb
@@ -29,7 +29,7 @@ draw_routes do
 end
 
 start_karafka_and_wait_until do
-  DT[:ticks].count >= 3
+  DT[:ticks].size >= 3
 end
 
 assert_equal DT[:ticks].uniq, [true]

--- a/spec/integrations/pro/consumption/periodic_jobs/with_lost_partition_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/with_lost_partition_spec.rb
@@ -49,7 +49,7 @@ Thread.new do
 end
 
 start_karafka_and_wait_until do
-  DT[:ticks].count >= 10 && DT.key?(:done)
+  DT[:ticks].size >= 10 && DT.key?(:done)
 end
 
 consumer.close

--- a/spec/integrations/pro/consumption/periodic_jobs/with_other_consumer_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/with_other_consumer_spec.rb
@@ -36,7 +36,7 @@ consumer.subscribe(DT.topic)
 end
 
 start_karafka_and_wait_until do
-  DT[:ticks].count >= 10
+  DT[:ticks].size >= 10
 end
 
 consumer.close

--- a/spec/integrations/pro/consumption/periodic_jobs/with_used_switched_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/with_used_switched_spec.rb
@@ -27,7 +27,7 @@ end
 produce_many(DT.topic, DT.uuids(1))
 
 start_karafka_and_wait_until do
-  DT[:used].count >= 5
+  DT[:used].size >= 5
 end
 
 assert DT[:used].uniq.size >= 1

--- a/spec/integrations/pro/consumption/periodic_jobs/without_any_data_ever_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/without_any_data_ever_spec.rb
@@ -30,7 +30,7 @@ draw_routes do
 end
 
 start_karafka_and_wait_until do
-  DT[:used].count >= 5
+  DT[:used].size >= 5
 end
 
 assert_equal DT[:used].uniq, [false]

--- a/spec/integrations/pro/consumption/piping/with_key/transactional_with_marking_spec.rb
+++ b/spec/integrations/pro/consumption/piping/with_key/transactional_with_marking_spec.rb
@@ -59,7 +59,7 @@ SETS = [P1, P2].freeze
 end
 
 start_karafka_and_wait_until do
-  DT[:piped].count >= 100
+  DT[:piped].size >= 100
 end
 
 DT[:piped].each do |message|

--- a/spec/integrations/pro/consumption/piping/with_key/with_alteration_to_headers_spec.rb
+++ b/spec/integrations/pro/consumption/piping/with_key/with_alteration_to_headers_spec.rb
@@ -57,7 +57,7 @@ SETS = [P1, P2].freeze
 end
 
 start_karafka_and_wait_until do
-  DT[:piped].count >= 100
+  DT[:piped].size >= 100
 end
 
 DT[:piped].each do |message|

--- a/spec/integrations/pro/consumption/piping/with_key/without_any_changes_spec.rb
+++ b/spec/integrations/pro/consumption/piping/with_key/without_any_changes_spec.rb
@@ -50,7 +50,7 @@ SETS = [P1, P2].freeze
 end
 
 start_karafka_and_wait_until do
-  DT[:piped].count >= 100
+  DT[:piped].size >= 100
 end
 
 DT[:piped].each do |message|

--- a/spec/integrations/pro/consumption/piping/with_key/without_any_changes_transactional_spec.rb
+++ b/spec/integrations/pro/consumption/piping/with_key/without_any_changes_transactional_spec.rb
@@ -56,7 +56,7 @@ SETS = [P1, P2].freeze
 end
 
 start_karafka_and_wait_until do
-  DT[:piped].count >= 100
+  DT[:piped].size >= 100
 end
 
 DT[:piped].each do |message|

--- a/spec/integrations/pro/consumption/piping/without_key/with_alteration_to_headers_spec.rb
+++ b/spec/integrations/pro/consumption/piping/without_key/with_alteration_to_headers_spec.rb
@@ -57,7 +57,7 @@ SETS = [P1, P2].freeze
 end
 
 start_karafka_and_wait_until do
-  DT[:piped].count >= 100
+  DT[:piped].size >= 100
 end
 
 DT[:piped].each do |message|

--- a/spec/integrations/pro/consumption/piping/without_key/without_any_changes_spec.rb
+++ b/spec/integrations/pro/consumption/piping/without_key/without_any_changes_spec.rb
@@ -50,7 +50,7 @@ SETS = [P1, P2].freeze
 end
 
 start_karafka_and_wait_until do
-  DT[:piped].count >= 100
+  DT[:piped].size >= 100
 end
 
 DT[:piped].each do |message|

--- a/spec/integrations/pro/consumption/piping/without_key/without_any_changes_transactional_spec.rb
+++ b/spec/integrations/pro/consumption/piping/without_key/without_any_changes_transactional_spec.rb
@@ -56,7 +56,7 @@ SETS = [P1, P2].freeze
 end
 
 start_karafka_and_wait_until do
-  DT[:piped].count >= 100
+  DT[:piped].size >= 100
 end
 
 DT[:piped].each do |message|

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_lrj_mom/without_dispatch_to_dlq_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_lrj_mom/without_dispatch_to_dlq_spec.rb
@@ -58,5 +58,5 @@ start_karafka_and_wait_until do
 end
 
 assert DT[0].size >= 10
-assert DT[:errors].count >= 10
+assert DT[:errors].size >= 10
 assert DT[1].empty?

--- a/spec/integrations/pro/consumption/strategies/aj/ftr_lrj_mom_vp/with_recoverable_jobs_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/ftr_lrj_mom_vp/with_recoverable_jobs_error_spec.rb
@@ -42,4 +42,4 @@ start_karafka_and_wait_until do
   DT[:errors].size >= 4
 end
 
-assert DT[:errors].count >= 4
+assert DT[:errors].size >= 4

--- a/spec/integrations/pro/consumption/strategies/aj/ftr_mom/with_recoverable_jobs_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/ftr_mom/with_recoverable_jobs_error_spec.rb
@@ -39,4 +39,4 @@ start_karafka_and_wait_until do
   DT[:errors].size >= 4
 end
 
-assert DT[:errors].count >= 4
+assert DT[:errors].size >= 4

--- a/spec/integrations/pro/consumption/strategies/aj/ftr_mom_vp/with_recoverable_jobs_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/ftr_mom_vp/with_recoverable_jobs_error_spec.rb
@@ -43,4 +43,4 @@ start_karafka_and_wait_until do
   DT[:errors].size >= 4
 end
 
-assert DT[:errors].count >= 4
+assert DT[:errors].size >= 4

--- a/spec/integrations/pro/consumption/strategies/aj/mom_vp/execution_on_failing_saturated_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/mom_vp/execution_on_failing_saturated_spec.rb
@@ -41,4 +41,4 @@ start_karafka_and_wait_until do
   DT[0].size >= 10
 end
 
-assert(DT[0].uniq.count >= 10)
+assert(DT[0].uniq.size >= 10)

--- a/spec/integrations/pro/consumption/strategies/dlq/default/multi_partition_source_target_flow_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/multi_partition_source_target_flow_spec.rb
@@ -45,8 +45,8 @@ end
 end
 
 start_karafka_and_wait_until do
-  DT[:partitions].uniq.count >= 10 &&
-    DT.data.keys.uniq.count >= 5
+  DT[:partitions].uniq.size >= 10 &&
+    DT.data.keys.uniq.size >= 5
 end
 
 samples = {}
@@ -63,5 +63,5 @@ end
 
 # Each original partition data should always go to one and the same target partition
 samples.each_value do |sources|
-  assert_equal 1, sources.uniq.count, sources
+  assert_equal 1, sources.uniq.size, sources
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/default/multi_partition_target_flow_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/multi_partition_target_flow_spec.rb
@@ -38,7 +38,7 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:broken].count >= 20
+  DT[:broken].size >= 20
 end
 
-assert_equal 1, DT[:broken].uniq.count
+assert_equal 1, DT[:broken].uniq.size

--- a/spec/integrations/pro/consumption/strategies/dlq/default/multi_topic_one_target_multi_partitions_flow_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/multi_topic_one_target_multi_partitions_flow_spec.rb
@@ -47,11 +47,11 @@ end
 end
 
 start_karafka_and_wait_until do
-  DT[0].count >= 20
+  DT[0].size >= 20
 end
 
 DT[0].each do |key|
   assert_equal key[0], key[1]
 end
 
-assert DT[0].map(&:first).uniq.count > 1
+assert DT[0].map(&:first).uniq.size > 1

--- a/spec/integrations/pro/consumption/strategies/dlq/default/original_offset_tracking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/original_offset_tracking_spec.rb
@@ -48,7 +48,7 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # The skipped should not be in the processed

--- a/spec/integrations/pro/consumption/strategies/dlq/default/with_non_recoverable_error_with_one_retry_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/with_non_recoverable_error_with_one_retry_spec.rb
@@ -49,11 +49,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # first error and one error on retry prior to moving on
-assert_equal 2, DT[:errors].count
+assert_equal 2, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..99).to_a - [10], DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/dlq/default/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/with_non_recoverable_error_with_retries_spec.rb
@@ -49,11 +49,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # first error and two errors on retries prior to moving on
-assert_equal 3, DT[:errors].count
+assert_equal 3, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..99).to_a - [10], DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/dlq/default/with_non_recoverable_error_without_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/with_non_recoverable_error_without_retries_spec.rb
@@ -49,11 +49,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # One error should occur, without retrying
-assert_equal 1, DT[:errors].count
+assert_equal 1, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..99).to_a - [10], DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/dlq/default/with_non_recoverable_first_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/with_non_recoverable_first_message_spec.rb
@@ -49,11 +49,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # first error and two errors on retries prior to moving on
-assert_equal 3, DT[:errors].count
+assert_equal 3, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..99).to_a - [0], DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/dlq/default/with_non_recoverable_last_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/with_non_recoverable_last_message_spec.rb
@@ -50,16 +50,16 @@ produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
   # Send one more when we reached all
-  if DT[:offsets].uniq.count == 99 && DT[:extra].empty?
+  if DT[:offsets].uniq.size == 99 && DT[:extra].empty?
     DT[:extra] << true
     produce(DT.topic, SecureRandom.hex(6))
   end
 
-  DT[:offsets].uniq.count >= 100 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 100 && DT.key?(:broken)
 end
 
 # first error and two errors on retries prior to moving on
-assert_equal 3, DT[:errors].count
+assert_equal 3, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..100).to_a - [99], DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/dlq/default/with_recoverable_error_on_retry_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/with_recoverable_error_on_retry_spec.rb
@@ -52,11 +52,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 100
+  DT[:offsets].uniq.size >= 100
 end
 
 # first error and two errors on retries prior to moving on
-assert_equal 1, DT[:errors].count
+assert_equal 1, DT[:errors].size
 
 # All should be present
 assert_equal (0..99).to_a, DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/dlq/default/with_sync_dispatch_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/with_sync_dispatch_spec.rb
@@ -46,7 +46,7 @@ elements = DT.uuids(5)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count > 1
+  DT[:offsets].uniq.size > 1
 end
 
 assert_equal DT[:offsets], (1..4).to_a

--- a/spec/integrations/pro/consumption/strategies/dlq/default/with_sync_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/with_sync_marking_spec.rb
@@ -46,7 +46,7 @@ elements = DT.uuids(5)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count > 1
+  DT[:offsets].uniq.size > 1
 end
 
 assert_equal DT[:offsets], (1..4).to_a

--- a/spec/integrations/pro/consumption/strategies/dlq/default/without_any_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/without_any_errors_spec.rb
@@ -46,11 +46,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 100
+  DT[:offsets].uniq.size >= 100
 end
 
 # No errors
-assert_equal 0, DT[:errors].count
+assert_equal 0, DT[:errors].size
 
 # All messages consumed
 assert_equal (0..99).to_a, DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/dlq/default/without_intermediate_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/without_intermediate_marking_spec.rb
@@ -52,14 +52,14 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 98 &&
+  DT[:offsets].uniq.size >= 98 &&
     !DT[:broken].empty? &&
     DT[:broken].any? { |broken| broken.last == elements[10] } &&
     DT[:broken].size >= 2
 end
 
 # first error, retry and same for more messages from batch previous to failing
-assert DT[:errors].count >= 3, DT[:errors]
+assert DT[:errors].size >= 3, DT[:errors]
 
 # we should not have the message that was failing
 assert_equal (0..99).to_a - [10, 99], DT[:offsets].uniq

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr/with_manual_pause_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr/with_manual_pause_spec.rb
@@ -16,7 +16,7 @@ class Consumer < Karafka::BaseConsumer
     messages.each do |message|
       DT[0] << message.offset
 
-      pause(messages.last.offset + 1, 500) if DT[0].count == 5
+      pause(messages.last.offset + 1, 500) if DT[0].size == 5
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr/with_non_recoverable_error_with_one_retry_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr/with_non_recoverable_error_with_one_retry_spec.rb
@@ -53,11 +53,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # first error and one error on retry prior to moving on
-assert_equal 2, DT[:errors].count
+assert_equal 2, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..99).to_a - [10], DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr/with_non_recoverable_error_with_retries_spec.rb
@@ -53,11 +53,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # first error and two errors on retries prior to moving on
-assert_equal 3, DT[:errors].count
+assert_equal 3, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..99).to_a - [10], DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr/with_non_recoverable_error_without_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr/with_non_recoverable_error_without_retries_spec.rb
@@ -53,11 +53,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # One error should occur, without retrying
-assert_equal 1, DT[:errors].count
+assert_equal 1, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..99).to_a - [10], DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr/with_recoverable_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr/with_recoverable_error_spec.rb
@@ -60,4 +60,4 @@ assert_equal(2, DT[0].count { |offset| offset == 7 })
 
 checks = DT[0].dup
 checks.delete_if { |offset| offset == 7 }
-assert_equal [1], checks.group_by(&:itself).values.map(&:count).uniq
+assert_equal [1], checks.group_by(&:itself).values.map(&:size).uniq

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj/with_non_recoverable_error_with_one_retry_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj/with_non_recoverable_error_with_one_retry_spec.rb
@@ -54,11 +54,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # first error and one error on retry prior to moving on
-assert_equal 2, DT[:errors].count
+assert_equal 2, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..99).to_a - [10], DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj/with_non_recoverable_error_with_retries_spec.rb
@@ -54,11 +54,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # first error and two errors on retries prior to moving on
-assert_equal 3, DT[:errors].count
+assert_equal 3, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..99).to_a - [10], DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj/with_non_recoverable_error_without_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj/with_non_recoverable_error_without_retries_spec.rb
@@ -54,11 +54,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # One error should occur, without retrying
-assert_equal 1, DT[:errors].count
+assert_equal 1, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..99).to_a - [10], DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj/with_recoverable_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj/with_recoverable_error_spec.rb
@@ -61,4 +61,4 @@ assert_equal(2, DT[0].count { |offset| offset == 7 })
 
 checks = DT[0].dup
 checks.delete_if { |offset| offset == 7 }
-assert_equal [1], checks.group_by(&:itself).values.map(&:count).uniq
+assert_equal [1], checks.group_by(&:itself).values.map(&:size).uniq

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_mom/with_manual_pause_on_early_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_mom/with_manual_pause_on_early_spec.rb
@@ -14,7 +14,7 @@ end
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    return unless messages.count > 1
+    return unless messages.size > 1
 
     messages.each do |message|
       DT[:offsets] << message.offset

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_vp/with_non_recoverable_error_with_one_retry_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_vp/with_non_recoverable_error_with_one_retry_spec.rb
@@ -55,12 +55,12 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # first error and one error on retry prior to moving on
 # + restarting offsets errors as we move from the last offset and it goes to dlq
-assert DT[:errors].count > 1
+assert DT[:errors].size > 1
 
 # we should not have the message that was failing
 # Order random due to VP

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_vp/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_vp/with_non_recoverable_error_with_retries_spec.rb
@@ -55,12 +55,12 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # first error and one error on retry prior to moving on
 # + restarting offsets errors as we move from the last offset and it goes to dlq
-assert DT[:errors].count > 1
+assert DT[:errors].size > 1
 
 # we should not have the message that was failing
 # Order random due to VP

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/multi_partition_source_target_flow_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/multi_partition_source_target_flow_spec.rb
@@ -48,8 +48,8 @@ end
 end
 
 start_karafka_and_wait_until do
-  DT[:partitions].uniq.count >= 2 &&
-    DT[:broken].uniq.count >= 5
+  DT[:partitions].uniq.size >= 2 &&
+    DT[:broken].uniq.size >= 5
 end
 
 # No need for any assertions as if it would pipe only to one, it would hang and crash via timeout

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/multi_partition_target_flow_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/multi_partition_target_flow_spec.rb
@@ -42,7 +42,7 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:broken].count >= 10
+  DT[:broken].size >= 10
 end
 
-assert_equal 1, DT[:broken].uniq.count
+assert_equal 1, DT[:broken].uniq.size

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_manual_pause_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_manual_pause_spec.rb
@@ -16,7 +16,7 @@ class Consumer < Karafka::BaseConsumer
     messages.each do |message|
       DT[0] << message.offset
 
-      pause(messages.last.offset + 1, 500) if DT[0].count == 5
+      pause(messages.last.offset + 1, 500) if DT[0].size == 5
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_error_and_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_error_and_marking_spec.rb
@@ -30,7 +30,7 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99
+  DT[:offsets].uniq.size >= 99
 end
 
 assert_equal 11, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_error_with_retries_spec.rb
@@ -52,11 +52,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # first error and two errors on retries prior to moving on
-assert_equal 3, DT[:errors].count
+assert_equal 3, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..99).to_a - [10], DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_error_without_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_error_without_retries_spec.rb
@@ -52,11 +52,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # One error should occur, without retrying
-assert_equal 1, DT[:errors].count
+assert_equal 1, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..99).to_a - [10], DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_first_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_first_message_spec.rb
@@ -52,11 +52,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # first error and two errors on retries prior to moving on
-assert_equal 3, DT[:errors].count
+assert_equal 3, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..99).to_a - [0], DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_last_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_last_message_spec.rb
@@ -53,16 +53,16 @@ produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
   # Send one more when we reached all
-  if DT[:offsets].uniq.count == 99 && DT[:extra].empty?
+  if DT[:offsets].uniq.size == 99 && DT[:extra].empty?
     DT[:extra] << true
     produce(DT.topic, SecureRandom.hex(6))
   end
 
-  DT[:offsets].uniq.count >= 100 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 100 && DT.key?(:broken)
 end
 
 # first error and two errors on retries prior to moving on
-assert_equal 3, DT[:errors].count
+assert_equal 3, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..100).to_a - [99], DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_recoverable_error_on_retry_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_recoverable_error_on_retry_spec.rb
@@ -53,11 +53,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 100
+  DT[:offsets].uniq.size >= 100
 end
 
 # first error and two errors on retries prior to moving on
-assert_equal 1, DT[:errors].count
+assert_equal 1, DT[:errors].size
 
 # All should be present
 assert_equal (0..99).to_a, DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/without_any_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/without_any_errors_spec.rb
@@ -48,11 +48,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 100
+  DT[:offsets].uniq.size >= 100
 end
 
 # No errors
-assert_equal 0, DT[:errors].count
+assert_equal 0, DT[:errors].size
 
 # All messages consumed
 assert_equal (0..99).to_a, DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/without_intermediate_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/without_intermediate_marking_spec.rb
@@ -53,7 +53,7 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].count >= 20
+  DT[:offsets].size >= 20
 end
 
 # None of the offsets should have been committed

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom_vp/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom_vp/with_non_recoverable_error_with_retries_spec.rb
@@ -59,7 +59,7 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # we should not have the message that was failing

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_vp/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_vp/with_non_recoverable_error_with_retries_spec.rb
@@ -58,7 +58,7 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # we should not have the message that was failing

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/non_recoverable_moving_forward_batch_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/non_recoverable_moving_forward_batch_marking_spec.rb
@@ -44,7 +44,7 @@ end
 produce_many(DT.topics[0], DT.uuids(50))
 
 start_karafka_and_wait_until do
-  DT[:errors].size >= 2 && DT[0].count >= 46
+  DT[:errors].size >= 2 && DT[0].size >= 46
 end
 
 assert !DT[0].include?(1)

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/non_recoverable_moving_forward_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/non_recoverable_moving_forward_marking_spec.rb
@@ -55,7 +55,7 @@ end
 produce_many(DT.topics[0], DT.uuids(100))
 
 start_karafka_and_wait_until do
-  DT[:errors].size >= 2 && DT[0].count >= 60
+  DT[:errors].size >= 2 && DT[0].size >= 60
 end
 
 # We skip last errored because it will not have continuity

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/non_recoverable_moving_forward_no_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/non_recoverable_moving_forward_no_marking_spec.rb
@@ -47,7 +47,7 @@ end
 produce_many(DT.topics[0], DT.uuids(50))
 
 start_karafka_and_wait_until do
-  DT[:errors].size >= 2 && DT[0].count >= 48
+  DT[:errors].size >= 2 && DT[0].size >= 48
 end
 
 duplicates = DT[:firsts] - [1, 25]

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/non_recoverable_with_dispatch_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/non_recoverable_with_dispatch_marking_spec.rb
@@ -42,7 +42,7 @@ end
 produce_many(DT.topics[0], DT.uuids(50))
 
 start_karafka_and_wait_until do
-  DT[:errors].size >= 2 && DT[0].count >= 46 && DT[0].include?(49)
+  DT[:errors].size >= 2 && DT[0].size >= 46 && DT[0].include?(49)
 end
 
 assert_equal fetch_next_offset, 26, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/with_manual_pause_on_early_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/with_manual_pause_on_early_spec.rb
@@ -14,7 +14,7 @@ end
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    return unless messages.count > 1
+    return unless messages.size > 1
 
     messages.each do |message|
       DT[:offsets] << message.offset

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/with_non_recoverable_slow_no_marking_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/with_non_recoverable_slow_no_marking_error_spec.rb
@@ -17,7 +17,7 @@ end
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    return seek(0) if messages.count < 2
+    return seek(0) if messages.size < 2
 
     @sleep ||= 20
     @sleep -= 5

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj_mom_vp/last_marking_without_intermediate_on_vp_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj_mom_vp/last_marking_without_intermediate_on_vp_spec.rb
@@ -15,9 +15,9 @@ end
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    DT[0] << messages.count
+    DT[0] << messages.size
 
-    return if messages.count < 2
+    return if messages.size < 2
 
     messages.each do |message|
       next unless message.offset == 49

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/at_most_once_skipping_on_error_poll_one_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/at_most_once_skipping_on_error_poll_one_spec.rb
@@ -48,7 +48,7 @@ elements = DT.uuids(20)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[0].count >= 20 && DT[:broken].size >= 10
+  DT[0].size >= 20 && DT[:broken].size >= 10
 end
 
 assert_equal (DT[0] + DT[:broken]).sort.uniq, (0..19).to_a

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/at_most_once_skipping_on_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/at_most_once_skipping_on_error_spec.rb
@@ -48,7 +48,7 @@ elements = DT.uuids(20)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  (DT[0] + DT[:broken]).uniq.count >= 20
+  (DT[0] + DT[:broken]).uniq.size >= 20
 end
 
 assert_equal (DT[0] + DT[:broken]).sort.uniq, (0..19).to_a

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/multi_partition_source_target_flow_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/multi_partition_source_target_flow_spec.rb
@@ -46,8 +46,8 @@ end
 end
 
 start_karafka_and_wait_until do
-  DT[:partitions].uniq.count >= 2 &&
-    DT[:broken].uniq.count >= 5
+  DT[:partitions].uniq.size >= 2 &&
+    DT[:broken].uniq.size >= 5
 end
 
 # No need for any assertions as if it would pipe only to one, it would hang and crash via timeout

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/multi_partition_target_flow_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/multi_partition_target_flow_spec.rb
@@ -40,7 +40,7 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:broken].count >= 10
+  DT[:broken].size >= 10
 end
 
-assert_equal 1, DT[:broken].uniq.count
+assert_equal 1, DT[:broken].uniq.size

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/non_recoverable_with_dispatch_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/non_recoverable_with_dispatch_marking_spec.rb
@@ -40,7 +40,7 @@ end
 produce_many(DT.topics[0], DT.uuids(50))
 
 start_karafka_and_wait_until do
-  DT[:errors].size >= 2 && DT[0].count >= 46
+  DT[:errors].size >= 2 && DT[0].size >= 46
 end
 
 assert_equal fetch_next_offset, 26

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/with_non_recoverable_error_with_retries_spec.rb
@@ -50,11 +50,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # first error and two errors on retries prior to moving on
-assert_equal 3, DT[:errors].count
+assert_equal 3, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..99).to_a - [10], DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/with_non_recoverable_error_without_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/with_non_recoverable_error_without_retries_spec.rb
@@ -50,11 +50,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # One error should occur, without retrying
-assert_equal 1, DT[:errors].count
+assert_equal 1, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..99).to_a - [10], DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/with_non_recoverable_first_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/with_non_recoverable_first_message_spec.rb
@@ -50,11 +50,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # first error and two errors on retries prior to moving on
-assert_equal 3, DT[:errors].count
+assert_equal 3, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..99).to_a - [0], DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/with_non_recoverable_last_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/with_non_recoverable_last_message_spec.rb
@@ -51,16 +51,16 @@ produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
   # Send one more when we reached all
-  if DT[:offsets].uniq.count == 99 && DT[:extra].empty?
+  if DT[:offsets].uniq.size == 99 && DT[:extra].empty?
     DT[:extra] << true
     produce(DT.topic, SecureRandom.hex(6))
   end
 
-  DT[:offsets].uniq.count >= 100 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 100 && DT.key?(:broken)
 end
 
 # first error and two errors on retries prior to moving on
-assert_equal 3, DT[:errors].count
+assert_equal 3, DT[:errors].size
 
 # we should not have the message that was failing
 assert_equal (0..100).to_a - [99], DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/with_recoverable_error_on_retry_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/with_recoverable_error_on_retry_spec.rb
@@ -52,11 +52,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 100
+  DT[:offsets].uniq.size >= 100
 end
 
 # first error and two errors on retries prior to moving on
-assert_equal 1, DT[:errors].count
+assert_equal 1, DT[:errors].size
 
 # All should be present
 assert_equal (0..99).to_a, DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/without_any_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/without_any_errors_spec.rb
@@ -46,11 +46,11 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 100
+  DT[:offsets].uniq.size >= 100
 end
 
 # No errors
-assert_equal 0, DT[:errors].count
+assert_equal 0, DT[:errors].size
 
 # All messages consumed
 assert_equal (0..99).to_a, DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/without_intermediate_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/without_intermediate_marking_spec.rb
@@ -51,7 +51,7 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].count >= 20
+  DT[:offsets].size >= 20
 end
 
 # None of the offsets should have been committed

--- a/spec/integrations/pro/consumption/strategies/dlq/mom_vp/collapse_and_continuity_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom_vp/collapse_and_continuity_spec.rb
@@ -85,7 +85,7 @@ produce_many(DT.topic, (0..9).to_a.map(&:to_s))
 
 start_karafka_and_wait_until do
   # 20 messages + 2 control records
-  DT[:flow].any? { |row| row.first == 19 && row.last == false } && DT[:flow].count >= 22
+  DT[:flow].any? { |row| row.first == 19 && row.last == false } && DT[:flow].size >= 22
 end
 
 pre_collapse_index = DT[:flow].index(&:last) - 1
@@ -106,7 +106,7 @@ pre_collapse_offsets.sort.each do |offset|
 end
 
 # Pre collapse should run in multiple threads
-assert pre_collapse.map { |row| row[1] }.uniq.count >= 2
+assert pre_collapse.map { |row| row[1] }.uniq.size >= 2
 
 # None of pre-collapse should be marked as collapsed
 assert pre_collapse.none?(&:last)
@@ -134,7 +134,7 @@ assert !flipped
 assert_equal nil, flipped_index
 
 # Collapsed should run in a single thread
-assert_equal 1, collapsed.map { |row| row[1] }.uniq.count
+assert_equal 1, collapsed.map { |row| row[1] }.uniq.size
 
 # All collapsed need to be in the pre collapsed because of retry
 assert (collapsed.map(&:first) - pre_collapse_offsets).empty?
@@ -158,7 +158,7 @@ uncollapsed = DT[:flow][(uncollapsed_index + 1)..100]
 assert uncollapsed.none?(&:last)
 
 # Post collapse should run in multiple threads
-assert uncollapsed.map { |row| row[1] }.uniq.count >= 2
+assert uncollapsed.map { |row| row[1] }.uniq.size >= 2
 
 # None of those processed later in parallel should be in the previous sets
 assert (uncollapsed.map(&:first) & collapsed.map(&:first)).empty?

--- a/spec/integrations/pro/consumption/strategies/dlq/mom_vp/skip_after_collapse_many_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom_vp/skip_after_collapse_many_spec.rb
@@ -83,5 +83,5 @@ assert(DT[:flow].none? { |row| row.first <= 9 })
 # A batch dispatched after the recovery should use VP back
 assert DT[:flow2].none?(&:last)
 
-threads = DT[:flow2].map { |row| row[1] }.uniq.count
+threads = DT[:flow2].map { |row| row[1] }.uniq.size
 assert threads >= 2

--- a/spec/integrations/pro/consumption/strategies/dlq/mom_vp/skip_after_collapse_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom_vp/skip_after_collapse_spec.rb
@@ -82,4 +82,4 @@ uncollapsed = DT[:flow][(uncollapsed_index + 1)..100]
 assert uncollapsed.none?(&:last)
 
 # Post collapse should run in multiple threads
-assert uncollapsed.map { |row| row[1] }.uniq.count >= 2
+assert uncollapsed.map { |row| row[1] }.uniq.size >= 2

--- a/spec/integrations/pro/consumption/strategies/dlq/vp/collapse_and_continuity_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/vp/collapse_and_continuity_spec.rb
@@ -84,7 +84,7 @@ produce_many(DT.topic, (0..9).to_a.map(&:to_s))
 
 start_karafka_and_wait_until do
   # 20 messages + 2 control records
-  DT[:flow].any? { |row| row.first == 19 && row.last == false } && DT[:flow].count >= 22
+  DT[:flow].any? { |row| row.first == 19 && row.last == false } && DT[:flow].size >= 22
 end
 
 pre_collapse_index = DT[:flow].index(&:last) - 1
@@ -105,7 +105,7 @@ pre_collapse_offsets.sort.each do |offset|
 end
 
 # Pre collapse should run in multiple threads
-assert pre_collapse.map { |row| row[1] }.uniq.count >= 2
+assert pre_collapse.map { |row| row[1] }.uniq.size >= 2
 
 # None of pre-collapse should be marked as collapsed
 assert pre_collapse.none?(&:last)
@@ -133,7 +133,7 @@ assert !flipped
 assert_equal nil, flipped_index
 
 # Collapsed should run in a single thread
-assert_equal 1, collapsed.map { |row| row[1] }.uniq.count
+assert_equal 1, collapsed.map { |row| row[1] }.uniq.size
 
 # All collapsed need to be in the pre collapsed because of retry
 assert (collapsed.map(&:first) - pre_collapse_offsets).empty?
@@ -157,7 +157,7 @@ uncollapsed = DT[:flow][(uncollapsed_index + 1)..100]
 assert uncollapsed.none?(&:last)
 
 # Post collapse should run in multiple threads
-assert uncollapsed.map { |row| row[1] }.uniq.count >= 2
+assert uncollapsed.map { |row| row[1] }.uniq.size >= 2
 
 # None of those processed later in parallel should be in the previous sets
 assert (uncollapsed.map(&:first) & collapsed.map(&:first)).empty?

--- a/spec/integrations/pro/consumption/strategies/dlq/vp/skip_after_collapse_many_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/vp/skip_after_collapse_many_spec.rb
@@ -82,5 +82,5 @@ assert(DT[:flow].none? { |row| row.first <= 9 })
 # A batch dispatched after the recovery should use VP back
 assert DT[:flow2].none?(&:last)
 
-threads = DT[:flow2].map { |row| row[1] }.uniq.count
+threads = DT[:flow2].map { |row| row[1] }.uniq.size
 assert threads >= 2

--- a/spec/integrations/pro/consumption/strategies/dlq/vp/skip_after_collapse_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/vp/skip_after_collapse_spec.rb
@@ -81,4 +81,4 @@ uncollapsed = DT[:flow][(uncollapsed_index + 1)..100]
 assert uncollapsed.none?(&:last)
 
 # Post collapse should run in multiple threads
-assert uncollapsed.map { |row| row[1] }.uniq.count >= 2
+assert uncollapsed.map { |row| row[1] }.uniq.size >= 2

--- a/spec/integrations/pro/consumption/strategies/ftr/chained_filters_with_post_throttle_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/chained_filters_with_post_throttle_spec.rb
@@ -13,7 +13,7 @@ setup_karafka
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    DT[:counts] << messages.count
+    DT[:counts] << messages.size
     DT[:times] << Time.now
 
     messages.each do |message|
@@ -58,7 +58,7 @@ end
 start_karafka_and_wait_until do
   produce_many(DT.topic, DT.uuids(5))
 
-  DT[:offsets].count > 50
+  DT[:offsets].size > 50
 end
 
 # All offsets that we've processed should be even and in order
@@ -79,4 +79,4 @@ assert average >= 0.17, average
 
 # On average will will get 1,4,1,4,1,4 because of throttling, but since throttling is applied
 # after filtering, we should always be above 2 with the number
-assert (DT[:counts].sum / DT[:counts].count.to_f) > 2
+assert (DT[:counts].sum / DT[:counts].size.to_f) > 2

--- a/spec/integrations/pro/consumption/strategies/ftr/chained_filters_with_pre_throttle_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/chained_filters_with_pre_throttle_spec.rb
@@ -13,7 +13,7 @@ setup_karafka
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    DT[:counts] << messages.count
+    DT[:counts] << messages.size
     DT[:times] << Time.now
 
     messages.each do |message|
@@ -58,7 +58,7 @@ end
 start_karafka_and_wait_until do
   produce_many(DT.topic, DT.uuids(5))
 
-  DT[:offsets].count > 50
+  DT[:offsets].size > 50
 end
 
 # All offsets that we've processed should be even and in order
@@ -80,4 +80,4 @@ assert average >= 0.19, average
 
 # Since we throttle on unfiltered set, we will always limit ourselves with throttle prior to
 # filtering, which will mean, we pass less to consumer
-assert (DT[:counts].sum / DT[:counts].count.to_f) < 3
+assert (DT[:counts].sum / DT[:counts].size.to_f) < 3

--- a/spec/integrations/pro/consumption/strategies/ftr/custom_per_topic_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/custom_per_topic_spec.rb
@@ -88,4 +88,4 @@ start_karafka_and_wait_until do
   sleep(20)
 end
 
-assert DT[1].count > DT[0].count * 2
+assert DT[1].size > DT[0].size * 2

--- a/spec/integrations/pro/consumption/strategies/ftr/custom_to_delay_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/custom_to_delay_spec.rb
@@ -72,5 +72,3 @@ produce_many(DT.topic, elements)
 start_karafka_and_wait_until do
   sleep(15)
 end
-
-p DT[0]

--- a/spec/integrations/pro/consumption/strategies/ftr/dlg/constant_flow_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/dlg/constant_flow_spec.rb
@@ -31,7 +31,7 @@ start_karafka_and_wait_until do
 
   sleep(0.1)
 
-  DT[0].count >= 100
+  DT[0].size >= 100
 end
 
 # All should be delivered and all should be old enough

--- a/spec/integrations/pro/consumption/strategies/ftr/dlg/with_only_old_enough_messages_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/dlg/with_only_old_enough_messages_spec.rb
@@ -44,7 +44,7 @@ produce_many(DT.topic, DT.uuids(50))
 sleep(2)
 
 start_karafka_and_wait_until do
-  DT[0].count >= 50
+  DT[0].size >= 50
 end
 
 assert DT[:unexpected].empty?

--- a/spec/integrations/pro/consumption/strategies/ftr/endless_skip_no_seek_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/endless_skip_no_seek_spec.rb
@@ -61,7 +61,7 @@ end
 start_karafka_and_wait_until do
   produce_many(DT.topic, DT.uuids(1))
 
-  DT[:offsets].count >= 50
+  DT[:offsets].size >= 50
 end
 
 assert DT[0].empty?

--- a/spec/integrations/pro/consumption/strategies/ftr/exg/with_always_fresh_messages_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/exg/with_always_fresh_messages_spec.rb
@@ -26,7 +26,7 @@ end
 start_karafka_and_wait_until do
   produce_many(DT.topic, DT.uuids(1))
 
-  DT[0].count >= 50
+  DT[0].size >= 50
 end
 
 previous = -1

--- a/spec/integrations/pro/consumption/strategies/ftr/exg/with_never_fresh_messages_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/exg/with_never_fresh_messages_spec.rb
@@ -29,7 +29,7 @@ start_karafka_and_wait_until do
   produce_many(DT.topic, DT.uuids(1))
   dispatched << 1
 
-  dispatched.count >= 50
+  dispatched.size >= 50
 end
 
 assert DT[0].empty?

--- a/spec/integrations/pro/consumption/strategies/ftr/exg/with_some_expiring_messages_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/exg/with_some_expiring_messages_spec.rb
@@ -32,7 +32,7 @@ end
 start_karafka_and_wait_until do
   produce_many(DT.topic, DT.uuids(5))
 
-  DT[0].count >= 50
+  DT[0].size >= 50
 end
 
 # None of them should be older than 1 second

--- a/spec/integrations/pro/consumption/strategies/ftr/increasing_lag_on_full_filtering_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/increasing_lag_on_full_filtering_spec.rb
@@ -65,7 +65,7 @@ end
 start_karafka_and_wait_until do
   produce_many(DT.topic, DT.uuids(1))
 
-  DT[:lags].count >= 10
+  DT[:lags].size >= 10
 end
 
 # expect lag to grow because aside from first marking, we no longer mark and just pass

--- a/spec/integrations/pro/consumption/strategies/ftr/not_increasing_lag_on_full_filtering_with_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/not_increasing_lag_on_full_filtering_with_marking_spec.rb
@@ -71,7 +71,7 @@ end
 start_karafka_and_wait_until do
   produce_many(DT.topic, DT.uuids(1))
 
-  DT[:lags].count >= 100
+  DT[:lags].size >= 100
 end
 
 # Expect lag to grow but then go lower when marking happens

--- a/spec/integrations/pro/consumption/strategies/ftr/persistent_post_rebalance_pausing_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/persistent_post_rebalance_pausing_spec.rb
@@ -105,11 +105,11 @@ start_karafka_and_wait_until do
   produce_many(DT.topic, DT.uuids(1))
   sleep(0.5)
 
-  DT[:times].count >= 2
+  DT[:times].size >= 2
 end
 
 other.join
 
-assert_equal 2, DT[:times].count
+assert_equal 2, DT[:times].size
 assert(DT[:times].last - DT[:times].first >= 10)
 assert_equal [0], DT[:firsts].uniq

--- a/spec/integrations/pro/consumption/strategies/ftr/persistent_transactional_offset_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/persistent_transactional_offset_spec.rb
@@ -127,7 +127,7 @@ other = Thread.new do
 end
 
 start_karafka_and_wait_until do
-  DT[:offsets].count >= 20
+  DT[:offsets].size >= 20
 end
 
 other.join

--- a/spec/integrations/pro/consumption/strategies/ftr/static_throttler_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/static_throttler_spec.rb
@@ -62,7 +62,7 @@ thread = Thread.new do
 end
 
 start_karafka_and_wait_until do
-  DT[:offsets].count >= 10 && DT[:revoked].size.positive?
+  DT[:offsets].size >= 10 && DT[:revoked].size.positive?
 end
 
 assert (DT[:times].last - DT[:revoked].first) >= 5

--- a/spec/integrations/pro/consumption/strategies/ftr/vp/from_earliest_throttled_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/vp/from_earliest_throttled_spec.rb
@@ -52,7 +52,7 @@ assert DT.data.size >= 5
 
 # On average we should have similar number of messages
 sizes = DT.data.values.map(&:size)
-average = sizes.sum / sizes.count
+average = sizes.sum / sizes.size
 # Small deviations may be expected
 assert average >= 8
 assert average <= 12

--- a/spec/integrations/pro/consumption/strategies/ftr/vp/throttled_collapse_and_continuity_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/vp/throttled_collapse_and_continuity_spec.rb
@@ -68,7 +68,7 @@ started_at = Time.now.to_f
 
 start_karafka_and_wait_until do
   # 20 messages + 2 control records
-  DT[:flow].any? { |row| row.first == 19 && row.last == false } && DT[:flow].count >= 22
+  DT[:flow].any? { |row| row.first == 19 && row.last == false } && DT[:flow].size >= 22
 end
 
 time_taken = Time.now.to_f - started_at
@@ -94,7 +94,7 @@ pre_collapse_offsets.sort.each do |offset|
 end
 
 # Pre collapse should run in multiple threads
-assert pre_collapse.map { |row| row[1] }.uniq.count >= 2
+assert pre_collapse.map { |row| row[1] }.uniq.size >= 2
 
 # None of pre-collapse should be marked as collapsed
 assert pre_collapse.none?(&:last)
@@ -122,7 +122,7 @@ assert !flipped
 assert_equal nil, flipped_index
 
 # Collapsed should run in a single thread
-assert_equal 1, collapsed.map { |row| row[1] }.uniq.count
+assert_equal 1, collapsed.map { |row| row[1] }.uniq.size
 
 # All collapsed need to be in the pre collapsed because of retry
 assert (collapsed.map(&:first) - pre_collapse_offsets).empty?
@@ -146,7 +146,7 @@ uncollapsed = DT[:flow][(uncollapsed_index + 1)..100]
 assert uncollapsed.none?(&:last)
 
 # Post collapse should run in multiple threads
-assert uncollapsed.map { |row| row[1] }.uniq.count >= 2
+assert uncollapsed.map { |row| row[1] }.uniq.size >= 2
 
 # None of those processed later in parallel should be in the previous sets
 assert (uncollapsed.map(&:first) & collapsed.map(&:first)).empty?

--- a/spec/integrations/pro/consumption/strategies/ftr/with_manual_pause_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/with_manual_pause_spec.rb
@@ -16,7 +16,7 @@ class Consumer < Karafka::BaseConsumer
     messages.each do |message|
       DT[0] << message.offset
 
-      pause(messages.last.offset + 1, 500) if DT[0].count == 5
+      pause(messages.last.offset + 1, 500) if DT[0].size == 5
     end
   end
 end

--- a/spec/integrations/pro/consumption/strategies/ftr/with_recoverable_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/with_recoverable_error_spec.rb
@@ -47,4 +47,4 @@ assert_equal(2, DT[0].count { |offset| offset == 7 })
 
 checks = DT[0].dup
 checks.delete_if { |offset| offset == 7 }
-assert_equal [1], checks.group_by(&:itself).values.map(&:count).uniq
+assert_equal [1], checks.group_by(&:itself).values.map(&:size).uniq

--- a/spec/integrations/pro/consumption/strategies/lrj/default/attempts_tracking_with_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/default/attempts_tracking_with_errors_spec.rb
@@ -16,7 +16,7 @@ class Consumer < Karafka::BaseConsumer
     DT[:attempts] << coordinator.pause_tracker.attempt
     DT[:raises] << true
 
-    return unless (DT[:raises].count % 2).positive?
+    return unless (DT[:raises].size % 2).positive?
 
     raise(StandardError)
   end

--- a/spec/integrations/pro/consumption/strategies/lrj/default/with_long_manual_pause_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/default/with_long_manual_pause_spec.rb
@@ -14,7 +14,7 @@ end
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    return if messages.count < 2
+    return if messages.size < 2
 
     DT[:paused] << messages.first.offset
     DT[:last] << messages.last.offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr/attempts_tracking_with_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr/attempts_tracking_with_errors_spec.rb
@@ -16,7 +16,7 @@ class Consumer < Karafka::BaseConsumer
     DT[:attempts] << coordinator.pause_tracker.attempt
     DT[:raises] << true
 
-    return unless (DT[:raises].count % 2).positive?
+    return unless (DT[:raises].size % 2).positive?
 
     raise(StandardError)
   end

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr/with_long_manual_pause_when_throttled_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr/with_long_manual_pause_when_throttled_spec.rb
@@ -16,7 +16,7 @@ end
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    return if messages.count < 2
+    return if messages.size < 2
 
     DT[:paused] << messages.first.offset
 

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/attempts_tracking_with_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/attempts_tracking_with_errors_spec.rb
@@ -17,7 +17,7 @@ class Consumer < Karafka::BaseConsumer
     DT[:attempts] << coordinator.pause_tracker.attempt
     DT[:raises] << true
 
-    return unless (DT[:raises].count % 2).positive?
+    return unless (DT[:raises].size % 2).positive?
 
     raise(StandardError)
   end

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/with_continuous_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/with_continuous_error_spec.rb
@@ -47,7 +47,5 @@ start_karafka_and_wait_until do
   DT[0].size >= 25 && DT[:errors].size >= 5
 end
 
-p fetch_next_offset
-p DT
 assert DT[0].count(0) > 1
 assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/with_long_manual_pause_when_throttled_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/with_long_manual_pause_when_throttled_spec.rb
@@ -17,7 +17,7 @@ end
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    if messages.count < 2 && @not_first.nil?
+    if messages.size < 2 && @not_first.nil?
       @not_first = true
       return
     end
@@ -43,5 +43,5 @@ start_karafka_and_wait_until do
   DT[:paused].size >= 3
 end
 
-assert_equal 1, DT[:paused].uniq.count
+assert_equal 1, DT[:paused].uniq.size
 assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/with_manual_pause_on_early_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/with_manual_pause_on_early_spec.rb
@@ -14,7 +14,7 @@ end
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    return unless messages.count > 1
+    return unless messages.size > 1
 
     messages.each do |message|
       DT[:offsets] << message.offset

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/attempts_tracking_with_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/attempts_tracking_with_errors_spec.rb
@@ -17,7 +17,7 @@ class Consumer < Karafka::BaseConsumer
     DT[:attempts] << coordinator.pause_tracker.attempt
     DT[:raises] << true
 
-    return unless (DT[:raises].count % 2).positive?
+    return unless (DT[:raises].size % 2).positive?
 
     raise(StandardError)
   end

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/shutdown_order_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/shutdown_order_spec.rb
@@ -14,7 +14,7 @@ end
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    return if messages.count == 1
+    return if messages.size == 1
 
     sleep(15)
 

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/with_long_manual_pause_when_throttled_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/with_long_manual_pause_when_throttled_spec.rb
@@ -17,7 +17,7 @@ end
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    if messages.count < 2 && @not_first.nil?
+    if messages.size < 2 && @not_first.nil?
       @not_first = true
       return
     end

--- a/spec/integrations/pro/consumption/strategies/lrj/mom/with_manual_pause_on_early_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/mom/with_manual_pause_on_early_spec.rb
@@ -14,7 +14,7 @@ end
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    return unless messages.count > 1
+    return unless messages.size > 1
 
     messages.each do |message|
       DT[:offsets] << message.offset

--- a/spec/integrations/pro/consumption/strategies/lrj/vp/with_in_the_middle_revoked_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/vp/with_in_the_middle_revoked_spec.rb
@@ -16,9 +16,9 @@ MUTEX = Mutex.new
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    return if messages.count <= 1
+    return if messages.size <= 1
 
-    DT[0] << messages.count
+    DT[0] << messages.size
 
     sleep(5) while DT[:rebalanced].empty?
 

--- a/spec/integrations/pro/consumption/strategies/mom/ftr_vp/marking_ahead_with_no_previous_in_batch_start_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/mom/ftr_vp/marking_ahead_with_no_previous_in_batch_start_spec.rb
@@ -38,7 +38,7 @@ end
 produce_many(DT.topic, DT.uuids(100))
 
 start_karafka_and_wait_until do
-  DT[:done].count.positive? && sleep(1)
+  DT[:done].size.positive? && sleep(1)
 end
 
 assert_equal 0, fetch_next_offset, nil

--- a/spec/integrations/pro/consumption/strategies/mom/ftr_vp/with_reversed_offsets_marking_and_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/mom/ftr_vp/with_reversed_offsets_marking_and_error_spec.rb
@@ -38,7 +38,7 @@ end
 produce_many(DT.topic, DT.uuids(1000))
 
 start_karafka_and_wait_until do
-  DT[:offsets].count > 500
+  DT[:offsets].size > 500
 end
 
 assert DT[:offsets].count(0) > 1

--- a/spec/integrations/pro/consumption/strategies/mom/vp/marking_ahead_with_no_previous_in_batch_start_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/mom/vp/marking_ahead_with_no_previous_in_batch_start_spec.rb
@@ -36,7 +36,7 @@ end
 produce_many(DT.topic, DT.uuids(100))
 
 start_karafka_and_wait_until do
-  DT[:done].count.positive? && sleep(1)
+  DT[:done].size.positive? && sleep(1)
 end
 
 assert_equal 0, fetch_next_offset, nil

--- a/spec/integrations/pro/consumption/strategies/mom/vp/with_partial_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/mom/vp/with_partial_marking_spec.rb
@@ -12,9 +12,9 @@ end
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    return if messages.count < 5
+    return if messages.size < 5
 
-    mark_as_consumed(messages.to_a[messages.count / 2])
+    mark_as_consumed(messages.to_a[messages.size / 2])
 
     DT[:lasts] << messages.last.offset
     DT[:batch] << true
@@ -34,7 +34,7 @@ end
 produce_many(DT.topic, DT.uuids(1000))
 
 start_karafka_and_wait_until do
-  DT[:batch].count > 5
+  DT[:batch].size > 5
 end
 
 # Since we do middle offset marking, this should never have the last from max batch

--- a/spec/integrations/pro/consumption/strategies/mom/vp/with_reversed_offsets_marking_and_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/mom/vp/with_reversed_offsets_marking_and_error_spec.rb
@@ -37,7 +37,7 @@ end
 produce_many(DT.topic, DT.uuids(1000))
 
 start_karafka_and_wait_until do
-  DT[:offsets].count > 500
+  DT[:offsets].size > 500
 end
 
 assert DT[:offsets].count(0) > 1

--- a/spec/integrations/pro/consumption/strategies/vp/cancelled_vps_due_to_bad_partitioning_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/cancelled_vps_due_to_bad_partitioning_spec.rb
@@ -16,7 +16,7 @@ class Consumer < Karafka::BaseConsumer
   def consume
     start = Time.now.to_f
 
-    DT[0] << messages.count
+    DT[0] << messages.size
 
     sleep(rand / 10.to_f)
 

--- a/spec/integrations/pro/consumption/strategies/vp/collapsing/collapse_and_continuity_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/collapsing/collapse_and_continuity_spec.rb
@@ -67,7 +67,7 @@ produce_many(DT.topic, (0..9).to_a.map(&:to_s))
 
 start_karafka_and_wait_until do
   # 20 messages + 2 control records
-  DT[:flow].any? { |row| row.first == 19 && row.last == false } && DT[:flow].count >= 22
+  DT[:flow].any? { |row| row.first == 19 && row.last == false } && DT[:flow].size >= 22
 end
 
 pre_collapse_index = DT[:flow].index(&:last) - 1
@@ -88,7 +88,7 @@ pre_collapse_offsets.sort.each do |offset|
 end
 
 # Pre collapse should run in multiple threads
-assert pre_collapse.map { |row| row[1] }.uniq.count >= 2
+assert pre_collapse.map { |row| row[1] }.uniq.size >= 2
 
 # None of pre-collapse should be marked as collapsed
 assert pre_collapse.none?(&:last)
@@ -116,7 +116,7 @@ assert !flipped
 assert_equal nil, flipped_index
 
 # Collapsed should run in a single thread
-assert_equal 1, collapsed.map { |row| row[1] }.uniq.count
+assert_equal 1, collapsed.map { |row| row[1] }.uniq.size
 
 # All collapsed need to be in the pre collapsed because of retry
 assert (collapsed.map(&:first) - pre_collapse_offsets).empty?
@@ -140,7 +140,7 @@ uncollapsed = DT[:flow][(uncollapsed_index + 1)..100]
 assert uncollapsed.none?(&:last)
 
 # Post collapse should run in multiple threads
-assert uncollapsed.map { |row| row[1] }.uniq.count >= 2
+assert uncollapsed.map { |row| row[1] }.uniq.size >= 2
 
 # None of those processed later in parallel should be in the previous sets
 assert (uncollapsed.map(&:first) & collapsed.map(&:first)).empty?

--- a/spec/integrations/pro/consumption/strategies/vp/collapsing/collapse_with_intermediate_marking_filtering_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/collapsing/collapse_with_intermediate_marking_filtering_spec.rb
@@ -36,7 +36,7 @@ end
 produce_many(DT.topic, DT.uuids(50))
 
 start_karafka_and_wait_until do
-  DT[0].count >= 50
+  DT[0].size >= 50
 end
 
-assert_equal DT[0].uniq.count, DT[0].count
+assert_equal DT[0].uniq.size, DT[0].size

--- a/spec/integrations/pro/consumption/strategies/vp/collective_state_awareness_break_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/collective_state_awareness_break_spec.rb
@@ -16,7 +16,7 @@ end
 # This eliminates the case of running a single virtual partition
 class Buffer < Karafka::Pro::Processing::Filters::Base
   def apply!(messages)
-    @applied = messages.count < 10
+    @applied = messages.size < 10
 
     return unless @applied
 

--- a/spec/integrations/pro/consumption/strategies/vp/consistent_distribution_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/consistent_distribution_spec.rb
@@ -41,7 +41,7 @@ Thread.new do
 end
 
 start_karafka_and_wait_until do
-  DT[:combinations].count >= 20
+  DT[:combinations].size >= 20
 end
 
 assignments = {}
@@ -55,4 +55,4 @@ DT[:combinations].each do |elements|
   end
 end
 
-assert assignments.values.map(&:count).all? { _1 == 1 }
+assert(assignments.values.map(&:size).all? { _1 == 1 })

--- a/spec/integrations/pro/consumption/strategies/vp/custom_partitioning_engine_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/custom_partitioning_engine_spec.rb
@@ -46,7 +46,7 @@ assert_equal Karafka::App.config.internal.processing.partitioner_class, CustomPa
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    DT[topic.name] << messages.count
+    DT[topic.name] << messages.size
   end
 end
 

--- a/spec/integrations/pro/consumption/strategies/vp/different_coordinator_different_partitions_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/different_coordinator_different_partitions_spec.rb
@@ -33,7 +33,7 @@ start_karafka_and_wait_until do
   produce(DT.topic, '1', partition: 0)
   produce(DT.topic, '1', partition: 1)
 
-  DT[:messages].count >= 100
+  DT[:messages].size >= 100
 end
 
 assert_equal 2, DT[:coordinators_ids].uniq.size

--- a/spec/integrations/pro/consumption/strategies/vp/from_earliest_patterned_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/from_earliest_patterned_spec.rb
@@ -48,7 +48,7 @@ assert DT.data.size >= 5
 
 # On average we should have similar number of messages
 sizes = DT.data.values.map(&:size)
-average = sizes.sum / sizes.count
+average = sizes.sum / sizes.size
 # Small deviations may be expected
 assert average >= 8
 assert average <= 12

--- a/spec/integrations/pro/consumption/strategies/vp/from_earliest_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/from_earliest_spec.rb
@@ -40,7 +40,7 @@ assert DT.data.size >= 5
 
 # On average we should have similar number of messages
 sizes = DT.data.values.map(&:size)
-average = sizes.sum / sizes.count
+average = sizes.sum / sizes.size
 # Small deviations may be expected
 assert average >= 8
 assert average <= 12

--- a/spec/integrations/pro/consumption/strategies/vp/groups_aggregation_halt_on_recovery_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/groups_aggregation_halt_on_recovery_spec.rb
@@ -33,7 +33,7 @@ end
 produce_many(DT.topic, DT.uuids(200))
 
 start_karafka_and_wait_until do
-  DT[:sizes].count >= 10
+  DT[:sizes].size >= 10
 end
 
 assert DT[:sizes].max <= 3

--- a/spec/integrations/pro/consumption/strategies/vp/pre_work_marking_retry_continuity_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/pre_work_marking_retry_continuity_spec.rb
@@ -36,9 +36,9 @@ produce_many(DT.topic, DT.uuids(50))
 extra_produced = false
 
 start_karafka_and_wait_until do
-  if DT[:offsets].count > 50
+  if DT[:offsets].size > 50
     true
-  elsif DT[:offsets].count == 50 && !extra_produced
+  elsif DT[:offsets].size == 50 && !extra_produced
     extra_produced = true
     produce_many(DT.topic, DT.uuids(1))
     false

--- a/spec/integrations/pro/consumption/strategies/vp/shared_coordinator_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/shared_coordinator_spec.rb
@@ -30,7 +30,7 @@ end
 produce_many(DT.topic, DT.uuids(100))
 
 start_karafka_and_wait_until do
-  DT[:messages].count >= 100
+  DT[:messages].size >= 100
 end
 
 assert_equal 1, DT[:coordinators_ids].uniq.size

--- a/spec/integrations/pro/consumption/strategies/vp/with_cycling_distribution_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/with_cycling_distribution_spec.rb
@@ -51,7 +51,7 @@ assert DT.data.size >= 5
 
 # On average we should have similar number of messages
 sizes = DT.data.values.map(&:size)
-average = sizes.sum / sizes.count
+average = sizes.sum / sizes.size
 # Small deviations may be expected
 assert average >= 8
 assert average <= 12

--- a/spec/integrations/pro/consumption/strategies/vp/with_headers_usage_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/with_headers_usage_spec.rb
@@ -39,5 +39,5 @@ end
 end
 
 start_karafka_and_wait_until do
-  DT[:selected].count >= 40
+  DT[:selected].size >= 40
 end

--- a/spec/integrations/pro/consumption/strategies/vp/with_limited_concurrency_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/with_limited_concurrency_spec.rb
@@ -18,12 +18,12 @@ class Consumer < Karafka::BaseConsumer
     times = []
 
     times << Time.now
-    sleep(10) unless messages.count == 1
+    sleep(10) unless messages.size == 1
     times << Time.now
 
     DT[:times] << times
 
-    DT[:messages] << messages.count
+    DT[:messages] << messages.size
   end
 end
 

--- a/spec/integrations/pro/consumption/strategies/vp/with_more_vps_than_workers_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/with_more_vps_than_workers_spec.rb
@@ -16,7 +16,7 @@ end
 class Consumer < Karafka::BaseConsumer
   def consume
     DT[:objects_ids] << object_id
-    DT[:messages] << messages.count
+    DT[:messages] << messages.size
   end
 end
 
@@ -41,4 +41,4 @@ end
 
 # The distribution is per batch and the first one is super small, so it won't be always 200, it
 # may be less due to how we reduce it and the data sample
-assert DT[:objects_ids].uniq.count > 100
+assert DT[:objects_ids].uniq.size > 100

--- a/spec/integrations/pro/consumption/strategies/vp/with_parallel_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/with_parallel_errors_spec.rb
@@ -21,7 +21,7 @@ end
 
 class Consumer < Karafka::BaseConsumer
   def consume
-    if !@raised && messages.count > 1
+    if !@raised && messages.size > 1
       @raised = true
       raise StandardError
     end

--- a/spec/integrations/pro/consumption/transactions/dlq/with_transactional_dispatch_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/dlq/with_transactional_dispatch_spec.rb
@@ -54,7 +54,7 @@ elements = DT.uuids(100)
 produce_many(DT.topic, elements)
 
 start_karafka_and_wait_until do
-  DT[:offsets].uniq.count >= 99 && DT.key?(:broken)
+  DT[:offsets].uniq.size >= 99 && DT.key?(:broken)
 end
 
 # The skipped should not be in the processed

--- a/spec/integrations/pro/iterator/long_living_iterator_spec.rb
+++ b/spec/integrations/pro/iterator/long_living_iterator_spec.rb
@@ -34,7 +34,7 @@ limit = 100
 buffer = []
 
 iterator.each do |message|
-  break if buffer.count >= limit
+  break if buffer.size >= limit
 
   # Message may be a nil when `yield_nil` is set to true
   buffer << message if message

--- a/spec/integrations/pro/iterator/negative_multiple_topics_lookups_spec.rb
+++ b/spec/integrations/pro/iterator/negative_multiple_topics_lookups_spec.rb
@@ -43,8 +43,8 @@ iterator.each do |message|
   offsets[message.topic][message.partition] << message.offset
 end
 
-assert_equal 2, offsets[DT.topics[0]].count
-assert_equal 2, offsets[DT.topics[1]].count
+assert_equal 2, offsets[DT.topics[0]].size
+assert_equal 2, offsets[DT.topics[1]].size
 assert_equal (15..19).to_a, offsets[DT.topics[0]][0]
 assert_equal (15..19).to_a, offsets[DT.topics[0]][1]
 assert_equal (10..19).to_a, offsets[DT.topics[1]][0]

--- a/spec/integrations/pro/rails/active_job/virtual_partitions/from_earliest_spec.rb
+++ b/spec/integrations/pro/rails/active_job/virtual_partitions/from_earliest_spec.rb
@@ -39,6 +39,6 @@ start_karafka_and_wait_until do
   DT[0].size >= 200
 end
 
-assert_equal 5, DT[:threads_ids].uniq.count
+assert_equal 5, DT[:threads_ids].uniq.size
 assert_equal values, DT[0].sort
 assert_equal DT[0], DT[0].uniq

--- a/spec/integrations/pro/routing/patterns/routing_definitions_spec.rb
+++ b/spec/integrations/pro/routing/patterns/routing_definitions_spec.rb
@@ -29,7 +29,7 @@ draw_routes(create_topics: false) do
   end
 end
 
-assert_equal 2, Karafka::App.routes.count
+assert_equal 2, Karafka::App.routes.size
 assert_equal 3, Karafka::App.routes.map(&:topics).flatten.map(&:to_a).flatten.size
 assert_equal 'test', Karafka::App.routes.first.topics.first.name
 assert !Karafka::App.routes.first.topics.first.patterns.active?

--- a/spec/integrations/rails/rails70_pristine/with-active_job_and_current_attributes/resource_accesibility_and_isolation_spec.rb
+++ b/spec/integrations/rails/rails70_pristine/with-active_job_and_current_attributes/resource_accesibility_and_isolation_spec.rb
@@ -61,7 +61,7 @@ class Consumer < Karafka::BaseConsumer
   def consume
     Current.user = SecureRandom.uuid
     ContextAwareOperation.call
-    DT[:messages] << messages.count
+    DT[:messages] << messages.size
     DT[:partitions] << messages.metadata.partition
   end
 end
@@ -78,7 +78,7 @@ draw_routes do
 end
 
 def done?
-  DT[:messages].sum >= 1000 && DT[:partitions].uniq.count >= 10
+  DT[:messages].sum >= 1000 && DT[:partitions].uniq.size >= 10
 end
 
 Thread.new do

--- a/spec/integrations/rails/rails71_pristine/with-active_job_and_current_attributes/resource_accesibility_and_isolation_spec.rb
+++ b/spec/integrations/rails/rails71_pristine/with-active_job_and_current_attributes/resource_accesibility_and_isolation_spec.rb
@@ -61,7 +61,7 @@ class Consumer < Karafka::BaseConsumer
   def consume
     Current.user = SecureRandom.uuid
     ContextAwareOperation.call
-    DT[:messages] << messages.count
+    DT[:messages] << messages.size
     DT[:partitions] << messages.metadata.partition
   end
 end
@@ -78,7 +78,7 @@ draw_routes do
 end
 
 def done?
-  DT[:messages].sum >= 1000 && DT[:partitions].uniq.count >= 10
+  DT[:messages].sum >= 1000 && DT[:partitions].uniq.size >= 10
 end
 
 Thread.new do

--- a/spec/integrations/rails/rails72_pristine/with-active_job_and_current_attributes/resource_accesibility_and_isolation_spec.rb
+++ b/spec/integrations/rails/rails72_pristine/with-active_job_and_current_attributes/resource_accesibility_and_isolation_spec.rb
@@ -62,7 +62,7 @@ class Consumer < Karafka::BaseConsumer
   def consume
     Current.user = SecureRandom.uuid
     ContextAwareOperation.call
-    DT[:messages] << messages.count
+    DT[:messages] << messages.size
     DT[:partitions] << messages.metadata.partition
   end
 end
@@ -79,7 +79,7 @@ draw_routes do
 end
 
 def done?
-  DT[:messages].sum >= 1000 && DT[:partitions].uniq.count >= 10
+  DT[:messages].sum >= 1000 && DT[:partitions].uniq.size >= 10
 end
 
 Thread.new do

--- a/spec/integrations/rails/rails80_pristine/with-active_job_and_current_attributes/resource_accesibility_and_isolation_spec.rb
+++ b/spec/integrations/rails/rails80_pristine/with-active_job_and_current_attributes/resource_accesibility_and_isolation_spec.rb
@@ -62,7 +62,7 @@ class Consumer < Karafka::BaseConsumer
   def consume
     Current.user = SecureRandom.uuid
     ContextAwareOperation.call
-    DT[:messages] << messages.count
+    DT[:messages] << messages.size
     DT[:partitions] << messages.metadata.partition
   end
 end
@@ -79,7 +79,7 @@ draw_routes do
 end
 
 def done?
-  DT[:messages].sum >= 1000 && DT[:partitions].uniq.count >= 10
+  DT[:messages].sum >= 1000 && DT[:partitions].uniq.size >= 10
 end
 
 Thread.new do

--- a/spec/integrations/rebalancing/exceeding_max_poll_with_late_commit_spec.rb
+++ b/spec/integrations/rebalancing/exceeding_max_poll_with_late_commit_spec.rb
@@ -24,7 +24,7 @@ class Consumer < Karafka::BaseConsumer
       mark_as_consumed message
     end
 
-    sleep(15) if messages.count > 1
+    sleep(15) if messages.size > 1
   end
 end
 

--- a/spec/integrations/rebalancing/message_order_with_sync_commit_spec.rb
+++ b/spec/integrations/rebalancing/message_order_with_sync_commit_spec.rb
@@ -20,7 +20,7 @@ class Consumer < Karafka::BaseConsumer
       # Wait until some amount of messages has been already processed to spice things up
       if condition_met?(message) &&
          !DT.key?(:contested_message) &&
-         DT[:consecutive_messages].count >= 60
+         DT[:consecutive_messages].size >= 60
         DT[:contested_message] << message
 
         sleep(0.1) until DT.key?(:second_closed)

--- a/spec/integrations/rebalancing/message_order_without_sync_commit_spec.rb
+++ b/spec/integrations/rebalancing/message_order_without_sync_commit_spec.rb
@@ -19,7 +19,7 @@ class Consumer < Karafka::BaseConsumer
       # Wait until some amount of messages has been already processed to spice things up
       if condition_met?(message) &&
          DT.data[:contested_message].empty? &&
-         DT.data[:consecutive_messages].count >= 60
+         DT.data[:consecutive_messages].size >= 60
         DT[:contested_message_tuple] << [message, messages.metadata.first_offset]
         sleep(0.1) until DT.data.key?(:second_closed)
       end
@@ -104,7 +104,7 @@ end
 
 wait_until do
   # Wait until the second consumer gets to the contested message and processes it
-  other_consumer.join && DT.data[:second_closed] == true && DT.data[:revoked].count >= 1
+  other_consumer.join && DT.data[:second_closed] == true && DT.data[:revoked].size >= 1
 end
 
 contested_message, contested_batch_first_offset = DT[:contested_message_tuple].first
@@ -123,7 +123,7 @@ end
 duplicate_counts = messages_from_contested_batch
                    .group_by { |_, _, offset| offset }
                    .values
-                   .map { |group| group.uniq.count }
+                   .map { |group| group.uniq.size }
 
 assert(duplicate_counts.all? { |size| size == 2 })
 

--- a/spec/integrations/rebalancing/multiple_consumer_groups_stability_spec.rb
+++ b/spec/integrations/rebalancing/multiple_consumer_groups_stability_spec.rb
@@ -49,7 +49,7 @@ end
 consumer = setup_rdkafka_consumer
 
 other = Thread.new do
-  sleep(1) while DT[:working].uniq.count < 2
+  sleep(1) while DT[:working].uniq.size < 2
 
   sleep(1)
 

--- a/spec/integrations/routing/stable_with_subscription_groups_spec.rb
+++ b/spec/integrations/routing/stable_with_subscription_groups_spec.rb
@@ -31,7 +31,7 @@ g00 = Karafka::App.subscription_groups.values[0][0].kafka[:'group.instance.id']
 g01 = Karafka::App.subscription_groups.values[0][1].kafka[:'group.instance.id']
 g10 = Karafka::App.subscription_groups.values[1][0].kafka[:'group.instance.id']
 
-assert [g00, g01, g10].uniq.count == 3
+assert [g00, g01, g10].uniq.size == 3
 assert_equal g00, "#{UUID}_0"
 assert_equal g01, "#{UUID}_1"
 assert_equal g10, "#{UUID}_2"

--- a/spec/integrations/routing/with_subscription_groups_chaotic_order_spec.rb
+++ b/spec/integrations/routing/with_subscription_groups_chaotic_order_spec.rb
@@ -29,5 +29,5 @@ end
 
 subscription_groups = Karafka::App.subscription_groups
 
-assert_equal 3, subscription_groups.values.first.count
-assert_equal 1, subscription_groups.values.last.count
+assert_equal 3, subscription_groups.values.first.size
+assert_equal 1, subscription_groups.values.last.size

--- a/spec/integrations/shutdown/on_quiet_with_work_finalization_spec.rb
+++ b/spec/integrations/shutdown/on_quiet_with_work_finalization_spec.rb
@@ -32,7 +32,7 @@ Thread.new do
 end
 
 start_karafka_and_wait_until do
-  DT[:states].count >= 2
+  DT[:states].size >= 2
 end
 
 assert_equal DT[:states], %w[quieting quiet]

--- a/spec/lib/karafka/messages/builders/batch_metadata_spec.rb
+++ b/spec/lib/karafka/messages/builders/batch_metadata_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe_current do
     before { allow(Time).to receive(:now).and_return(now) }
 
     it { is_expected.to be_a(Karafka::Messages::BatchMetadata) }
-    it { expect(result.size).to eq kafka_batch.count }
+    it { expect(result.size).to eq kafka_batch.size }
     it { expect(result.partition).to eq partition }
     it { expect(result.first_offset).to eq kafka_batch.first.offset }
     it { expect(result.last_offset).to eq kafka_batch.last.offset }

--- a/spec/lib/karafka/pro/base_consumer_spec.rb
+++ b/spec/lib/karafka/pro/base_consumer_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Karafka::BaseConsumer, type: :pro do
       Karafka::Messages::Messages,
       first: first_message,
       last: last_message,
-      count: 2,
+      size: 2,
       metadata: Karafka::Messages::BatchMetadata.new(
         topic: topic.name,
         partition: 0,

--- a/spec/lib/karafka/pro/instrumentation/performance_tracker_spec.rb
+++ b/spec/lib/karafka/pro/instrumentation/performance_tracker_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe_current do
 
     context 'when topic exists but not the partition' do
       let(:message) { build(:messages_message, metadata: build(:messages_metadata)) }
-      let(:messages) { OpenStruct.new(metadata: message.metadata, count: 12) }
+      let(:messages) { OpenStruct.new(metadata: message.metadata, size: 12) }
       let(:payload) { { caller: OpenStruct.new(messages: messages), time: 200 } }
       let(:topic) { message.metadata.topic }
       let(:partition) { 1 }
@@ -32,7 +32,7 @@ RSpec.describe_current do
     context 'when topic and partition exist' do
       context 'when there is only one value' do
         let(:message) { build(:messages_message, metadata: build(:messages_metadata)) }
-        let(:messages) { OpenStruct.new(metadata: message.metadata, count: 1) }
+        let(:messages) { OpenStruct.new(metadata: message.metadata, size: 1) }
         let(:payload) { { caller: OpenStruct.new(messages: messages), time: 20 } }
         let(:topic) { message.metadata.topic }
         let(:partition) { 0 }
@@ -44,7 +44,7 @@ RSpec.describe_current do
 
       context 'when there are more values for a give partition' do
         let(:message) { build(:messages_message, metadata: build(:messages_metadata)) }
-        let(:messages) { OpenStruct.new(metadata: message.metadata, count: 1) }
+        let(:messages) { OpenStruct.new(metadata: message.metadata, size: 1) }
         let(:payload) { { caller: OpenStruct.new(messages: messages), time: 20 } }
         let(:topic) { message.metadata.topic }
         let(:partition) { 0 }

--- a/spec/lib/karafka/pro/processing/filters/throttler_spec.rb
+++ b/spec/lib/karafka/pro/processing/filters/throttler_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe_current do
 
       it 'expect not to remove last message when we reached limit' do
         throttler.apply!(messages)
-        expect(messages.count).to eq(max_messages)
+        expect(messages.size).to eq(max_messages)
       end
     end
 
@@ -79,7 +79,7 @@ RSpec.describe_current do
 
       it 'expect not to remove last message when we reached limit' do
         throttler.apply!(messages)
-        expect(messages.count).to eq(max_messages)
+        expect(messages.size).to eq(max_messages)
       end
     end
   end

--- a/spec/lib/karafka/pro/processing/schedulers/default_spec.rb
+++ b/spec/lib/karafka/pro/processing/schedulers/default_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe_current do
 
       4.times do |i|
         let("messages#{i}") do
-          OpenStruct.new(metadata: public_send("message#{i}").metadata, count: 1)
+          OpenStruct.new(metadata: public_send("message#{i}").metadata, size: 1)
         end
 
         let("payload#{i}") do
@@ -77,7 +77,7 @@ RSpec.describe_current do
 
       4.times do |i|
         let("messages#{i}") do
-          OpenStruct.new(metadata: public_send("message#{i}").metadata, count: 1)
+          OpenStruct.new(metadata: public_send("message#{i}").metadata, size: 1)
         end
 
         let("payload#{i}") do

--- a/spec/lib/karafka/pro/routing/features/delaying/topic_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/delaying/topic_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe_current do
       end
 
       it 'expect not to add second expire' do
-        expect(topic.filter.factories.count).to eq(1)
+        expect(topic.filter.factories.size).to eq(1)
       end
     end
   end

--- a/spec/lib/karafka/pro/routing/features/expiring/topic_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/expiring/topic_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe_current do
       end
 
       it 'expect not to add second expire' do
-        expect(topic.filter.factories.count).to eq(1)
+        expect(topic.filter.factories.size).to eq(1)
       end
     end
   end

--- a/spec/lib/karafka/pro/routing/features/inline_insights/topic_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/inline_insights/topic_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe_current do
       end
 
       it 'expect not to add any filters' do
-        expect(topic.filter.factories.count).to eq(0)
+        expect(topic.filter.factories.size).to eq(0)
       end
     end
   end

--- a/spec/lib/karafka/routing/consumer_group_spec.rb
+++ b/spec/lib/karafka/routing/consumer_group_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe_current do
 
     before { built_topic }
 
-    it { expect(consumer_group.topics.count).to eq 1 }
+    it { expect(consumer_group.topics.size).to eq 1 }
     it { expect(built_topic.name).to eq :topic_name.to_s }
   end
 


### PR DESCRIPTION
misuse of count caused some specs to crash. not often but could happen:

```
A = Set.new; Thread.new {  loop { A << rand; sleep(0.0001) }  }; loop { A.count  }
```

vs

```
A = Set.new; Thread.new {  loop { A << rand; sleep(0.0001) }  }; loop { A.size  }
```

this PR replaces count with size where possible.