### PR TITLE
chore(deps): add dependencies label to Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,5 +29,8 @@
       ],
       "groupName": "ruby setup"
     }
+  ],
+  "labels": [
+    "dependencies"
   ]
 }


### PR DESCRIPTION
Adds `dependencies` label to all Renovate PRs for better filtering and organization.

This makes the Renovate config consistent across all repositories.