### PR TITLE
fix past dispatch grace period

### DIFF
--- a/lib/karafka/pro/scheduled_messages/max_epoch.rb
+++ b/lib/karafka/pro/scheduled_messages/max_epoch.rb
@@ -15,7 +15,7 @@ module Karafka
         end
 
         # Updates epoch if bigger than current max
-        # @param new_max [Integer] potential new max epoch
+        # @param new_max [Integer, nil] potential new max epoch
         def update(new_max)
           return unless new_max
           return unless new_max > @max
@@ -23,9 +23,9 @@ module Karafka
           @max = new_max
         end
 
-        # @return [Integer] max epoch recorded
+        # @return [Integer] max epoch recorded minus grace period
         def to_i
-          @max
+          @max - Contracts::Message::GRACE_PERIOD
         end
       end
     end

--- a/spec/integrations/pro/scheduled_messages/fast_close_future_schedules_spec.rb
+++ b/spec/integrations/pro/scheduled_messages/fast_close_future_schedules_spec.rb
@@ -67,4 +67,4 @@ start_karafka_and_wait_until(sleep: 1) do
   dispatched.size >= 500
 end
 
-assert_equal dispatched.size, 500
+assert_equal 500, dispatched.size

--- a/spec/integrations/pro/scheduled_messages/fast_close_future_schedules_spec.rb
+++ b/spec/integrations/pro/scheduled_messages/fast_close_future_schedules_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# This code is part of Karafka Pro, a commercial component not licensed under LGPL.
+# See LICENSE for details.
+
+setup_karafka
+
+draw_routes do
+  scheduled_messages(DT.topics[0])
+
+  topic DT.topics[1] do
+    active(false)
+  end
+end
+
+Thread.new do
+  sleep(5)
+
+  iteration = 0
+
+  100.times do
+    iteration += 1
+
+    5.times do |round|
+      enveloped = Karafka::Pro::ScheduledMessages.schedule(
+        message: {
+          topic: DT.topics[1],
+          payload: {}.to_json, key: "#{5 - round}.seconds.ago.to_i-#{iteration}"
+        },
+        epoch: Time.now.to_i - (5 + round),
+        envelope: {
+          topic: DT.topics[0],
+          key: "#{iteration}-#{Time.now.to_i}#{SecureRandom.uuid}",
+          partition: 0
+        }
+      )
+
+      Karafka.producer.produce_async(enveloped)
+    end
+
+    sleep(0.1)
+  end
+end
+
+schedules = Array.new(50) do |i|
+  message = {
+    topic: DT.topics[1],
+    key: i.to_s,
+    headers: { 'b' => i.to_s },
+    payload: "payload#{i}"
+  }
+
+  Karafka::Pro::ScheduledMessages.schedule(
+    message: message,
+    epoch: Time.now.to_i + 1,
+    envelope: { topic: DT.topics[0], partition: 0 }
+  )
+end
+
+Karafka.producer.produce_many_sync(schedules)
+
+dispatched = nil
+
+start_karafka_and_wait_until(sleep: 1) do
+  dispatched = Karafka::Admin.read_topic(DT.topics[1], 0, 500)
+
+  dispatched.size >= 500
+end
+
+assert_equal dispatched.size, 500


### PR DESCRIPTION
This PR ensures that messages scheduled in close past are not affected by the skip on grace period.

This affects only messages scheduled in the close past but since we allow that, they should be dispatched as any others.