### PR TITLE
improve declarative topics reporting + add declarative topics CLI help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Karafka Framework Changelog
 
-## 2.4.19 (Unreleased)
+## 2.5.0 (Unreleased)
 - **[Breaking]** Use DLQ and Piping prefix `source_` instead of `original_` to align with naming convention of Kafka Streams and Apache Flink for future usage.
 - **[Breaking]** Rename scheduled jobs topics names in their config (Pro).
 - **[Feature]** Parallel Segments for concurrent processing of the same partition with more than partition count of processes (Pro).
@@ -30,6 +30,8 @@
 - [Enhancement] Set `topic.metadata.refresh.interval.ms` for default producer in dev to 5s to align with consumer setup.
 - [Enhancement] Alias `-2` and `-1` with `latest` and `earliest` for seeking.
 - [Enhancement] Allow for usage of `latest` and `earliest` in the `Karafka::Pro::Iterator`.
+- [Enhancement] Failures during `topics migrate` (and other subcommands) don't show what topic failed, and why it's invalid.
+- [Enhancement] Apply changes to topics configuration in atomic independent requests when using Declarative Topics.
 - [Refactor] Introduce a `bin/verify_kafka_warnings` script to clean Kafka from temporary test-suite topics.
 - [Refactor] Introduce a `bin/verify_topics_naming` script to ensure proper test topics naming convention.
 - [Refactor] Make sure all temporary topics have a `it-` prefix in their name.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
 - [Enhancement] Allow for usage of `latest` and `earliest` in the `Karafka::Pro::Iterator`.
 - [Enhancement] Failures during `topics migrate` (and other subcommands) don't show what topic failed, and why it's invalid.
 - [Enhancement] Apply changes to topics configuration in atomic independent requests when using Declarative Topics.
+- [Enhancement] Execute the help CLI command when no command provided (similar to Rails) to improve DX.
+- [Enhancement] Remove backtrace from the CLI error for incorrect commands (similar to Rails) to improve DX.
+- [Enhancement] Provide `karafka topics help` sub-help due to nesting of Declarative Topics actions.
 - [Refactor] Introduce a `bin/verify_kafka_warnings` script to clean Kafka from temporary test-suite topics.
 - [Refactor] Introduce a `bin/verify_topics_naming` script to ensure proper test topics naming convention.
 - [Refactor] Make sure all temporary topics have a `it-` prefix in their name.

--- a/bin/integrations
+++ b/bin/integrations
@@ -48,7 +48,8 @@ class Scenario
     'instrumentation/post_errors_instrumentation_error_spec.rb' => [1].freeze,
     'cli/declaratives/delete/existing_with_exit_code_spec.rb' => [2].freeze,
     'cli/declaratives/create/new_with_exit_code_spec.rb' => [2].freeze,
-    'cli/declaratives/plan/when_changes_with_detailed_exit_code_spec.rb' => [2].freeze
+    'cli/declaratives/plan/when_changes_with_detailed_exit_code_spec.rb' => [2].freeze,
+    'cli/declaratives/align/incorrectly_spec.rb' => [1].freeze
   }.freeze
 
   private_constant :MAX_RUN_TIME, :EXIT_CODES

--- a/lib/karafka/cli.rb
+++ b/lib/karafka/cli.rb
@@ -21,6 +21,8 @@ module Karafka
           args = action ? [action] : []
 
           command.new.call(*args)
