### PR TITLE
Disable nagle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [Enhancement] Move post-forceful shutdown termination wait value to a config.
 - [Enhancement] Include consumer group, subscription group and other details in error logs for key error locations.
 - [Enhancement] Inherit from `ActiveJob::QueueAdapters::AbstractAdapter` when possible for ActiveJob base class.
+- [Enhancement] Disable Nagle algorithm by default for improved network performance.
 - [Maintenance] Add basic direct DD integration spec via DD gem karafka monitoring feature.
 - [Fix] Fix incorrect (6 seconds vs 60 seconds) reset of connections on non-recoverable errors.
 - [Fix] Introduce mutex-safe and thread-safe `#inspect` where needed.

--- a/lib/karafka/setup/defaults_injector.rb
+++ b/lib/karafka/setup/defaults_injector.rb
@@ -16,6 +16,7 @@ module Karafka
         # some features may use this value for computation and it is better to ensure, we do
         # always have it
         'max.poll.interval.ms': 300_000,
+        'socket.nagle.disable': true,
         'client.software.version': [
           "v#{Karafka::VERSION}",
           "rdkafka-ruby-v#{Rdkafka::VERSION}",
@@ -42,7 +43,8 @@ module Karafka
       PRODUCER_KAFKA_DEV_DEFAULTS = {
         # For all of those same reasoning as for the consumer
         'allow.auto.create.topics': 'true',
-        'topic.metadata.refresh.interval.ms': 5_000
+        'topic.metadata.refresh.interval.ms': 5_000,
+        'socket.nagle.disable': true
       }.freeze
 
       private_constant :CONSUMER_KAFKA_DEFAULTS, :CONSUMER_KAFKA_DEV_DEFAULTS,

--- a/spec/lib/karafka/setup/defaults_injector_spec.rb
+++ b/spec/lib/karafka/setup/defaults_injector_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe_current do
           'statistics.interval.ms': 5_000,
           'client.software.name': 'karafka',
           'max.poll.interval.ms': 300_000,
+          'socket.nagle.disable': true,
           'client.software.version': [
             "v#{Karafka::VERSION}",
             "rdkafka-ruby-v#{Rdkafka::VERSION}",
@@ -44,6 +45,7 @@ RSpec.describe_current do
           'statistics.interval.ms': 5_000,
           'client.software.name': 'karafka',
           'max.poll.interval.ms': 300_000,
+          'socket.nagle.disable': true,
           'client.software.version': [
             "v#{Karafka::VERSION}",
             "rdkafka-ruby-v#{Rdkafka::VERSION}",
@@ -79,7 +81,8 @@ RSpec.describe_current do
           'max.poll.interval.ms': 200_000,
           'client.software.version': 'custom_version',
           'allow.auto.create.topics': 'false',
-          'topic.metadata.refresh.interval.ms': 10_000
+          'topic.metadata.refresh.interval.ms': 10_000,
+          'socket.nagle.disable': true
         )
       end
     end
@@ -106,7 +109,8 @@ RSpec.describe_current do
       it 'adds producer kafka dev defaults' do
         expect(kafka_config).to include(
           'allow.auto.create.topics': 'true',
-          'topic.metadata.refresh.interval.ms': 5_000
+          'topic.metadata.refresh.interval.ms': 5_000,
+          'socket.nagle.disable': true
         )
       end
     end
@@ -127,7 +131,8 @@ RSpec.describe_current do
       it 'does not overwrite existing settings' do
         expect(kafka_config).to eq(
           'allow.auto.create.topics': 'false',
-          'topic.metadata.refresh.interval.ms': 10_000
+          'topic.metadata.refresh.interval.ms': 10_000,
+          'socket.nagle.disable': true
         )
       end
     end


### PR DESCRIPTION
Add socket.nagle.disable: true to consumer and producer defaults to improve network performance by reducing latency for small message batches.
