### PR TITLE
Update yard-lint to 1.3.0 and fix documentation offenses

### DIFF
--- a/.yard-lint.yml
+++ b/.yard-lint.yml
@@ -3,172 +3,274 @@
 
 # Global settings for all validators
 AllValidators:
-  # YARD command-line options (applied to all validators by default)
   YardOptions:
-    - --private
-    - --protected
-
-  # Global file exclusion patterns
+  - "--private"
+  - "--protected"
   Exclude:
-    - '\.git'
-    - 'vendor/**/*'
-    - 'node_modules/**/*'
-    - 'spec/**/*'
-    - 'test/**/*'
-
-  # Exit code behavior (error, warning, convention, never)
+  - "\\.git"
+  - vendor/**/*
+  - node_modules/**/*
+  - spec/**/*
+  - test/**/*
   FailOnSeverity: convention
-
-  # Minimum documentation coverage percentage (0-100)
-  # Fails if coverage is below this threshold
   MinCoverage: 99.0
-
-  # Diff mode settings
   DiffMode:
-    # Default base ref for --diff (auto-detects main/master if not specified)
-    DefaultBaseRef: ~
+    DefaultBaseRef:
 
 # Documentation validators
 Documentation/UndocumentedObjects:
-  Description: 'Checks for classes, modules, and methods without documentation.'
+  Description: Checks for classes, modules, and methods without documentation.
   Enabled: true
   Severity: error
   ExcludedMethods:
-    - 'initialize/0'  # Exclude parameter-less initialize
-    - '/^_/'          # Exclude private methods (by convention)
+  - initialize/0
+  - "/^_/"
 
 Documentation/UndocumentedMethodArguments:
-  Description: 'Checks for method parameters without @param tags.'
+  Description: Checks for method parameters without @param tags.
   Enabled: true
   Severity: error
 
 Documentation/UndocumentedBooleanMethods:
-  Description: 'Checks that question mark methods document their boolean return.'
+  Description: Checks that question mark methods document their boolean return.
   Enabled: true
   Severity: error
 
 Documentation/UndocumentedOptions:
-  Description: 'Detects methods with options hash parameters but no @option tags.'
+  Description: Detects methods with options hash parameters but no @option tags.
   Enabled: true
   Severity: error
 
 Documentation/MarkdownSyntax:
-  Description: 'Detects common markdown syntax errors in documentation.'
+  Description: Detects common markdown syntax errors in documentation.
   Enabled: true
   Severity: error
+
+Documentation/EmptyCommentLine:
+  Description: Detects empty comment lines at the start or end of documentation blocks.
+  Enabled: true
+  Severity: convention
+  EnabledPatterns:
+    Leading: true
+    Trailing: true
+
+Documentation/BlankLineBeforeDefinition:
+  Description: Detects blank lines between YARD documentation and method definition.
+  Enabled: true
+  Severity: convention
+  OrphanedSeverity: convention
+  EnabledPatterns:
+    SingleBlankLine: true
+    OrphanedDocs: true
 
 # Tags validators
 Tags/Order:
-  Description: 'Enforces consistent ordering of YARD tags.'
+  Description: Enforces consistent ordering of YARD tags.
   Enabled: true
   Severity: error
   EnforcedOrder:
-    - param
-    - option
-    - return
-    - raise
-    - example
+  - param
+  - option
+  - return
+  - raise
+  - example
 
 Tags/InvalidTypes:
-  Description: 'Validates type definitions in @param, @return, @option tags.'
+  Description: Validates type definitions in @param, @return, @option tags.
   Enabled: true
   Severity: error
   ValidatedTags:
-    - param
-    - option
-    - return
+  - param
+  - option
+  - return
 
 Tags/TypeSyntax:
-  Description: 'Validates YARD type syntax using YARD parser.'
+  Description: Validates YARD type syntax using YARD parser.
   Enabled: true
   Severity: error
   ValidatedTags:
-    - param
-    - option
-    - return
-    - yieldreturn
+  - param
+  - option
+  - return
+  - yieldreturn
 
 Tags/MeaninglessTag:
