### PR TITLE
test: add integration test for Datadog metric exclusion pattern

### DIFF
--- a/spec/integrations/instrumentation/vendors/datadog/with_excluded_librdkafka_metrics_spec.rb
+++ b/spec/integrations/instrumentation/vendors/datadog/with_excluded_librdkafka_metrics_spec.rb
@@ -110,7 +110,7 @@ end
 
 # Network latency p95 should be present (NOT excluded)
 assert_equal true, statsd_dummy.buffer[:gauge].key?("karafka.network.latency.p95"),
-             "network.latency.p95 should be present (not excluded)"
+  "network.latency.p95 should be present (not excluded)"
 
 # Excluded network latency metrics should NOT be present
 %w[
@@ -118,7 +118,7 @@ assert_equal true, statsd_dummy.buffer[:gauge].key?("karafka.network.latency.p95
   karafka.network.latency.p99
 ].each do |gauge_key|
   assert_equal false, statsd_dummy.buffer[:gauge].key?(gauge_key),
-               "#{gauge_key} should be excluded"
+    "#{gauge_key} should be excluded"
 end
 
 # Excluded connection metrics should NOT be present
@@ -127,7 +127,7 @@ end
   karafka.connection.disconnects
 ].each do |count_key|
   assert_equal false, statsd_dummy.buffer[:count].key?(count_key),
-               "#{count_key} should be excluded"
+    "#{count_key} should be excluded"
 end
 
 # Non-excluded broker-level error metrics should still be present


### PR DESCRIPTION
## Summary

Adds an integration test for the `CustomDatadogListener` pattern documented in the wiki that allows excluding specific Datadog metrics without manually recreating the entire default metrics list.

## Changes

- New integration test: `spec/integrations/instrumentation/vendors/datadog/with_excluded_librdkafka_metrics_spec.rb`
- Tests the `exclude_rd_kafka_metrics` setting pattern
- Validates that excluded metrics are NOT published
- Validates that non-excluded metrics ARE published

## Test Coverage

The test verifies:

**Excluded metrics (should NOT be published):**
- `network.latency.avg`
- `network.latency.p99`
- `connection.connects`
- `connection.disconnects`

**Non-excluded metrics (SHOULD be published):**
- `network.latency.p95` (keeping this percentile)
- `consumer.lags` and `consumer.lags_delta`
- `messages.consumed` and `messages.consumed.bytes`
- All broker error metrics (`consume.attempts`, `consume.errors`, `receive.errors`)
- All standard application metrics (worker, consumer, etc.)

## Motivation

This validates the cost-reduction strategy where users want to exclude specific high-cardinality metrics (like certain network latency percentiles) while keeping most default observability. The pattern doesn't require any Karafka core changes - users extend the listener in their own codebase.

## Related

- Wiki documentation: Operations/Monitoring-and-Logging.md (will be updated after this PR passes)
- Addresses use case from Slack where users want to exclude specific percentiles without listing all metrics manually