### PR TITLE
optimize retryable wait in admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **[Breaking]** Use DLQ and Piping prefix `source_` instead of `original_` to align with naming convention of Kafka Streams and Apache Flink for future usage.
 - **[Breaking]** Rename scheduled jobs topics names in their config (Pro).
 - **[Breaking]** Change K8s listener response from `204` to `200` and include JSON body with reasons.
+- **[Breaking]** Replace admin config `max_attempts` with `max_retries_duration` and 
 - **[Feature]** Parallel Segments for concurrent processing of the same partition with more than partition count of processes (Pro).
 - [Enhancement] Normalize topic + partition logs format.
 - [Enhancement] Support KIP-82 (header values of arrays).
@@ -45,6 +46,7 @@
 - [Enhancement] Do not overwrite the `key` in the Pro DLQ dispatched messages for routing reasons.
 - [Enhancement] Introduce `errors_tracker.trace_id` for distributed error details correlation with the Web UI.
 - [Enhancement] Improve contracts validations reporting.
+- [Enhancement] Optimize topic creation and repartitioning admin operations for topics with hundreds of partitions.
 - [Refactor] Introduce a `bin/verify_kafka_warnings` script to clean Kafka from temporary test-suite topics.
 - [Refactor] Introduce a `bin/verify_topics_naming` script to ensure proper test topics naming convention.
 - [Refactor] Make sure all temporary topics have a `it-` prefix in their name.
@@ -69,6 +71,8 @@
 - [Fix] Scheduled Messages re-seek moves to `latest` on inheritance of initial offset when `0` offset is compacted.
 - [Fix] Seek to `:latest` without `topic_partition_position` (-1) will not seek at all.
 - [Fix] Extremely high turn over of scheduled messages can cause them not to reach EOF/Loaded state.
+- [Fix] Fix incorrectly passed `max_wait_time` to rdkafka (ms instead of seconds) causing too long wait.
+- [Fix] Remove aggresive requerying of the Kafka cluster on topic creation/removal/altering.
 - [Change] Move to trusted-publishers and remove signing since no longer needed.
 
 ## 2.4.18 (2025-04-09)

--- a/config/locales/errors.yml
+++ b/config/locales/errors.yml
@@ -84,7 +84,8 @@ en:
       admin.kafka_format: needs to be a hash
       admin.group_id_format: 'needs to be a string with a Kafka accepted format'
       admin.max_wait_time_format: 'needs to be an integer bigger than 0'
-      admin.max_attempts_format: 'needs to be an integer bigger than 0'
+      admin.retry_backoff_format: 'needs to be an integer bigger than 100'
+      admin.max_retries_duration_format: 'needs to be an integer bigger than 1000'
 
       swarm.nodes_format: 'needs to be an integer bigger than 0'
       swarm.node_format: needs to be false or node instance

--- a/lib/karafka/contracts/config.rb
+++ b/lib/karafka/contracts/config.rb
@@ -53,7 +53,8 @@ module Karafka
         required(:kafka) { |val| val.is_a?(Hash) }
         required(:group_id) { |val| val.is_a?(String) && Contracts::TOPIC_REGEXP.match?(val) }
         required(:max_wait_time) { |val| val.is_a?(Integer) && val.positive? }
-        required(:max_attempts) { |val| val.is_a?(Integer) && val.positive? }
+        required(:retry_backoff) { |val| val.is_a?(Integer) && val >= 100 }
+        required(:max_retries_duration) { |val| val.is_a?(Integer) && val >= 1_000 }
       end
 
       # We validate internals just to be sure, that they are present and working

--- a/lib/karafka/setup/config.rb
+++ b/lib/karafka/setup/config.rb
@@ -133,9 +133,14 @@ module Karafka
         # failed using external factor.
         setting :max_wait_time, default: 1_000
 
