### PR TITLE
fix: resume partition after handle_post_filtering :skip in LRJ strategies

### DIFF
--- a/lib/karafka/pro/processing/strategies/aj/dlq_ftr_lrj_mom.rb
+++ b/lib/karafka/pro/processing/strategies/aj/dlq_ftr_lrj_mom.rb
@@ -52,6 +52,11 @@ module Karafka
 
                   if coordinator.filtered? && !revoked?
                     handle_post_filtering
+
+                    # handle_post_filtering may pause (throttle) or seek+resume on its own,
+                    # but when the filter action is :skip, the LRJ pause is still active and
+                    # must be lifted explicitly to avoid a permanent partition freeze.
+                    resume if coordinator.filter.action == :skip
                   elsif !revoked?
                     # no need to check for manual seek because AJ consumer is internal and
                     # fully controlled by us

--- a/lib/karafka/pro/processing/strategies/aj/dlq_ftr_lrj_mom_vp.rb
+++ b/lib/karafka/pro/processing/strategies/aj/dlq_ftr_lrj_mom_vp.rb
@@ -58,6 +58,11 @@ module Karafka
 
                   if coordinator.filtered? && !revoked?
                     handle_post_filtering
+
+                    # handle_post_filtering may pause (throttle) or seek+resume on its own,
+                    # but when the filter action is :skip, the LRJ pause is still active and
+                    # must be lifted explicitly to avoid a permanent partition freeze.
+                    resume if coordinator.filter.action == :skip
                   elsif !revoked?
                     # no need to check for manual seek because AJ consumer is internal and
                     # fully controlled by us

--- a/lib/karafka/pro/processing/strategies/aj/ftr_lrj_mom_vp.rb
+++ b/lib/karafka/pro/processing/strategies/aj/ftr_lrj_mom_vp.rb
@@ -54,6 +54,11 @@ module Karafka
 
                   if coordinator.filtered? && !revoked?
                     handle_post_filtering
+
+                    # handle_post_filtering may pause (throttle) or seek+resume on its own,
+                    # but when the filter action is :skip, the LRJ pause is still active and
+                    # must be lifted explicitly to avoid a permanent partition freeze.
+                    resume if coordinator.filter.action == :skip
                   elsif !revoked?
                     # no need to check for manual seek because AJ consumer is internal and
                     # fully controlled by us

--- a/lib/karafka/pro/processing/strategies/dlq/ftr_lrj.rb
+++ b/lib/karafka/pro/processing/strategies/dlq/ftr_lrj.rb
@@ -56,6 +56,11 @@ module Karafka
 
                   if coordinator.filtered? && !revoked?
                     handle_post_filtering
+
+                    # handle_post_filtering may pause (throttle) or seek+resume on its own,
+                    # but when the filter action is :skip, the LRJ pause is still active and
+                    # must be lifted explicitly to avoid a permanent partition freeze.
+                    resume if coordinator.filter.action == :skip
                   elsif !revoked? && !coordinator.manual_seek?
                     seek(seek_offset, false, reset_offset: false)
                     resume

--- a/lib/karafka/pro/processing/strategies/dlq/ftr_lrj_mom.rb
+++ b/lib/karafka/pro/processing/strategies/dlq/ftr_lrj_mom.rb
@@ -51,6 +51,11 @@ module Karafka
 
                   if coordinator.filtered? && !revoked?
                     handle_post_filtering
+
+                    # handle_post_filtering may pause (throttle) or seek+resume on its own,
+                    # but when the filter action is :skip, the LRJ pause is still active and
+                    # must be lifted explicitly to avoid a permanent partition freeze.
+                    resume if coordinator.filter.action == :skip
                   elsif !revoked? && !coordinator.manual_seek?
                     seek(last_group_message.offset + 1, false, reset_offset: false)
                     resume

--- a/lib/karafka/pro/processing/strategies/lrj/ftr.rb
+++ b/lib/karafka/pro/processing/strategies/lrj/ftr.rb
@@ -54,6 +54,11 @@ module Karafka
                   # If still not revoked and was throttled, we need to apply throttling logic
                   if coordinator.filtered? && !revoked?
                     handle_post_filtering
