### PR TITLE
Fix support URL in LICENSE-COMM

### DIFF
--- a/LICENSE-COMM
+++ b/LICENSE-COMM
@@ -32,7 +32,7 @@ The Open Source version of the Software (“LGPL Version”) is licensed under t
 
 5. Fees and Payment. The Software license fees will be due and payable in full as set forth in the applicable invoice or at the time of purchase. There are no refunds beyond the remedy refund.
 
-6. Support, Maintenance and Services. Subject to the terms and conditions of this Agreement, as set forth in your invoice, and as set forth on the Karafka Pro support page (https://github.com/karafka/karafka/wiki/Commercial-Support), support and maintenance services may be included with the purchase of your license subscription.
+6. Support, Maintenance and Services. Subject to the terms and conditions of this Agreement, as set forth in your invoice, and as set forth on the Karafka Pro support page (https://karafka.io/docs/Pro-Support/), support and maintenance services may be included with the purchase of your license subscription.
 
 7. Term of Agreement.
 


### PR DESCRIPTION
Updated the support and maintenance services URL in the license agreement.

Since we moved the wiki to karafka page we should point there for the appropriate terms