### PR TITLE
karafka-rdkafka 0.20 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 - [Refactor] Introduce a `bin/verify_topics_naming` script to ensure proper test topics naming convention.
 - [Refactor] Make sure all temporary topics have a `it-` prefix in their name.
 - [Refactor] Improve CI specs parallelization.
-- [Maintenance] Require `karafka-rdkafka` `>=` `0.19.1` due to usage of `#rd_kafka_global_init` and KIP-82.
+- [Maintenance] Require `karafka-rdkafka` `>=` `0.20.0` due to usage of `#rd_kafka_global_init` and KIP-82.
 - [Maintenance] Add Deimos routing patch into integration suite not to break it in the future.
 - [Maintenance] Remove Rails `7.0` specs due to upcoming EOL.
 - [Fix] Fix a case where `unknown_topic_or_part` error could leak out of the consumer on consumer shutdown.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     karafka (2.4.19)
       base64 (~> 0.2)
       karafka-core (>= 2.4.11, < 2.5.0)
-      karafka-rdkafka (>= 0.19.1)
+      karafka-rdkafka (>= 0.20.0.rc2)
       waterdrop (>= 2.8.3, < 3.0.0)
       zeitwerk (~> 2.3)
 
@@ -62,8 +62,9 @@ GEM
     karafka-core (2.4.11)
       karafka-rdkafka (>= 0.17.6, < 0.20.0)
       logger (>= 1.6.0)
-    karafka-rdkafka (0.19.1)
+    karafka-rdkafka (0.20.0.rc2)
       ffi (~> 1.15)
+      logger (>= 1.5)
       mini_portile2 (~> 2.6)
       rake (> 12)
     karafka-testing (2.4.7)
@@ -142,4 +143,4 @@ DEPENDENCIES
   stringio
 
 BUNDLED WITH
-   2.6.7
+   2.4.22

--- a/karafka.gemspec
+++ b/karafka.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'base64', '~> 0.2'
   spec.add_dependency 'karafka-core', '>= 2.4.11', '< 2.5.0'
-  spec.add_dependency 'karafka-rdkafka', '>= 0.19.1'
+  spec.add_dependency 'karafka-rdkafka', '>= 0.20.0.rc2'
   spec.add_dependency 'waterdrop', '>= 2.8.3', '< 3.0.0'
   spec.add_dependency 'zeitwerk', '~> 2.3'
 


### PR DESCRIPTION
This PR is used to test karafka-rdkafka 0.20.0 and librdkafka 2.10 stability against karafka.