-        # How many times should be try. 1 000 ms x 60 => 60 seconds wait in total and then we give
-        # up on pending operations
-        setting :max_attempts, default: 60
+        # How long should we wait on admin operation retrying before giving up and raising an
+        # error that result is not visible
+        setting :max_retries_duration, default: 60_000
+
+        # In case of fast-finished async work, this `retry_backoff` help us not re-query Kafka
+        # too fast after previous call to check the async operation results. Basically prevents
+        # us from spamming metadata requests to Kafka in a loop
+        setting :retry_backoff, default: 500
 
         # option poll_timeout [Integer] time in ms
         # How long should a poll wait before yielding on no results (rdkafka-ruby setting)

--- a/lib/karafka/swarm/supervisor.rb
+++ b/lib/karafka/swarm/supervisor.rb
@@ -157,7 +157,7 @@ module Karafka
         # Run forceful kill
         manager.terminate
         # And wait until linux kills them
-        # This prevents us from existing forcefully with any dead child process still existing
+        # This prevents us from exiting forcefully with any dead child process still existing
         # Since we have sent the `KILL` signal, it must die, so we can wait until all dead
         sleep(supervision_sleep) until manager.stopped?
 

--- a/spec/lib/karafka/admin_spec.rb
+++ b/spec/lib/karafka/admin_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe_current do
 
       it { expect(topics).to include(name) }
     end
+
+    # This spec is slow. We test such case to make sure that it does not timeout. It used to
+    # timeout because of a bug that would make Karafka wait not long enough and would overload
+    # Kafka with queries.
+    context 'when creating topic with many partition' do
+      before { described_class.create_topic(name, 500, 1) }
+
+      it { expect(topics).to include(name) }
+    end
   end
 
   describe '#delete_topic and #cluster_info' do

--- a/spec/lib/karafka/contracts/config_spec.rb
+++ b/spec/lib/karafka/contracts/config_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe_current do
         kafka: {},
         group_id: 'karafka_admin',
         max_wait_time: 1_000,
-        max_attempts: 10
+        retry_backoff: 100,
+        max_retries_duration: 1_000
       },
       internal: {
         supervision_sleep: 0.1,
@@ -314,20 +315,38 @@ RSpec.describe_current do
       it { expect(contract.call(config)).not_to be_success }
     end
 
-    context 'when max_attempts is missing' do
-      before { admin_cfg.delete(:max_attempts) }
+    context 'when retry_backoff is missing' do
+      before { admin_cfg.delete(:retry_backoff) }
 
       it { expect(contract.call(config)).not_to be_success }
     end
 
-    context 'when max_attempts is not bigger than 0' do
-      before { admin_cfg[:max_attempts] = 0 }
+    context 'when retry_backoff is not bigger than 100' do
+      before { admin_cfg[:retry_backoff] = 99 }
 
       it { expect(contract.call(config)).not_to be_success }
     end
 
-    context 'when max_attempts is float' do
-      before { admin_cfg[:max_attempts] = 1.1 }
+    context 'when retry_backoff is float' do
+      before { admin_cfg[:retry_backoff] = 1.1 }
+
+      it { expect(contract.call(config)).not_to be_success }
+    end
+
+    context 'when max_retries_duration is missing' do
+      before { admin_cfg.delete(:max_retries_duration) }
+
+      it { expect(contract.call(config)).not_to be_success }
+    end
+
+    context 'when max_retries_duration is not bigger than 100' do
+      before { admin_cfg[:max_retries_duration] = 99 }
+
+      it { expect(contract.call(config)).not_to be_success }
+    end
+
+    context 'when max_retries_duration is float' do
+      before { admin_cfg[:max_retries_duration] = 1.1 }
 
       it { expect(contract.call(config)).not_to be_success }
     end


### PR DESCRIPTION
This PR optimizes the admin re-wait, reduces number of consecutive check queries to Kafka and stabilizes the API for case of creation of topic with hundreds or more partitions.

close https://github.com/karafka/karafka/issues/2687