### PR TITLE
Add docker-compose files to Renovate includePaths

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,8 @@
     "Gemfile.lint",
     "karafka.gemspec",
     "package.json",
-    ".github/workflows/**"
+    ".github/workflows/**",
+    "docker-compose*.yml"
   ],
   "ignorePaths": [
     "spec/integrations"


### PR DESCRIPTION
## Summary
- Adds `docker-compose*.yml` pattern to Renovate's `includePaths` configuration
- Enables automatic dependency updates for Docker images defined in compose files
- Docker Compose files (docker-compose.yml, docker-compose.multi-broker.yml) were previously excluded from Renovate scanning due to the allowlist nature of `includePaths`