### PR TITLE
Add test showing empty rd_kafka_metrics produces no statistics metrics

### DIFF
--- a/spec/integrations/instrumentation/vendors/datadog/custom_listener_with_empty_rd_kafka_metrics_spec.rb
+++ b/spec/integrations/instrumentation/vendors/datadog/custom_listener_with_empty_rd_kafka_metrics_spec.rb
@@ -139,6 +139,13 @@ end
 end
 
 %w[
+  karafka.consumer.offset
+].each do |gauge_key|
+  assert_equal true, statsd_dummy.buffer[:gauge].key?(gauge_key),
+    "#{gauge_key} should be present - on_consumer_consumed doesn't depend on rd_kafka_metrics"
+end
+
+%w[
   karafka.consumer.consumed.time_taken
   karafka.consumer.batch_size
   karafka.consumer.processing_lag


### PR DESCRIPTION
## Summary

- Adds integration test demonstrating that when `rd_kafka_metrics = []`, `on_statistics_emitted` is still called but no statistics-derived metrics are published
- This helps diagnose user issues where statistics metrics are missing due to configuration rather than event propagation problems

This test was created to help debug a user-reported issue where they weren't seeing statistics metrics in DataDog. The root cause was setting `rd_kafka_metrics = []` in their listener configuration.

## Test plan

- [x] Run locally: `ruby bin/integrations custom_listener_with_empty_rd_kafka_metrics_spec.rb` passes
- [x] Verifies `on_statistics_emitted` IS called (event propagation works)
- [x] Verifies NO statistics metrics are published when `rd_kafka_metrics = []`
- [x] Verifies non-statistics metrics (from `on_consumer_consumed`) still work