-  Description: 'Detects @param/@option tags on classes, modules, or constants.'
+  Description: Detects @param/@option tags on classes, modules, or constants.
   Enabled: true
   Severity: error
   CheckedTags:
-    - param
-    - option
+  - param
+  - option
   InvalidObjectTypes:
-    - class
-    - module
-    - constant
+  - class
+  - module
+  - constant
 
 Tags/CollectionType:
-  Description: 'Validates Hash collection syntax consistency.'
+  Description: Validates Hash collection syntax consistency.
   Enabled: true
   Severity: error
-  EnforcedStyle: long  # 'long' for Hash{K => V} (YARD standard), 'short' for {K => V}
+  EnforcedStyle: long
   ValidatedTags:
-    - param
-    - option
-    - return
-    - yieldreturn
+  - param
+  - option
+  - return
+  - yieldreturn
 
 Tags/TagTypePosition:
-  Description: 'Validates type annotation position in tags.'
+  Description: Validates type annotation position in tags.
   Enabled: true
   Severity: error
   CheckedTags:
-    - param
-    - option
-  # EnforcedStyle: 'type_after_name' (YARD standard: @param name [Type])
-  #                or 'type_first' (@param [Type] name)
+  - param
+  - option
   EnforcedStyle: type_after_name
 
 Tags/ApiTags:
-  Description: 'Enforces @api tags on public objects.'
-  Enabled: false  # Opt-in validator
+  Description: Enforces @api tags on public objects.
+  Enabled: false
   Severity: error
   AllowedApis:
-    - public
-    - private
-    - internal
+  - public
+  - private
+  - internal
 
 Tags/OptionTags:
-  Description: 'Requires @option tags for methods with options parameters.'
+  Description: Requires @option tags for methods with options parameters.
   Enabled: true
   Severity: error
 
+Tags/ExampleSyntax:
+  Description: Validates Ruby syntax in @example tags.
+  Enabled: true
+  Severity: warning
+
+Tags/RedundantParamDescription:
+  Description: Detects meaningless parameter descriptions that add no value.
+  Enabled: true
+  Severity: convention
+  CheckedTags:
+  - param
+  - option
+  Articles:
+  - The
+  - the
+  - A
+  - a
+  - An
+  - an
+  MaxRedundantWords: 6
+  GenericTerms:
+  - object
+  - instance
+  - value
+  - data
+  - item
+  - element
+  EnabledPatterns:
+    ArticleParam: true
+    PossessiveParam: true
+    TypeRestatement: true
+    ParamToVerb: true
+    IdPattern: true
+    DirectionalDate: true
+    TypeGeneric: true
+
+Tags/InformalNotation:
+  Description: Detects informal tag notation patterns like "Note:" instead of @note.
+  Enabled: true
+  Severity: warning
+  CaseSensitive: false
+  RequireStartOfLine: true
+  Patterns:
+    Note: "@note"
+    Todo: "@todo"
+    TODO: "@todo"
+    FIXME: "@todo"
+    See: "@see"
+    See also: "@see"
+    Warning: "@deprecated"
+    Deprecated: "@deprecated"
+    Author: "@author"
+    Version: "@version"
+    Since: "@since"
+    Returns: "@return"
+    Raises: "@raise"
+    Example: "@example"
+
+Tags/NonAsciiType:
+  Description: Detects non-ASCII characters in type annotations.
+  Enabled: true
+  Severity: warning
+  ValidatedTags:
+  - param
+  - option
+  - return
+  - yieldreturn
+  - yieldparam
+
+Tags/TagGroupSeparator:
+  Description: Enforces blank line separators between different YARD tag groups.
+  Enabled: false
+  Severity: convention
+  TagGroups:
+    param:
+    - param
+    - option
+    return:
+    - return
+    error:
+    - raise
+    - throws
+    example:
+    - example
+    meta:
+    - see
+    - note
+    - todo
+    - deprecated
+    - since
+    - version
+    - api
+    yield:
+    - yield
+    - yieldparam
+    - yieldreturn
+  RequireAfterDescription: false
+
 # Warnings validators - catches YARD parser errors
 Warnings/UnknownTag:
-  Description: 'Detects unknown YARD tags.'
+  Description: Detects unknown YARD tags.
   Enabled: true
   Severity: error
 
 Warnings/UnknownDirective:
-  Description: 'Detects unknown YARD directives.'
+  Description: Detects unknown YARD directives.
   Enabled: true
   Severity: error
 
 Warnings/InvalidTagFormat:
-  Description: 'Detects malformed tag syntax.'
+  Description: Detects malformed tag syntax.
   Enabled: true
   Severity: error
 
 Warnings/InvalidDirectiveFormat:
-  Description: 'Detects malformed directive syntax.'
+  Description: Detects malformed directive syntax.
   Enabled: true
   Severity: error
 
 Warnings/DuplicatedParameterName:
-  Description: 'Detects duplicate @param tags.'
+  Description: Detects duplicate @param tags.
   Enabled: true
   Severity: error
 
 Warnings/UnknownParameterName:
-  Description: 'Detects @param tags for non-existent parameters.'
+  Description: Detects @param tags for non-existent parameters.
   Enabled: true
   Severity: error
 
 # Semantic validators
 Semantic/AbstractMethods:
-  Description: 'Ensures @abstract methods do not have real implementations.'
+  Description: Ensures @abstract methods do not have real implementations.
   Enabled: true
   Severity: error

--- a/Gemfile
+++ b/Gemfile
@@ -25,5 +25,5 @@ group :test do
   gem 'factory_bot'
   gem 'ostruct'
   gem 'simplecov'
-  gem 'yard-lint'
+  gem 'yard-lint', '>= 1.3.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
       karafka-rdkafka (>= 0.23.1)
       zeitwerk (~> 2.3)
     yard (0.9.37)
-    yard-lint (1.2.3)
+    yard-lint (1.3.0)
       yard (~> 0.9)
       zeitwerk (~> 2.6)
     zeitwerk (2.7.3)
@@ -171,7 +171,7 @@ DEPENDENCIES
   simplecov
   stringio
   warning
-  yard-lint
+  yard-lint (>= 1.3.0)
 
 BUNDLED WITH
    2.7.1

--- a/lib/karafka/instrumentation/logger_listener.rb
+++ b/lib/karafka/instrumentation/logger_listener.rb
@@ -24,8 +24,6 @@ module Karafka
         @log_polling = log_polling
       end
 
-      #
-      #
       # @param event [Karafka::Core::Monitoring::Event] event details including payload
       def on_connection_listener_before_fetch_loop(event)
         listener_id = event[:caller].id

--- a/lib/karafka/pro/cleaner/messages/messages.rb
+++ b/lib/karafka/pro/cleaner/messages/messages.rb
@@ -13,7 +13,7 @@ module Karafka
         # This module is prepended to Karafka::Messages::Messages to add cleaning functionality.
         # The implementation calls super() to maintain compatibility with other libraries that
         # also prepend modules to modify the #each method (e.g., DataDog tracing).
-        # See: https://github.com/DataDog/dd-trace-rb/issues/4867
+        # @see https://github.com/DataDog/dd-trace-rb/issues/4867
         module Messages
           # @param clean [Boolean] do we want to clean each message after we're done working with
           #   it.

--- a/lib/karafka/pro/processing/jobs_queue.rb
+++ b/lib/karafka/pro/processing/jobs_queue.rb
@@ -101,10 +101,8 @@ module Karafka
         end
 
         # Allows for explicit unlocking of locked queue of a group
-        #
         # @param group_id [String] id of the group we want to unlock
         # @param lock_id [Object] unique id we want to use to identify our lock
-        #
         def unlock_async(group_id, lock_id)
           @mutex.synchronize do
             if @locks[group_id].delete(lock_id)


### PR DESCRIPTION
## Summary
- Bump yard-lint from 1.2.3 to 1.3.0
- Update `.yard-lint.yml` with 7 new validators using `yard-lint --update`
- Fix 4 documentation offenses detected by the new version:
  - Remove empty leading comment lines in `LoggerListener`
  - Remove empty trailing comment line in `JobsQueue`
  - Replace informal `See:` notation with proper `@see` tag in `Messages`

## Test plan
- [x] `bundle exec yard-lint lib/` passes with no offenses