+
+                    # handle_post_filtering may pause (throttle) or seek+resume on its own,
+                    # but when the filter action is :skip, the LRJ pause is still active and
+                    # must be lifted explicitly to avoid a permanent partition freeze.
+                    resume if coordinator.filter.action == :skip
                   elsif !revoked? && !coordinator.manual_seek?
                     # If not revoked and not throttled, we move to where we were suppose to and
                     # resume

--- a/lib/karafka/pro/processing/strategies/lrj/ftr_mom.rb
+++ b/lib/karafka/pro/processing/strategies/lrj/ftr_mom.rb
@@ -52,6 +52,11 @@ module Karafka
                   # If still not revoked and was throttled, we need to apply filtering logic
                   if coordinator.filtered? && !revoked?
                     handle_post_filtering
+
+                    # handle_post_filtering may pause (throttle) or seek+resume on its own,
+                    # but when the filter action is :skip, the LRJ pause is still active and
+                    # must be lifted explicitly to avoid a permanent partition freeze.
+                    resume if coordinator.filter.action == :skip
                   elsif !revoked? && !coordinator.manual_seek?
                     # If not revoked and not throttled, we move to where we were suppose to and
                     # resume


### PR DESCRIPTION
## Summary

When a custom filter removes messages but uses the default `:skip` action (via `Karafka::Pro::Processing::Filters::Base`), LRJ strategies never call `resume()` after `handle_post_filtering`, leaving the partition paused for `MAX_PAUSE_TIME` (~31,709 years).

**Root cause:** LRJ pauses the partition for `MAX_PAUSE_TIME` in `handle_before_schedule_consume`. After consumption, if a filter is applied, the strategy calls `handle_post_filtering`. For the `:skip` action, `handle_post_filtering` returns `nil` without calling `resume()`. Since LRJ strategies don't have a fallback `resume()` on this code path (unlike the `elsif !revoked?` branch), the partition stays paused indefinitely.

**Kill chain:**
1. LRJ pauses partition for `MAX_PAUSE_TIME` (1,000,000,000,000 ms ≈ 31,709 years)
2. Filter's `apply!` removes duplicate messages and sets `@applied = true`
3. `coordinator.filtered?` returns `true`, routing to `handle_post_filtering`
4. `handle_post_filtering` checks `filter.action` → `:skip` (default from `Filters::Base`)
5. `:skip` branch returns `nil` — no `seek()`, no `resume()`
6. Partition remains paused forever

**Fix:** After `handle_post_filtering`, explicitly call `resume` when the filter action is `:skip`. This is safe because:
- `:seek` already calls `resume()` inside `handle_post_filtering`
- `:pause` intentionally re-pauses (throttling), so no resume needed
- `:skip` is the only action that leaves the LRJ pause active with no way to lift it

This also affects the built-in `Expirer` filter which sets `@applied = true` and inherits the default `:skip` action.

## Affected files (7 strategies)

- `lrj/ftr.rb`
- `lrj/ftr_mom.rb`
- `dlq/ftr_lrj.rb`
- `dlq/ftr_lrj_mom.rb`
- `aj/ftr_lrj_mom_vp.rb`
- `aj/dlq_ftr_lrj_mom.rb`
- `aj/dlq_ftr_lrj_mom_vp.rb`

Plus 5 additional strategies that inherit the bug via module inclusion:
- `dlq/ftr_lrj_mom_vp.rb` (includes `dlq/ftr_lrj_mom`)
- `dlq/ftr_lrj_vp.rb` (includes `dlq/ftr_lrj`)
- `aj/ftr_lrj_mom.rb` (includes `lrj/ftr_mom`)
- `aj/dlq_ftr_lrj.rb` (includes `dlq/ftr_lrj`)
- `aj/dlq_ftr_lrj_vp.rb` (includes `dlq/ftr_lrj`)

Fixes #3029