### PR TITLE
Remove Coditsu references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,9 +16,7 @@ Any code change should be submitted as a pull request. The description should ex
 
 ### Code review process
 
-Each pull request must pass all the rspec specs and meet our quality requirements.
-
-To check if everything is as it should be, we use [Coditsu](https://coditsu.io) that combines multiple linters and code analyzers for both code and documentation. Once you're done with your changes, submit a pull request.
+Each pull request must pass all the rspec specs and meet our quality requirements. Once you're done with your changes, submit a pull request.
 
 ### Contributing to Pro components
 

--- a/spec/lib/karafka/instrumentation/vendors/appsignal/client_spec.rb
+++ b/spec/lib/karafka/instrumentation/vendors/appsignal/client_spec.rb
@@ -1,4 +1,3 @@
 # frozen_string_literal: true
 
-# Placeholder for Coditsu
-# This is covered in the integration suite
+# Covered in the integration suite.

--- a/spec/lib/karafka/pro/routing/features/recurring_tasks/proxy_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/recurring_tasks/proxy_spec.rb
@@ -20,4 +20,4 @@
 # License: https://karafka.io/docs/Pro-License-Comm/
 # Contact: contact@karafka.io
 
-# Placeholder for Coditsu. Checked in integrations.
+# Checked in integrations.

--- a/spec/lib/karafka/pro/routing/features/scheduled_messages/proxy_spec.rb
+++ b/spec/lib/karafka/pro/routing/features/scheduled_messages/proxy_spec.rb
@@ -20,4 +20,4 @@
 # License: https://karafka.io/docs/Pro-License-Comm/
 # Contact: contact@karafka.io
 
-# Placeholder for Coditsu. Checked in integrations.
+# Checked in integrations.

--- a/spec/lib/karafka/routing/features/active_job/proxy_spec.rb
+++ b/spec/lib/karafka/routing/features/active_job/proxy_spec.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-# Placeholder for Coditsu. Checked in integrations.
+# Checked in integrations.


### PR DESCRIPTION
## Summary
- Remove Coditsu references from CONTRIBUTING.md and spec files
- Coditsu is no longer used for code quality checks