### PR TITLE
improve AJ flows needed for continuations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Karafka Framework Changelog
 
 ## 2.5.1 (Unreleased)
+- [Enhancement] Support past `dispatch_at` times with `jitter: 0` in the OSS Karafka to support ActiveJob continuation.
+- [Enhancement] Use direct topci dispatches when `dispatch_at` is used for past times to bypass Scheduled Messages flow.
 - [Enhancement] Support immediate error raising with `auto.offset.reset` set to `error`.
 - [Enhancement] Don't create not needed dirs in the non-Rails setup template.
 - [Enhancement] Improve printing of TTIN to separate threads

--- a/lib/active_job/queue_adapters/karafka_adapter.rb
+++ b/lib/active_job/queue_adapters/karafka_adapter.rb
@@ -40,6 +40,11 @@ module ActiveJob
       def enqueue_after_transaction_commit?
         true
       end
+
+      # @return [Boolean] should we stop the job. Used by the ActiveJob continuation feature
+      def stopping?
+        Karafka::App.done?
+      end
     end
   end
 end

--- a/spec/integrations/consumption/strategies/aj_mom/retry_on_flow_spec.rb
+++ b/spec/integrations/consumption/strategies/aj_mom/retry_on_flow_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# Karafka should be able to handle retry_on with immediate retries in OSS as long as there is no
+# jitter
+
+setup_karafka(allow_errors: true)
+setup_active_job
+
+draw_routes do
+  active_job_topic DT.topic
+end
+
+class RetryableJob < ActiveJob::Base
+  queue_as DT.topic
+
+  retry_on StandardError, attempts: 3, wait: 0, jitter: false
+
+  def perform(job_id)
+    # Track execution attempts
+    DT[:executions] ||= {}
+    DT[:executions][job_id] ||= 0
+    DT[:executions][job_id] += 1
+
+    current_attempt = DT[:executions][job_id]
+
+    if current_attempt < 3
+      DT[:attempts] ||= []
+      DT[:attempts] << "job#{job_id}_attempt_#{current_attempt}"
+      raise StandardError, "Simulated failure on attempt #{current_attempt}"
+    else
+      DT[:success] ||= []
+      DT[:success] << "job#{job_id}_success"
+    end
+  end
+end
+
+class FailingJob < ActiveJob::Base
+  queue_as DT.topic
+
+  retry_on StandardError, attempts: 3, wait: 0, jitter: false
+
+  def perform(job_id)
+    DT[:failed_executions] ||= {}
+    DT[:failed_executions][job_id] ||= 0
+    DT[:failed_executions][job_id] += 1
+    DT[:failed_attempts] ||= []
+    DT[:failed_attempts] << "failing_job#{job_id}_attempt_#{DT[:failed_executions][job_id]}"
+
+    raise StandardError, 'Always fails'
+  end
+end
+
+# Enqueue jobs
+RetryableJob.perform_later(1)
+RetryableJob.perform_later(2)
+FailingJob.perform_later(3)
+
+start_karafka_and_wait_until do
+  success_count = DT[:success].size
+  failed_count = DT[:failed_attempts].size
+
+  success_count == 2 && failed_count == 3
+end
+
+assert_equal 3, DT[:executions][1], 'Job 1 should have been executed 3 times'
+assert_equal 3, DT[:executions][2], 'Job 2 should have been executed 3 times'
+assert_equal 3, DT[:failed_executions][3], 'Failing job should have been executed 3 times'
+
+expected_attempts = %w[job1_attempt_1 job1_attempt_2 job2_attempt_1 job2_attempt_2]
+
+assert_equal expected_attempts.sort, DT[:attempts].sort
+
+expected_success = %w[job1_success job2_success]
+assert_equal expected_success.sort, DT[:success].sort
+
+expected_failed_attempts = %w[failing_job3_attempt_1 failing_job3_attempt_2 failing_job3_attempt_3]
+
+assert_equal expected_failed_attempts, DT[:failed_attempts]

--- a/spec/integrations/pro/scheduled_messages/active_job_past_job_spec.rb
+++ b/spec/integrations/pro/scheduled_messages/active_job_past_job_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# This code is part of Karafka Pro, a commercial component not licensed under LGPL.
+# See LICENSE for details.
+
+# Karafka should schedule past messages directly, bypassing the scheduled messages completely
+
+setup_karafka
+setup_active_job
+
+draw_routes do
+  active_job_topic DT.topics[0]
+  # We do not activate this. If karafka would be using scheduled messages for past, we will not
+  # receive what we are waiting for
+  # scheduled_messages(DT.topics[1])
+end
+
+class Job < ActiveJob::Base
+  queue_as DT.topic
+
+  karafka_options(
+    dispatch_method: :produce_sync,
+    scheduled_messages_topic: DT.topics[1]
+  )
+
+  def perform(value1, value2)
+    DT[0] << value1
+    DT[0] << value2
+  end
+end
+
+VALUE1 = rand
+VALUE2 = rand
+
+Job.set(wait: 0.seconds).perform_later(VALUE1, VALUE2)
+
+start_karafka_and_wait_until do
+  DT.key?(0)
+end
+
+aj_config = Karafka::App.config.internal.active_job
+
+assert_equal aj_config.dispatcher.class, Karafka::Pro::ActiveJob::Dispatcher
+assert_equal aj_config.job_options_contract.class, Karafka::Pro::ActiveJob::JobOptionsContract
+assert_equal VALUE1, DT[0][0]
+assert_equal VALUE2, DT[0][1]
+assert_equal 1, DT.data.size


### PR DESCRIPTION
This PR adds some improvements so the continuations feature (https://github.com/rails/rails/pull/55127) can work. It redispatches messages (even with the past) via the scheduling API with timestamp. This was causing Karafka OSS to crash because it was assuming future dispatch which is in Pro only.

This has been fixed and on top of that in Pro direct bypass for dispatches has been implemented improving on the responsivness of job delivery. 