+        elsif command_name.nil?
+          Help.new.call
         else
           raise(
             Karafka::Errors::UnrecognizedCommandError,

--- a/lib/karafka/cli/topics.rb
+++ b/lib/karafka/cli/topics.rb
@@ -27,7 +27,10 @@ module Karafka
       # crashes
       CHANGES_EXIT_CODE = 2
 
-      private_constant :NO_CHANGES_EXIT_CODE, :CHANGES_EXIT_CODE
+      # Used when there was an error during execution.
+      ERROR_EXIT_CODE = 1
+
+      private_constant :NO_CHANGES_EXIT_CODE, :CHANGES_EXIT_CODE, :ERROR_EXIT_CODE
 
       # @param action [String] action we want to take
       def call(action = 'missing')
@@ -57,6 +60,8 @@ module Karafka
         return unless detailed_exit_code
 
         changes ? exit(CHANGES_EXIT_CODE) : exit(NO_CHANGES_EXIT_CODE)
+      rescue Errors::CommandValidationError
+        exit(ERROR_EXIT_CODE)
       end
     end
   end

--- a/lib/karafka/cli/topics.rb
+++ b/lib/karafka/cli/topics.rb
@@ -33,7 +33,7 @@ module Karafka
       private_constant :NO_CHANGES_EXIT_CODE, :CHANGES_EXIT_CODE, :ERROR_EXIT_CODE
 
       # @param action [String] action we want to take
-      def call(action = 'missing')
+      def call(action = 'help')
         detailed_exit_code = options.fetch(:detailed_exitcode, false)
 
         command = case action
@@ -51,8 +51,10 @@ module Karafka
                     Topics::Align
                   when 'plan'
                     Topics::Plan
+                  when 'help'
+                    Topics::Help
                   else
-                    raise ::ArgumentError, "Invalid topics action: #{action}"
+                    raise Errors::UnrecognizedCommandError, "Unrecognized topics action: #{action}"
                   end
 
         changes = command.new.call

--- a/lib/karafka/cli/topics/align.rb
+++ b/lib/karafka/cli/topics/align.rb
@@ -30,10 +30,13 @@ module Karafka
             return false
           end
 
-          names = resources_to_migrate.map(&:name).join(', ')
-          puts "Updating configuration of the following topics: #{names}"
-          Karafka::Admin::Configs.alter(resources_to_migrate)
-          puts "#{green('Updated')} all requested topics configuration."
+          resources_to_migrate.each do |resource|
+            supervised("Updating topic: #{resource.name} configuration") do
+              Karafka::Admin::Configs.alter(resource)
+            end
+
+            puts "#{green('Updated')} topic #{resource.name} configuration."
+          end
 
           true
         end

--- a/lib/karafka/cli/topics/base.rb
+++ b/lib/karafka/cli/topics/base.rb
@@ -26,7 +26,7 @@ module Karafka
           puts "#{operation_message} #{red('failed')}:"
           puts e
 
-          raise Errors::CommandValidationError
+          raise Errors::CommandValidationError, cause: e
         end
 
         # @return [Array<Karafka::Routing::Topic>] all available topics that can be managed

--- a/lib/karafka/cli/topics/base.rb
+++ b/lib/karafka/cli/topics/base.rb
@@ -12,6 +12,23 @@ module Karafka
 
         private
 
+        # Used to run Karafka Admin commands that talk with Kafka and that can fail due to broker
+        # errors and other issues. We catch errors and provide nicer printed output prior to
+        # re-raising the mapped error for proper exit code status handling
+        #
+        # @param operation_message [String] message that we use to print that it is going to run
+        #   and if case if failed with a failure indication.
+        def supervised(operation_message)
+          puts "#{operation_message}..."
+
+          yield
+        rescue Rdkafka::RdkafkaError => e
+          puts "#{operation_message} #{red('failed')}:"
+          puts e
+
+          raise Errors::CommandValidationError
+        end
+
         # @return [Array<Karafka::Routing::Topic>] all available topics that can be managed
         # @note If topic is defined in multiple consumer groups, first config will be used. This
         #   means, that this CLI will not work for simultaneous management of multiple clusters

--- a/lib/karafka/cli/topics/create.rb
+++ b/lib/karafka/cli/topics/create.rb
@@ -15,13 +15,15 @@ module Karafka
             if existing_topics_names.include?(name)
               puts "#{yellow('Skipping')} because topic #{name} already exists."
             else
-              puts "Creating topic #{name}..."
-              Admin.create_topic(
-                name,
-                topic.declaratives.partitions,
-                topic.declaratives.replication_factor,
-                topic.declaratives.details
-              )
+              supervised("Creating topic #{name}") do
+                Admin.create_topic(
+                  name,
+                  topic.declaratives.partitions,
+                  topic.declaratives.replication_factor,
+                  topic.declaratives.details
+                )
+              end
+
               puts "#{green('Created')} topic #{name}."
               any_created = true
             end

--- a/lib/karafka/cli/topics/delete.rb
+++ b/lib/karafka/cli/topics/delete.rb
@@ -13,8 +13,10 @@ module Karafka
             name = topic.name
 
             if existing_topics_names.include?(name)
-              puts "Deleting topic #{name}..."
-              Admin.delete_topic(name)
+              supervised("Deleting topic #{name}") do
+                Admin.delete_topic(name)
+              end
+
               puts "#{green('Deleted')} topic #{name}."
               any_deleted = true
             else

--- a/lib/karafka/cli/topics/help.rb
+++ b/lib/karafka/cli/topics/help.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Karafka
+  class Cli
+    class Topics < Cli::Base
+      # Declarative topics CLI sub-help
+      class Help < Base
+        # Displays help information for all available topics management commands
+        def call
+          puts <<~HELP
+            Karafka topics commands:
+              align        # Aligns configuration of all declarative topics based on definitions
+              create       # Creates topics with appropriate settings
+              delete       # Deletes all topics defined in the routes
+              help         # Describes available topics management commands
+              migrate      # Creates missing topics, repartitions existing and aligns configuration
+              plan         # Plans migration process and prints changes to be applied
+              repartition  # Adds additional partitions to topics with fewer partitions than expected
+              reset        # Deletes and re-creates all topics
+
+            Options:
+              --detailed-exitcode  # Provides detailed exit codes (0=no changes, 1=error, 2=changes applied)
+
+            Examples:
+              karafka topics create
+              karafka topics plan --detailed-exitcode
+              karafka topics migrate
+              karafka topics align
+
+            Note: All admin operations run on the default cluster only.
+          HELP
+
+          # We return false to indicate with exit code 0 that no changes were applied
+          false
+        end
+      end
+    end
+  end
+end

--- a/lib/karafka/cli/topics/repartition.rb
+++ b/lib/karafka/cli/topics/repartition.rb
@@ -21,8 +21,10 @@ module Karafka
             existing_count = existing_partitions.fetch(name, false)
 
             if existing_count && existing_count < desired_count
-              puts "Increasing number of partitions to #{desired_count} on topic #{name}..."
-              Admin.create_partitions(name, desired_count)
+              supervised("Increasing number of partitions to #{desired_count} on topic #{name}") do
+                Admin.create_partitions(name, desired_count)
+              end
+
               change = desired_count - existing_count
               puts "#{green('Created')} #{change} additional partitions on topic #{name}."
               any_repartitioned = true

--- a/lib/karafka/errors.rb
+++ b/lib/karafka/errors.rb
@@ -92,7 +92,13 @@ module Karafka
     ResultNotVisibleError = Class.new(BaseError)
 
     # Raised when there is an attempt to run an unrecognized CLI command
-    UnrecognizedCommandError = Class.new(BaseError)
+    UnrecognizedCommandError = Class.new(BaseError) do
+      # Overwritten not to print backtrace for unknown CLI command
+      def initialize(*args)
+        super
+        set_backtrace([])
+      end
+    end
 
     # Raised when you were executing a command and it could not finish successfully because of
     # a setup state or parameters configuration

--- a/spec/integrations/admin/acl_flow_spec.rb
+++ b/spec/integrations/admin/acl_flow_spec.rb
@@ -37,7 +37,7 @@ acl2 = Karafka::Admin::Acl.new(
 Karafka::Admin::Acl.create(acl2)
 
 # Give some time to create rule
-sleep(1)
+sleep(5)
 
 assert_equal 1, Karafka::Admin::Acl.describe(acl2).size
 assert Karafka::Admin::Acl.all.map(&:resource_name).include?(uuid2)

--- a/spec/integrations/admin/acl_flow_spec.rb
+++ b/spec/integrations/admin/acl_flow_spec.rb
@@ -19,7 +19,7 @@ Karafka::Admin::Acl.create(acl1)
 Karafka::Admin::Acl.delete(acl1)
 
 # Give some time for acl to sync up
-sleep(1)
+sleep(5)
 
 assert_equal [], Karafka::Admin::Acl.describe(acl1)
 assert !Karafka::Admin::Acl.all.map(&:resource_name).include?(uuid1)

--- a/spec/integrations/cli/cli_unknown_spec.rb
+++ b/spec/integrations/cli/cli_unknown_spec.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
-# Karafka CLI should work and should just run help without command
+# Karafka CLI should work and should fail with unknown command error
 
 failed = false
+
+ARGV[0] = 'unknown'
 
 begin
   Karafka::Cli.start
@@ -10,4 +12,4 @@ rescue Karafka::Errors::UnrecognizedCommandError
   failed = true
 end
 
-assert !failed
+assert failed

--- a/spec/integrations/cli/declaratives/align/incorrectly_spec.rb
+++ b/spec/integrations/cli/declaratives/align/incorrectly_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # karafka topics align should crash if we want to align something with incorrect changes
-# Please note this is NOT transactional
+# Please note this is NOT transactional. It will crash and exit 1.
 
 setup_karafka
 
@@ -24,12 +24,4 @@ end
 ARGV[0] = 'topics'
 ARGV[1] = 'align'
 
-raised = false
-
-begin
-  Karafka::Cli.start
-rescue Rdkafka::RdkafkaError
-  raised = true
-end
-
-assert raised
+Karafka::Cli.start

--- a/spec/integrations/pro/recurring_tasks/smarter_reconfiguration_spec.rb
+++ b/spec/integrations/pro/recurring_tasks/smarter_reconfiguration_spec.rb
@@ -21,8 +21,8 @@ end
 
 begin
   Karafka::Cli::Topics::Create.new.call
-rescue Rdkafka::RdkafkaError => e
-  code = e.code
+rescue Karafka::Errors::CommandValidationError => e
+  code = e.cause.code
 end
 
 assert_equal code, :invalid_replication_factor

--- a/spec/lib/karafka/cli/topics/help_spec.rb
+++ b/spec/lib/karafka/cli/topics/help_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+RSpec.describe_current do
+  subject(:help_topics) { described_class.new }
+
+  describe '#call' do
+    before do
+      # Suppress console output during tests
+      allow(help_topics).to receive(:puts)
+    end
+
+    it 'displays the help message and returns false' do
+      expect(help_topics.call).to be_falsey
+    end
+
+    it 'outputs the complete help text with all commands' do
+      help_topics.call
+
+      expected_commands = [
+        'align        # Aligns configuration of all declarative topics based on definitions',
+        'create       # Creates topics with appropriate settings',
+        'delete       # Deletes all topics defined in the routes',
+        'help         # Describes available topics management commands',
+        'migrate      # Creates missing topics, repartitions existing and aligns configuration',
+        'plan         # Plans migration process and prints changes to be applied',
+        'repartition  # Adds additional partitions to topics with fewer partitions than expected',
+        'reset        # Deletes and re-creates all topics'
+      ]
+
+      expected_commands.each do |command_line|
+        expect(help_topics).to have_received(:puts).with(
+          a_string_including(command_line)
+        )
+      end
+    end
+
+    it 'outputs options section with detailed exit code information' do
+      help_topics.call
+
+      expect(help_topics).to have_received(:puts).with(
+        a_string_including('--detailed-exitcode  # Provides detailed exit codes')
+      )
+    end
+
+    it 'outputs examples section with common usage patterns' do
+      help_topics.call
+
+      expected_examples = [
+        'karafka topics create',
+        'karafka topics plan --detailed-exitcode',
+        'karafka topics migrate',
+        'karafka topics align'
+      ]
+
+      expected_examples.each do |example|
+        expect(help_topics).to have_received(:puts).with(
+          a_string_including(example)
+        )
+      end
+    end
+
+    it 'outputs the cluster limitation note' do
+      help_topics.call
+
+      expect(help_topics).to have_received(:puts).with(
+        a_string_including('Note: All admin operations run on the default cluster only.')
+      )
+    end
+
+    it 'outputs the complete help structure with proper sections' do
+      help_topics.call
+
+      expect(help_topics).to have_received(:puts).with(
+        a_string_including('Karafka topics commands:')
+      )
+      expect(help_topics).to have_received(:puts).with(
+        a_string_including('Options:')
+      )
+      expect(help_topics).to have_received(:puts).with(
+        a_string_including('Examples:')
+      )
+    end
+
+    context 'when called multiple times' do
+      it 'consistently returns false' do
+        expect(help_topics.call).to be_falsey
+        expect(help_topics.call).to be_falsey
+        expect(help_topics.call).to be_falsey
+      end
+
+      it 'outputs help text each time' do
+        3.times { help_topics.call }
+
+        expect(help_topics).to have_received(:puts).exactly(3).times
+      end
+    end
+
+    context 'when checking output format' do
+      it 'outputs a single heredoc string' do
+        help_topics.call
+
+        # Should be called exactly once with the full help text
+        expect(help_topics).to have_received(:puts).once
+      end
+
+      it 'includes all required sections in the output' do
+        help_topics.call
+
+        # Capture the argument passed to puts
+        output = nil
+        allow(help_topics).to receive(:puts) { |arg| output = arg }
+        help_topics.call
+
+        expect(output).to include('Karafka topics commands:')
+        expect(output).to include('Options:')
+        expect(output).to include('Examples:')
+        expect(output).to include('Note:')
+      end
+    end
+
+    context 'when verifying return value semantics' do
+      it 'returns false to indicate no changes were applied' do
+        # The help command should return false to indicate with exit code 0
+        # that no changes were applied, consistent with other Karafka CLI commands
+        expect(help_topics.call).to be_falsey
+      end
+
+      it 'returns boolean false specifically, not nil' do
+        result = help_topics.call
+        expect(result).to be false
+        expect(result).not_to be_nil
+      end
+    end
+  end
+end

--- a/spec/lib/karafka/cli_spec.rb
+++ b/spec/lib/karafka/cli_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe_current do
   end
 
   describe '.start' do
-    it 'expect to raise error when no command provided' do
-      expect { cli.start }.to raise_error(Karafka::Errors::UnrecognizedCommandError)
+    it 'expect to use help when no command provided' do
+      expect { cli.start }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
Declarative topics will now (after karafka-rdkafka release) print full messages including broker errors and in the correct order.

Also topic alignments are now independent for much better reporting.

This PR also adds the help command for declarative topics.


close https://github.com/karafka/karafka/issues/2612
close https://github.com/karafka/karafka/issues/2604