### PR TITLE
Add integration test for custom DataDog listener with overridden methods

### DIFF
--- a/spec/integrations/instrumentation/vendors/datadog/custom_listener_with_overridden_methods_spec.rb
+++ b/spec/integrations/instrumentation/vendors/datadog/custom_listener_with_overridden_methods_spec.rb
@@ -27,7 +27,8 @@ end
 
 # Custom listener that mimics the user's MinimalDatadogListener pattern
 # Overrides several methods to suppress metrics we don't care about
-# but does NOT override on_statistics_emitted
+# and overrides on_statistics_emitted only to add tracking for test verification,
+# while delegating to the parent implementation via `super`.
 class MinimalDatadogListener < Karafka::Instrumentation::Vendors::Datadog::MetricsListener
   # Track that on_statistics_emitted was actually called (for verification)
   def on_statistics_emitted(event)


### PR DESCRIPTION
## Summary

- Adds integration test verifying `statistics.emitted` events are properly propagated to custom listeners inheriting from `MetricsListener`
- Tests the pattern where users override some event handlers with no-ops to reduce metrics cost
- Confirms that overriding methods like `on_worker_process`, `on_consumer_revoked`, etc. doesn't break `on_statistics_emitted`

This test was created in response to a user report about `statistics.emitted` not being called with a custom listener. The test confirms the event propagation works correctly, suggesting issues in such cases are likely related to listener subscription timing or configuration.

## Test plan

- [x] Run `ruby bin/integrations datadog` - all 11 tests pass
- [x] New test verifies:
  - `on_statistics_emitted` is called multiple times
  - Statistics-derived metrics (`messages.consumed`, `consumer.lags`, etc.) are published
  - Overridden no-op methods suppress their respective metrics
  - Non-overridden methods (`on_consumer_consumed`) continue working