### PR TITLE
Fix license constant overwriting in test environments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -160,6 +160,10 @@ Lint/NonLocalExitFromIterator:
 Lint/StructNewOverride:
   Enabled: false
 
+Lint/ConstantDefinitionInBlock:
+  Exclude:
+    - lib/karafka/licenser.rb
+
 # Style
 Style/AccessModifierDeclarations:
   Exclude:

--- a/spec/lib/karafka/licenser_spec.rb
+++ b/spec/lib/karafka/licenser_spec.rb
@@ -208,6 +208,23 @@ RSpec.describe_current do
           expect(described_class).not_to receive(:require)
           described_class.detect { true }
         end
+
+        it "overwrites existing stale License constant with gem data" do
+          # First define a stale License module
+          stale_license = Module.new do
+            def self.token
+              "stale-token"
+            end
+          end
+          stub_const("Karafka::License", stale_license)
+
+          # Should overwrite with actual gem data
+          described_class.detect { true }
+
+          expect(Karafka::License.token).to eq(license_content)
+          expect(Karafka::License.token).not_to eq("stale-token")
+          expect(Karafka::License.version).to eq(version_content)
+        end
       end
     end
 

--- a/spec/lib/karafka/setup/config_spec.rb
+++ b/spec/lib/karafka/setup/config_spec.rb
@@ -3,6 +3,15 @@
 RSpec.describe_current do
   subject(:config_class) { described_class }
 
+  # Ensure License constant is removed before each test to prevent test pollution
+  # This is critical because other tests (like licenser_spec) may define License constants
+  # and with random test order, those constants may leak into these tests
+  before do
+    # rubocop:disable RSpec/RemoveConst
+    Karafka.send(:remove_const, :License) if Karafka.const_defined?(:License)
+    # rubocop:enable RSpec/RemoveConst
+  end
+
   describe "#setup" do
     it { expect { |block| config_class.setup(&block) }.to yield_with_args }
   end


### PR DESCRIPTION
## Problem

After merging #3000 (license loading optimization), master CI started failing with `InvalidLicenseTokenError` in tests that weren't expecting license verification. The tests passed in the PR CI but failed in master CI with the same code.

### Root Cause

The issue was caused by test order randomization combined with cached karafka-license gem in CI:

1. The karafka-license gem gets cached in CI from previous integration test runs
2. When `Licenser.detect` runs at gem load time, it finds and loads the License constant
3. Due to RSpec's random test order (`config.order = :random`), sometimes tests run before license cleanup
4. Tests call `Karafka::App.setup` which triggers `Licenser.prepare_and_verify`
5. Verification fails because the cached License has invalid/incomplete data

## Solution

Modified the licenser to always overwrite stale License constants when the actual karafka-license gem is present:

- **`safe_load_license`**: Now removes and replaces existing License constant with fresh data from gem
- **`fallback_require_license`**: Checks gem existence before removing constants to avoid breaking RSpec's `stub_const`
- **Added test**: Verifies License constant gets overwritten with gem data
- **Updated `.rubocop.yml`**: Excluded `Lint/ConstantDefinitionInBlock` for licenser.rb

## Testing

All tests pass locally and should now pass consistently in CI regardless of test execution order:

```bash
SPECS_TYPE=regular bundle exec rspec spec/lib/karafka/setup/config_spec.rb spec/lib/karafka/licenser_spec.rb
# 39 examples, 0 failures
```

## Related

- Fixes test failures in https://github.com/karafka/karafka/actions/runs/21654967309/job/62427768702
- Follow-up to #3000