### PR TITLE
Add batch-level clean! method to Cleaner::Messages

### DIFF
--- a/lib/karafka/pro/cleaner/messages/messages.rb
+++ b/lib/karafka/pro/cleaner/messages/messages.rb
@@ -53,6 +53,16 @@ module Karafka
               super(&)
             end
           end
+
+          # Cleans all messages in the batch
+          #
+          # @param metadata [Boolean] should we also clean metadata alongside the payload for
+          #   each message. `true` by default.
+          #
+          # @note This is a convenience method that calls `clean!` on each message in the batch.
+          def clean!(metadata: true)
+            each { |message| message.clean!(metadata: metadata) }
+          end
         end
       end
     end

--- a/spec/lib/karafka/pro/cleaner/messages/messages_spec.rb
+++ b/spec/lib/karafka/pro/cleaner/messages/messages_spec.rb
@@ -150,4 +150,34 @@ RSpec.describe_current do
       end
     end
   end
+
+  describe "#clean!" do
+    context "when called with default metadata: true" do
+      before { messages.clean! }
+
+      it "expect to have all messages cleaned" do
+        expect(message1.cleaned?).to be(true)
+        expect(message2.cleaned?).to be(true)
+      end
+
+      it "expect to have all messages metadata cleaned" do
+        expect(message1.metadata.cleaned?).to be(true)
+        expect(message2.metadata.cleaned?).to be(true)
+      end
+    end
+
+    context "when called with metadata: false" do
+      before { messages.clean!(metadata: false) }
+
+      it "expect to have all messages cleaned" do
+        expect(message1.cleaned?).to be(true)
+        expect(message2.cleaned?).to be(true)
+      end
+
+      it "expect not to have messages metadata cleaned" do
+        expect(message1.metadata.cleaned?).to be(false)
+        expect(message2.metadata.cleaned?).to be(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
close https://github.com/karafka/karafka/issues/3024

## Summary
- Adds a convenience `clean!` method on `Messages` to clean all messages in a batch at once
- Delegates to each message's `clean!` method with `metadata` flag support (defaults to `true`)
- Includes specs for both `metadata: true` and `metadata: false` scenarios

## Test plan
- [x] Unit tests added for `#clean!` with default metadata cleaning
- [x] Unit tests added for `#clean!` with metadata: false