### PR TITLE
Count errors per error class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **[Breaking]** Use DLQ and Piping prefix `source_` instead of `original_` to align with naming convention of Kafka Streams and Apache Flink for future usage.
 - **[Breaking]** Rename scheduled jobs topics names in their config (Pro).
 - **[Feature]** Parallel Segments for concurrent processing of the same partition with more than partition count of processes (Pro).
+- [Enhancement] Enhance errors tracker with `#counts` that contains per-error class specific counters for granular flow handling.
 - [Enhancement] Provide explicit `Karafka::Admin.copy_consumer_group` API.
 - [Enhancement] Return explicit value from `Karafka::Admin.copy_consumer_group` and `Karafka::Admin.rename_consumer_group` APIs.
 - [Enhancement] Introduce balanced non-consistent VP distributor improving the utilization up to 50% (Pro).

--- a/lib/karafka/pro/processing/coordinators/errors_tracker.rb
+++ b/lib/karafka/pro/processing/coordinators/errors_tracker.rb
@@ -19,29 +19,41 @@ module Karafka
           # @return [Integer] partition of this error tracker
           attr_reader :partition
 
+          # @return [Hash]
+          attr_reader :counts
+
           # Max errors we keep in memory.
           # We do not want to keep more because for DLQ-less this would cause memory-leaks.
+          # We do however count per class for granular error counting
           STORAGE_LIMIT = 100
 
           private_constant :STORAGE_LIMIT
 
           # @param topic [Karafka::Routing::Topic]
           # @param partition [Integer]
-          def initialize(topic, partition)
+          # @param limit [Integer] max number of errors we want to keep for reference when
+          #   implementing custom error handling.
+          # @note `limit` does not apply to the counts. They will work beyond the number of errors
+          #   occurring
+          def initialize(topic, partition, limit: STORAGE_LIMIT)
             @errors = []
+            @counts = Hash.new { |hash, key| hash[key] = 0 }
             @topic = topic
             @partition = partition
+            @limit = limit
           end
 
           # Clears all the errors
           def clear
             @errors.clear
+            @counts.clear
           end
 
           # @param error [StandardError] adds the error to the tracker
           def <<(error)
-            @errors.shift if @errors.size >= STORAGE_LIMIT
+            @errors.shift if @errors.size >= @limit
             @errors << error
+            @counts[error.class] += 1
           end
 
           # @return [Boolean] is the error tracker empty
@@ -51,7 +63,9 @@ module Karafka
 
           # @return [Integer] number of elements
           def size
-            count
+            # We use counts reference of all errors and not the `@errors` array because it allows
+            # us to go beyond the whole errors storage limit
+            @counts.values.sum
           end
 
           # @return [StandardError, nil] last error that occurred or nil if no errors

--- a/spec/integrations/pro/consumption/with_granular_errors_tracker_tracking_spec.rb
+++ b/spec/integrations/pro/consumption/with_granular_errors_tracker_tracking_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+# This code is part of Karafka Pro, a commercial component not licensed under LGPL.
+# See LICENSE for details.
+
+# Error counting should happen per error class
+
+setup_karafka(allow_errors: %w[consumer.consume.error]) do |config|
+  config.concurrency = 1
+end
+
+# Define different error classes for testing
+E1 = Class.new(StandardError)
+E2 = Class.new(StandardError)
+E3 = Class.new(StandardError)
+
+class Consumer < Karafka::BaseConsumer
+  def initialize
+    super
+    @error_count = 0
+  end
+
+  def consume
+    # Track current error counts
+    DT[:error_counts] << errors_tracker.counts.dup
+
+    @error_count += 1
+
+    # Raise different errors based on retry count
+    case @error_count
+    when 1
+      raise E1
+    when 2
+      raise E2
+    when 3
+      raise E3
+    when 4
+      raise E1
+    when 5
+      raise E2
+    else
+      raise
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+  end
+end
+
+# Produce a single message that will trigger multiple errors
+produce(DT.topic, 'test')
+
+# Start Karafka and wait for multiple retries
+start_karafka_and_wait_until do
+  DT[:error_counts].size >= 6
+end
+
+# Verify error counts are accumulating for different error classes
+last_counts = DT[:error_counts].last
+assert_equal 2, last_counts[E1], 'Should count E1 errors correctly'
+assert_equal 2, last_counts[E2], 'Should count E2 errors correctly'
+assert_equal 1, last_counts[E3], 'Should count E3 errors correctly'


### PR DESCRIPTION
This PR enhances the errors tracker with tracking per error type (class) for granular decision making since processing of one message may have different errors. While we do have last 100 in the `.errors` some users have more complex cases that go beyond that