### PR TITLE
Replace pidfd with ppid check for orphan detection in swarm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [Enhancement] Include consumer group, subscription group and other details in error logs for key error locations.
 - [Enhancement] Inherit from `ActiveJob::QueueAdapters::AbstractAdapter` when possible for ActiveJob base class.
 - [Enhancement] Disable Nagle algorithm by default for improved network performance.
+- [Enhancement] Replace pidfd-based parent process check with simpler ppid check in swarm for cross-platform compatibility.
 - [Maintenance] Add basic direct DD integration spec via DD gem karafka monitoring feature.
 - [Fix] Fix incorrect (6 seconds vs 60 seconds) reset of connections on non-recoverable errors.
 - [Fix] Introduce mutex-safe and thread-safe `#inspect` where needed.

--- a/lib/karafka/swarm/node.rb
+++ b/lib/karafka/swarm/node.rb
@@ -45,7 +45,7 @@ module Karafka
       # @param parent_pid [Integer] parent pid for zombie fencing
       def initialize(id, parent_pid)
         @id = id
-        @parent_pidfd = Pidfd.new(parent_pid)
+        @parent_pid = parent_pid
       end
 
       # Starts a new fork and:
@@ -153,7 +153,7 @@ module Karafka
       # @return [Boolean] true if node is orphaned or false otherwise. Used for orphans detection.
       # @note Child API
       def orphaned?
-        !@parent_pidfd.alive?
+        ::Process.ppid != @parent_pid
       end
 
       # Sends sigterm to the node

--- a/spec/lib/karafka/swarm/node_spec.rb
+++ b/spec/lib/karafka/swarm/node_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe Karafka::Swarm::Node, mode: :fork do
   end
 
   describe '#orphaned?' do
+    subject(:node) { described_class.new(0, ::Process.ppid) }
+
     it { expect(node.orphaned?).to be(false) }
   end
 


### PR DESCRIPTION
Replaces the Linux-specific pidfd approach with a ppid (parent process ID) check for detecting orphaned swarm nodes. This change improves cross-platform compatibility (works on macOS, BSD, etc.) and reduces complexity while maintaining the same functionality. The ppid check is cheaper and more portable than maintaining file descriptors with pidfd.