### PR TITLE
cache root not to run `Bundler.with_unbundled_env` multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - [Refactor] Improve CI specs parallelization.
 - [Maintenance] Require `karafka-rdkafka` `>=` `0.19.1` due to usage of `#rd_kafka_global_init` and KIP-82.
 - [Maintenance] Add Deimos routing patch into integration suite not to break it in the future.
+- [Fix] Make sure `Bundler.with_unbundled_env` is not called multiple times.
 - [Fix] Fix missing `virtual_partitions.partitioner.error` custom error logging in the `LoggerListener`.
 - [Fix] Prevent applied system filters `#timeout` from potentially interacting with user filters.
 - [Fix] Use more sane value in `Admin#seek_consumer_group` for long ago.

--- a/lib/karafka.rb
+++ b/lib/karafka.rb
@@ -57,15 +57,21 @@ module Karafka
 
     # @return [Pathname] Karafka app root path (user application path)
     def root
+      return @root if @root
+
       # If user points to a different root explicitly, use it
-      return Pathname.new(ENV['KARAFKA_ROOT_DIR']) if ENV['KARAFKA_ROOT_DIR']
+      if ENV['KARAFKA_ROOT_DIR']
+        @root = Pathname.new(ENV['KARAFKA_ROOT_DIR'])
+
+        return @root
+      end
 
       # By default we infer the project root from bundler.
       # We cannot use the BUNDLE_GEMFILE env directly because it may be altered by things like
       # ruby-lsp. Instead we always fallback to the most outer Gemfile. In most of the cases, it
       # won't matter but in case of some automatic setup alterations like ruby-lsp, the location
       # from which the project starts may not match the original Gemfile.
-      Pathname.new(
+      @root = Pathname.new(
         File.dirname(
           Bundler.with_unbundled_env { Bundler.default_gemfile }
         )

--- a/spec/lib/karafka_spec.rb
+++ b/spec/lib/karafka_spec.rb
@@ -3,6 +3,8 @@
 RSpec.describe_current do
   subject(:karafka) { described_class }
 
+  before { karafka.instance_variable_set('@root', nil) }
+
   describe '.env' do
     it { expect(karafka.env).to eq('test') }
   end


### PR DESCRIPTION
We should not run `Bundler.with_unbundled_env` multiple times because it is not atomic.