### PR TITLE
Fix LRJ partition freeze when filter action is :skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Enhancement] Optimize license loading process by reading license files directly from the gem directory instead of requiring the entire gem, reducing initialization overhead and adding support for user-defined License modules.
 - [Change] Migrate Admin `AbstractHandle#wait` calls from deprecated `max_wait_timeout` (seconds) to `max_wait_timeout_ms` (milliseconds) to align with `karafka-rdkafka` `0.24.0`.
 - [Change] Require `karafka-rdkafka` `>=` `0.24.0` to support the new `max_wait_timeout_ms` API.
+- [Fix] Fix LRJ partition freeze when filter returns `applied? true` with `action :skip`, causing partition to remain paused for ~31,709 years instead of resuming after processing.
 
 ## 2.5.5 (2026-01-24)
 - [Feature] Add multi-cluster Admin support via `Karafka::Admin.new(kafka: { ... })` allowing operations against different Kafka clusters while maintaining backward compatibility with existing class-method API.

--- a/lib/karafka/pro/processing/strategies/aj/dlq_ftr_lrj_mom.rb
+++ b/lib/karafka/pro/processing/strategies/aj/dlq_ftr_lrj_mom.rb
@@ -52,14 +52,17 @@ module Karafka
 
                   if coordinator.filtered? && !revoked?
                     handle_post_filtering
+
+                    # :seek and :pause are fully handled by handle_post_filtering
+                    # For :skip we still need to resume the LRJ MAX_PAUSE_TIME pause
+                    return unless coordinator.filter.action == :skip
                   elsif !revoked?
                     # no need to check for manual seek because AJ consumer is internal and
                     # fully controlled by us
                     seek(seek_offset, false, reset_offset: false)
-                    resume
-                  else
-                    resume
                   end
+
+                  resume
                 else
                   apply_dlq_flow do
                     skippable_message, = find_skippable_message

--- a/lib/karafka/pro/processing/strategies/aj/dlq_ftr_lrj_mom_vp.rb
+++ b/lib/karafka/pro/processing/strategies/aj/dlq_ftr_lrj_mom_vp.rb
@@ -58,14 +58,17 @@ module Karafka
 
                   if coordinator.filtered? && !revoked?
                     handle_post_filtering
+
+                    # :seek and :pause are fully handled by handle_post_filtering
+                    # For :skip we still need to resume the LRJ MAX_PAUSE_TIME pause
+                    return unless coordinator.filter.action == :skip
                   elsif !revoked?
                     # no need to check for manual seek because AJ consumer is internal and
                     # fully controlled by us
                     seek(seek_offset, false, reset_offset: false)
-                    resume
-                  else
-                    resume
                   end
+
+                  resume
                 else
                   apply_dlq_flow do
                     skippable_message, = find_skippable_message

--- a/lib/karafka/pro/processing/strategies/aj/ftr_lrj_mom_vp.rb
+++ b/lib/karafka/pro/processing/strategies/aj/ftr_lrj_mom_vp.rb
@@ -54,14 +54,17 @@ module Karafka
 
                   if coordinator.filtered? && !revoked?
                     handle_post_filtering
+
+                    # :seek and :pause are fully handled by handle_post_filtering
+                    # For :skip we still need to resume the LRJ MAX_PAUSE_TIME pause
+                    return unless coordinator.filter.action == :skip
                   elsif !revoked?
                     # no need to check for manual seek because AJ consumer is internal and
                     # fully controlled by us
                     seek(seek_offset, false, reset_offset: false)
-                    resume
-                  else
-                    resume
                   end
+
+                  resume
                 else
                   retry_after_pause
                 end

--- a/lib/karafka/pro/processing/strategies/dlq/ftr_lrj.rb
+++ b/lib/karafka/pro/processing/strategies/dlq/ftr_lrj.rb
@@ -56,12 +56,15 @@ module Karafka
 
                   if coordinator.filtered? && !revoked?
                     handle_post_filtering
+
+                    # :seek and :pause are fully handled by handle_post_filtering
+                    # For :skip we still need to resume the LRJ MAX_PAUSE_TIME pause
+                    return unless coordinator.filter.action == :skip
                   elsif !revoked? && !coordinator.manual_seek?
                     seek(seek_offset, false, reset_offset: false)
-                    resume
-                  else
-                    resume
                   end
+
+                  resume
                 else
                   apply_dlq_flow do
                     return resume if revoked?

--- a/lib/karafka/pro/processing/strategies/dlq/ftr_lrj_mom.rb
+++ b/lib/karafka/pro/processing/strategies/dlq/ftr_lrj_mom.rb
@@ -51,12 +51,15 @@ module Karafka
 
                   if coordinator.filtered? && !revoked?
                     handle_post_filtering
+
+                    # :seek and :pause are fully handled by handle_post_filtering
+                    # For :skip we still need to resume the LRJ MAX_PAUSE_TIME pause
+                    return unless coordinator.filter.action == :skip
                   elsif !revoked? && !coordinator.manual_seek?
                     seek(last_group_message.offset + 1, false, reset_offset: false)
-                    resume
-                  else
-                    resume
                   end
+
+                  resume
                 else
                   apply_dlq_flow do
                     return resume if revoked?

--- a/lib/karafka/pro/processing/strategies/lrj/ftr.rb
+++ b/lib/karafka/pro/processing/strategies/lrj/ftr.rb
@@ -54,14 +54,17 @@ module Karafka
                   # If still not revoked and was throttled, we need to apply throttling logic
                   if coordinator.filtered? && !revoked?
                     handle_post_filtering
+
+                    # :seek and :pause are fully handled by handle_post_filtering
+                    # For :skip we still need to resume the LRJ MAX_PAUSE_TIME pause
+                    return unless coordinator.filter.action == :skip
                   elsif !revoked? && !coordinator.manual_seek?
                     # If not revoked and not throttled, we move to where we were suppose to and
                     # resume
                     seek(seek_offset, false, reset_offset: false)
-                    resume
-                  else
-                    resume
                   end
+
+                  resume
                 else
                   # If processing failed, we need to pause
                   # For long running job this will overwrite the default never-ending pause and

--- a/lib/karafka/pro/processing/strategies/lrj/ftr_mom.rb
+++ b/lib/karafka/pro/processing/strategies/lrj/ftr_mom.rb
@@ -52,14 +52,17 @@ module Karafka
                   # If still not revoked and was throttled, we need to apply filtering logic
                   if coordinator.filtered? && !revoked?
                     handle_post_filtering
+
+                    # :seek and :pause are fully handled by handle_post_filtering
+                    # For :skip we still need to resume the LRJ MAX_PAUSE_TIME pause
+                    return unless coordinator.filter.action == :skip
                   elsif !revoked? && !coordinator.manual_seek?
                     # If not revoked and not throttled, we move to where we were suppose to and
                     # resume
                     seek(last_group_message.offset + 1, false, reset_offset: false)
-                    resume
-                  else
-                    resume
                   end
+
+                  resume
                 else
                   # If processing failed, we need to pause
                   # For long running job this will overwrite the default never-ending pause and

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_lrj_mom/with_skip_filter_applied_not_freezing_partition_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_lrj_mom/with_skip_filter_applied_not_freezing_partition_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# Karafka Pro - Source Available Commercial Software
+# Copyright (c) 2017-present Maciej Mensfeld. All rights reserved.
+#
+# This software is NOT open source. It is source-available commercial software
+# requiring a paid license for use. It is NOT covered by LGPL.
+#
+# PROHIBITED:
+# - Use without a valid commercial license
+# - Redistribution, modification, or derivative works without authorization
+# - Use as training data for AI/ML models or inclusion in datasets
+# - Scraping, crawling, or automated collection for any purpose
+#
+# PERMITTED:
+# - Reading, referencing, and linking for personal or commercial use
+# - Runtime retrieval by AI assistants, coding agents, and RAG systems
+#   for the purpose of providing contextual help to Karafka users
+#
+# License: https://karafka.io/docs/Pro-License-Comm/
+# Contact: contact@karafka.io
+
+# When AJ + DLQ + FTR + LRJ + MoM are combined and a filter returns applied? true with action
+# :skip, the partition should NOT become permanently frozen.
+
+setup_active_job
+
+setup_karafka do |config|
+  config.max_messages = 5
+  config.kafka[:"max.poll.interval.ms"] = 10_000
+  config.kafka[:"session.timeout.ms"] = 10_000
+end
+
+class SkipFilter < Karafka::Pro::Processing::Filters::Base
+  def apply!(messages)
+    @applied = false
+    @cursor = nil
+
+    messages.delete_if do |message|
+      parsed = JSON.parse(message.raw_payload)
+      value = parsed["arguments"]&.first
+
+      if value.is_a?(Integer) && value.odd?
+        @applied = true
+        @cursor = message
+        true
+      else
+        false
+      end
+    rescue JSON::ParserError
+      false
+    end
+  end
+end
+
+class Job < ActiveJob::Base
+  queue_as DT.topic
+
+  def perform(value)
+    DT[:processed] << value
+  end
+end
+
+draw_routes do
+  active_job_topic DT.topic do
+    max_messages 5
+    long_running_job true
+    dead_letter_queue topic: DT.topics[1], max_retries: 4
+    filter ->(*) { SkipFilter.new }
+  end
+end
+
+20.times { |i| Job.perform_later(i) }
+
+start_karafka_and_wait_until do
+  DT[:processed].size >= 10
+end
+
+assert DT[:processed].size >= 10

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_lrj_mom_vp/with_skip_filter_applied_not_freezing_partition_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_lrj_mom_vp/with_skip_filter_applied_not_freezing_partition_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# Karafka Pro - Source Available Commercial Software
+# Copyright (c) 2017-present Maciej Mensfeld. All rights reserved.
+#
+# This software is NOT open source. It is source-available commercial software
+# requiring a paid license for use. It is NOT covered by LGPL.
+#
+# PROHIBITED:
+# - Use without a valid commercial license
+# - Redistribution, modification, or derivative works without authorization
+# - Use as training data for AI/ML models or inclusion in datasets
+# - Scraping, crawling, or automated collection for any purpose
+#
+# PERMITTED:
+# - Reading, referencing, and linking for personal or commercial use
+# - Runtime retrieval by AI assistants, coding agents, and RAG systems
+#   for the purpose of providing contextual help to Karafka users
+#
+# License: https://karafka.io/docs/Pro-License-Comm/
+# Contact: contact@karafka.io
+
+# When AJ + DLQ + FTR + LRJ + MoM + VP are combined and a filter returns applied? true with
+# action :skip, the partition should NOT become permanently frozen.
+
+setup_active_job
+
+setup_karafka do |config|
+  config.max_messages = 5
+  config.kafka[:"max.poll.interval.ms"] = 10_000
+  config.kafka[:"session.timeout.ms"] = 10_000
+end
+
+class SkipFilter < Karafka::Pro::Processing::Filters::Base
+  def apply!(messages)
+    @applied = false
+    @cursor = nil
+
+    messages.delete_if do |message|
+      parsed = JSON.parse(message.raw_payload)
+      value = parsed["arguments"]&.first
+
+      if value.is_a?(Integer) && value.odd?
+        @applied = true
+        @cursor = message
+        true
+      else
+        false
+      end
+    rescue JSON::ParserError
+      false
+    end
+  end
+end
+
+class Job < ActiveJob::Base
+  queue_as DT.topic
+
+  def perform(value)
+    DT[:processed] << value
+  end
+end
+
+draw_routes do
+  active_job_topic DT.topic do
+    max_messages 5
+    long_running_job true
+    dead_letter_queue topic: DT.topics[1], max_retries: 4
+    filter ->(*) { SkipFilter.new }
+    virtual_partitions(
+      partitioner: ->(_) { rand(2) }
+    )
+  end
+end
+
+20.times { |i| Job.perform_later(i) }
+
+start_karafka_and_wait_until do
+  DT[:processed].size >= 10
+end
+
+assert DT[:processed].size >= 10

--- a/spec/integrations/pro/consumption/strategies/aj/ftr_lrj_mom/with_skip_filter_applied_not_freezing_partition_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/ftr_lrj_mom/with_skip_filter_applied_not_freezing_partition_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# Karafka Pro - Source Available Commercial Software
+# Copyright (c) 2017-present Maciej Mensfeld. All rights reserved.
+#
+# This software is NOT open source. It is source-available commercial software
+# requiring a paid license for use. It is NOT covered by LGPL.
+#
+# PROHIBITED:
+# - Use without a valid commercial license
+# - Redistribution, modification, or derivative works without authorization
+# - Use as training data for AI/ML models or inclusion in datasets
+# - Scraping, crawling, or automated collection for any purpose
+#
+# PERMITTED:
+# - Reading, referencing, and linking for personal or commercial use
+# - Runtime retrieval by AI assistants, coding agents, and RAG systems
+#   for the purpose of providing contextual help to Karafka users
+#
+# License: https://karafka.io/docs/Pro-License-Comm/
+# Contact: contact@karafka.io
+
+# When AJ + FTR + LRJ + MoM are combined and a filter returns applied? true with action :skip,
+# the partition should NOT become permanently frozen.
+
+setup_active_job
+
+setup_karafka do |config|
+  config.max_messages = 5
+  config.kafka[:"max.poll.interval.ms"] = 10_000
+  config.kafka[:"session.timeout.ms"] = 10_000
+end
+
+class SkipFilter < Karafka::Pro::Processing::Filters::Base
+  def apply!(messages)
+    @applied = false
+    @cursor = nil
+
+    messages.delete_if do |message|
+      parsed = JSON.parse(message.raw_payload)
+      value = parsed["arguments"]&.first
+
+      if value.is_a?(Integer) && value.odd?
+        @applied = true
+        @cursor = message
+        true
+      else
+        false
+      end
+    rescue JSON::ParserError
+      false
+    end
+  end
+end
+
+class Job < ActiveJob::Base
+  queue_as DT.topic
+
+  def perform(value)
+    DT[:processed] << value
+  end
+end
+
+draw_routes do
+  active_job_topic DT.topic do
+    max_messages 5
+    long_running_job true
+    filter ->(*) { SkipFilter.new }
+  end
+end
+
+20.times { |i| Job.perform_later(i) }
+
+start_karafka_and_wait_until do
+  DT[:processed].size >= 10
+end
+
+assert DT[:processed].size >= 10

--- a/spec/integrations/pro/consumption/strategies/aj/ftr_lrj_mom_vp/with_skip_filter_applied_not_freezing_partition_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/ftr_lrj_mom_vp/with_skip_filter_applied_not_freezing_partition_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# Karafka Pro - Source Available Commercial Software
+# Copyright (c) 2017-present Maciej Mensfeld. All rights reserved.
+#
+# This software is NOT open source. It is source-available commercial software
+# requiring a paid license for use. It is NOT covered by LGPL.
+#
+# PROHIBITED:
+# - Use without a valid commercial license
+# - Redistribution, modification, or derivative works without authorization
+# - Use as training data for AI/ML models or inclusion in datasets
+# - Scraping, crawling, or automated collection for any purpose
+#
+# PERMITTED:
+# - Reading, referencing, and linking for personal or commercial use
+# - Runtime retrieval by AI assistants, coding agents, and RAG systems
+#   for the purpose of providing contextual help to Karafka users
+#
+# License: https://karafka.io/docs/Pro-License-Comm/
+# Contact: contact@karafka.io
+
+# When AJ + FTR + LRJ + MoM + VP are combined and a filter returns applied? true with action
+# :skip, the partition should NOT become permanently frozen.
+
+setup_active_job
+
+setup_karafka do |config|
+  config.max_messages = 5
+  config.kafka[:"max.poll.interval.ms"] = 10_000
+  config.kafka[:"session.timeout.ms"] = 10_000
+end
+
+class SkipFilter < Karafka::Pro::Processing::Filters::Base
+  def apply!(messages)
+    @applied = false
+    @cursor = nil
+
+    messages.delete_if do |message|
+      parsed = JSON.parse(message.raw_payload)
+      value = parsed["arguments"]&.first
+
+      if value.is_a?(Integer) && value.odd?
+        @applied = true
+        @cursor = message
+        true
+      else
+        false
+      end
+    rescue JSON::ParserError
+      false
+    end
+  end
+end
+
+class Job < ActiveJob::Base
+  queue_as DT.topic
+
+  def perform(value)
+    DT[:processed] << value
+  end
+end
+
+draw_routes do
+  active_job_topic DT.topic do
+    max_messages 5
+    long_running_job true
+    filter ->(*) { SkipFilter.new }
+    virtual_partitions(
+      partitioner: ->(_) { rand(2) }
+    )
+  end
+end
+
+20.times { |i| Job.perform_later(i) }
+
+start_karafka_and_wait_until do
+  DT[:processed].size >= 10
+end
+
+assert DT[:processed].size >= 10

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj/with_skip_filter_applied_not_freezing_partition_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj/with_skip_filter_applied_not_freezing_partition_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Karafka Pro - Source Available Commercial Software
+# Copyright (c) 2017-present Maciej Mensfeld. All rights reserved.
+#
+# This software is NOT open source. It is source-available commercial software
+# requiring a paid license for use. It is NOT covered by LGPL.
+#
+# PROHIBITED:
+# - Use without a valid commercial license
+# - Redistribution, modification, or derivative works without authorization
+# - Use as training data for AI/ML models or inclusion in datasets
+# - Scraping, crawling, or automated collection for any purpose
+#
+# PERMITTED:
+# - Reading, referencing, and linking for personal or commercial use
+# - Runtime retrieval by AI assistants, coding agents, and RAG systems
+#   for the purpose of providing contextual help to Karafka users
+#
+# License: https://karafka.io/docs/Pro-License-Comm/
+# Contact: contact@karafka.io
+
+# When DLQ + FTR + LRJ are combined and a filter returns applied? true with action :skip,
+# the partition should NOT become permanently frozen.
+
+setup_karafka do |config|
+  config.max_messages = 5
+  config.kafka[:"max.poll.interval.ms"] = 10_000
+  config.kafka[:"session.timeout.ms"] = 10_000
+end
+
+class SkipFilter < Karafka::Pro::Processing::Filters::Base
+  def apply!(messages)
+    @applied = false
+    @cursor = nil
+
+    messages.delete_if do |message|
+      if message.raw_payload.include?("odd")
+        @applied = true
+        @cursor = message
+        true
+      else
+        false
+      end
+    end
+  end
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[:processed] << message.offset
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    long_running_job true
+    dead_letter_queue topic: DT.topics[1], max_retries: 4
+    filter ->(*) { SkipFilter.new }
+  end
+end
+
+payloads = Array.new(20) { |i| i.even? ? "even-#{i}" : "odd-#{i}" }
+produce_many(DT.topic, payloads)
+
+start_karafka_and_wait_until do
+  DT[:processed].size >= 10
+end
+
+even_offsets = (0...20).select(&:even?).to_a
+assert_equal even_offsets, DT[:processed].sort

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_mom/with_skip_filter_applied_not_freezing_partition_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_mom/with_skip_filter_applied_not_freezing_partition_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# Karafka Pro - Source Available Commercial Software
+# Copyright (c) 2017-present Maciej Mensfeld. All rights reserved.
+#
+# This software is NOT open source. It is source-available commercial software
+# requiring a paid license for use. It is NOT covered by LGPL.
+#
+# PROHIBITED:
+# - Use without a valid commercial license
+# - Redistribution, modification, or derivative works without authorization
+# - Use as training data for AI/ML models or inclusion in datasets
+# - Scraping, crawling, or automated collection for any purpose
+#
+# PERMITTED:
+# - Reading, referencing, and linking for personal or commercial use
+# - Runtime retrieval by AI assistants, coding agents, and RAG systems
+#   for the purpose of providing contextual help to Karafka users
+#
+# License: https://karafka.io/docs/Pro-License-Comm/
+# Contact: contact@karafka.io
+
+# When DLQ + FTR + LRJ + MoM are combined and a filter returns applied? true with action :skip,
+# the partition should NOT become permanently frozen.
+
+setup_karafka do |config|
+  config.max_messages = 5
+  config.kafka[:"max.poll.interval.ms"] = 10_000
+  config.kafka[:"session.timeout.ms"] = 10_000
+end
+
+class SkipFilter < Karafka::Pro::Processing::Filters::Base
+  def apply!(messages)
+    @applied = false
+    @cursor = nil
+
+    messages.delete_if do |message|
+      if message.raw_payload.include?("odd")
+        @applied = true
+        @cursor = message
+        true
+      else
+        false
+      end
+    end
+  end
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[:processed] << message.offset
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    long_running_job true
+    manual_offset_management true
+    dead_letter_queue topic: DT.topics[1], max_retries: 4
+    filter ->(*) { SkipFilter.new }
+  end
+end
+
+payloads = Array.new(20) { |i| i.even? ? "even-#{i}" : "odd-#{i}" }
+produce_many(DT.topic, payloads)
+
+start_karafka_and_wait_until do
+  DT[:processed].size >= 10
+end
+
+even_offsets = (0...20).select(&:even?).to_a
+assert_equal even_offsets, DT[:processed].sort

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_mom_vp/with_skip_filter_applied_not_freezing_partition_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_mom_vp/with_skip_filter_applied_not_freezing_partition_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# Karafka Pro - Source Available Commercial Software
+# Copyright (c) 2017-present Maciej Mensfeld. All rights reserved.
+#
+# This software is NOT open source. It is source-available commercial software
+# requiring a paid license for use. It is NOT covered by LGPL.
+#
+# PROHIBITED:
+# - Use without a valid commercial license
+# - Redistribution, modification, or derivative works without authorization
+# - Use as training data for AI/ML models or inclusion in datasets
+# - Scraping, crawling, or automated collection for any purpose
+#
+# PERMITTED:
+# - Reading, referencing, and linking for personal or commercial use
+# - Runtime retrieval by AI assistants, coding agents, and RAG systems
+#   for the purpose of providing contextual help to Karafka users
+#
+# License: https://karafka.io/docs/Pro-License-Comm/
+# Contact: contact@karafka.io
+
+# When DLQ + FTR + LRJ + MoM + VP are combined and a filter returns applied? true with action
+# :skip, the partition should NOT become permanently frozen.
+
+setup_karafka do |config|
+  config.max_messages = 5
+  config.kafka[:"max.poll.interval.ms"] = 10_000
+  config.kafka[:"session.timeout.ms"] = 10_000
+end
+
+class SkipFilter < Karafka::Pro::Processing::Filters::Base
+  def apply!(messages)
+    @applied = false
+    @cursor = nil
+
+    messages.delete_if do |message|
+      if message.raw_payload.include?("odd")
+        @applied = true
+        @cursor = message
+        true
+      else
+        false
+      end
+    end
+  end
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[:processed] << message.offset
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    long_running_job true
+    manual_offset_management true
+    dead_letter_queue topic: DT.topics[1], max_retries: 4
+    filter ->(*) { SkipFilter.new }
+    virtual_partitions(
+      partitioner: ->(_msg) { rand(2) }
+    )
+  end
+end
+
+payloads = Array.new(20) { |i| i.even? ? "even-#{i}" : "odd-#{i}" }
+produce_many(DT.topic, payloads)
+
+start_karafka_and_wait_until do
+  DT[:processed].size >= 10
+end
+
+even_offsets = (0...20).select(&:even?).to_a
+assert_equal even_offsets, DT[:processed].sort

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_vp/with_skip_filter_applied_not_freezing_partition_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj_vp/with_skip_filter_applied_not_freezing_partition_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+# Karafka Pro - Source Available Commercial Software
+# Copyright (c) 2017-present Maciej Mensfeld. All rights reserved.
+#
+# This software is NOT open source. It is source-available commercial software
+# requiring a paid license for use. It is NOT covered by LGPL.
+#
+# PROHIBITED:
+# - Use without a valid commercial license
+# - Redistribution, modification, or derivative works without authorization
+# - Use as training data for AI/ML models or inclusion in datasets
+# - Scraping, crawling, or automated collection for any purpose
+#
+# PERMITTED:
+# - Reading, referencing, and linking for personal or commercial use
+# - Runtime retrieval by AI assistants, coding agents, and RAG systems
+#   for the purpose of providing contextual help to Karafka users
+#
+# License: https://karafka.io/docs/Pro-License-Comm/
+# Contact: contact@karafka.io
+
+# When DLQ + FTR + LRJ + VP are combined and a filter returns applied? true with action :skip,
+# the partition should NOT become permanently frozen.
+
+setup_karafka do |config|
+  config.max_messages = 5
+  config.kafka[:"max.poll.interval.ms"] = 10_000
+  config.kafka[:"session.timeout.ms"] = 10_000
+end
+
+class SkipFilter < Karafka::Pro::Processing::Filters::Base
+  def apply!(messages)
+    @applied = false
+    @cursor = nil
+
+    messages.delete_if do |message|
+      if message.raw_payload.include?("odd")
+        @applied = true
+        @cursor = message
+        true
+      else
+        false
+      end
+    end
+  end
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[:processed] << message.offset
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    long_running_job true
+    dead_letter_queue topic: DT.topics[1], max_retries: 4
+    filter ->(*) { SkipFilter.new }
+    virtual_partitions(
+      partitioner: ->(_msg) { rand(2) }
+    )
+  end
+end
+
+payloads = Array.new(20) { |i| i.even? ? "even-#{i}" : "odd-#{i}" }
+produce_many(DT.topic, payloads)
+
+start_karafka_and_wait_until do
+  DT[:processed].size >= 10
+end
+
+even_offsets = (0...20).select(&:even?).to_a
+assert_equal even_offsets, DT[:processed].sort

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr/with_skip_filter_applied_not_freezing_partition_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr/with_skip_filter_applied_not_freezing_partition_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# Karafka Pro - Source Available Commercial Software
+# Copyright (c) 2017-present Maciej Mensfeld. All rights reserved.
+#
+# This software is NOT open source. It is source-available commercial software
+# requiring a paid license for use. It is NOT covered by LGPL.
+#
+# PROHIBITED:
+# - Use without a valid commercial license
+# - Redistribution, modification, or derivative works without authorization
+# - Use as training data for AI/ML models or inclusion in datasets
+# - Scraping, crawling, or automated collection for any purpose
+#
+# PERMITTED:
+# - Reading, referencing, and linking for personal or commercial use
+# - Runtime retrieval by AI assistants, coding agents, and RAG systems
+#   for the purpose of providing contextual help to Karafka users
+#
+# License: https://karafka.io/docs/Pro-License-Comm/
+# Contact: contact@karafka.io
+
+# When a topic configured with long_running_job: true uses a filter where applied? returns true
+# and action returns :skip (the default from Filters::Base), the partition should NOT become
+# permanently frozen. After the filter removes some messages and the remaining ones are processed,
+# the consumer should resume and continue processing subsequent batches normally.
+
+setup_karafka do |config|
+  config.max_messages = 5
+  config.kafka[:"max.poll.interval.ms"] = 10_000
+  config.kafka[:"session.timeout.ms"] = 10_000
+end
+
+class SkipFilter < Karafka::Pro::Processing::Filters::Base
+  def apply!(messages)
+    @applied = false
+    @cursor = nil
+
+    messages.delete_if do |message|
+      if message.raw_payload.include?("odd")
+        @applied = true
+        @cursor = message
+        true
+      else
+        false
+      end
+    end
+  end
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[:processed] << message.offset
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    long_running_job true
+    filter ->(*) { SkipFilter.new }
+  end
+end
+
+payloads = Array.new(20) { |i| i.even? ? "even-#{i}" : "odd-#{i}" }
+produce_many(DT.topic, payloads)
+
+start_karafka_and_wait_until do
+  DT[:processed].size >= 10
+end
+
+even_offsets = (0...20).select(&:even?).to_a
+assert_equal even_offsets, DT[:processed].sort

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/with_skip_filter_applied_not_freezing_partition_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom/with_skip_filter_applied_not_freezing_partition_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Karafka Pro - Source Available Commercial Software
+# Copyright (c) 2017-present Maciej Mensfeld. All rights reserved.
+#
+# This software is NOT open source. It is source-available commercial software
+# requiring a paid license for use. It is NOT covered by LGPL.
+#
+# PROHIBITED:
+# - Use without a valid commercial license
+# - Redistribution, modification, or derivative works without authorization
+# - Use as training data for AI/ML models or inclusion in datasets
+# - Scraping, crawling, or automated collection for any purpose
+#
+# PERMITTED:
+# - Reading, referencing, and linking for personal or commercial use
+# - Runtime retrieval by AI assistants, coding agents, and RAG systems
+#   for the purpose of providing contextual help to Karafka users
+#
+# License: https://karafka.io/docs/Pro-License-Comm/
+# Contact: contact@karafka.io
+
+# When LRJ + FTR + MoM are combined and a filter returns applied? true with action :skip,
+# the partition should NOT become permanently frozen.
+
+setup_karafka do |config|
+  config.max_messages = 5
+  config.kafka[:"max.poll.interval.ms"] = 10_000
+  config.kafka[:"session.timeout.ms"] = 10_000
+end
+
+class SkipFilter < Karafka::Pro::Processing::Filters::Base
+  def apply!(messages)
+    @applied = false
+    @cursor = nil
+
+    messages.delete_if do |message|
+      if message.raw_payload.include?("odd")
+        @applied = true
+        @cursor = message
+        true
+      else
+        false
+      end
+    end
+  end
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[:processed] << message.offset
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    long_running_job true
+    manual_offset_management true
+    filter ->(*) { SkipFilter.new }
+  end
+end
+
+payloads = Array.new(20) { |i| i.even? ? "even-#{i}" : "odd-#{i}" }
+produce_many(DT.topic, payloads)
+
+start_karafka_and_wait_until do
+  DT[:processed].size >= 10
+end
+
+even_offsets = (0...20).select(&:even?).to_a
+assert_equal even_offsets, DT[:processed].sort

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/with_skip_filter_applied_not_freezing_partition_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_mom_vp/with_skip_filter_applied_not_freezing_partition_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+# Karafka Pro - Source Available Commercial Software
+# Copyright (c) 2017-present Maciej Mensfeld. All rights reserved.
+#
+# This software is NOT open source. It is source-available commercial software
+# requiring a paid license for use. It is NOT covered by LGPL.
+#
+# PROHIBITED:
+# - Use without a valid commercial license
+# - Redistribution, modification, or derivative works without authorization
+# - Use as training data for AI/ML models or inclusion in datasets
+# - Scraping, crawling, or automated collection for any purpose
+#
+# PERMITTED:
+# - Reading, referencing, and linking for personal or commercial use
+# - Runtime retrieval by AI assistants, coding agents, and RAG systems
+#   for the purpose of providing contextual help to Karafka users
+#
+# License: https://karafka.io/docs/Pro-License-Comm/
+# Contact: contact@karafka.io
+
+# When LRJ + FTR + MoM + VP are combined and a filter returns applied? true with action :skip,
+# the partition should NOT become permanently frozen.
+
+setup_karafka do |config|
+  config.max_messages = 5
+  config.kafka[:"max.poll.interval.ms"] = 10_000
+  config.kafka[:"session.timeout.ms"] = 10_000
+end
+
+class SkipFilter < Karafka::Pro::Processing::Filters::Base
+  def apply!(messages)
+    @applied = false
+    @cursor = nil
+
+    messages.delete_if do |message|
+      if message.raw_payload.include?("odd")
+        @applied = true
+        @cursor = message
+        true
+      else
+        false
+      end
+    end
+  end
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[:processed] << message.offset
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    long_running_job true
+    manual_offset_management true
+    filter ->(*) { SkipFilter.new }
+    virtual_partitions(
+      partitioner: ->(_msg) { rand(2) }
+    )
+  end
+end
+
+payloads = Array.new(20) { |i| i.even? ? "even-#{i}" : "odd-#{i}" }
+produce_many(DT.topic, payloads)
+
+start_karafka_and_wait_until do
+  DT[:processed].size >= 10
+end
+
+even_offsets = (0...20).select(&:even?).to_a
+assert_equal even_offsets, DT[:processed].sort

--- a/spec/integrations/pro/consumption/strategies/lrj/ftr_vp/with_skip_filter_applied_not_freezing_partition_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/lrj/ftr_vp/with_skip_filter_applied_not_freezing_partition_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# Karafka Pro - Source Available Commercial Software
+# Copyright (c) 2017-present Maciej Mensfeld. All rights reserved.
+#
+# This software is NOT open source. It is source-available commercial software
+# requiring a paid license for use. It is NOT covered by LGPL.
+#
+# PROHIBITED:
+# - Use without a valid commercial license
+# - Redistribution, modification, or derivative works without authorization
+# - Use as training data for AI/ML models or inclusion in datasets
+# - Scraping, crawling, or automated collection for any purpose
+#
+# PERMITTED:
+# - Reading, referencing, and linking for personal or commercial use
+# - Runtime retrieval by AI assistants, coding agents, and RAG systems
+#   for the purpose of providing contextual help to Karafka users
+#
+# License: https://karafka.io/docs/Pro-License-Comm/
+# Contact: contact@karafka.io
+
+# When LRJ + FTR + VP are combined and a filter returns applied? true with action :skip,
+# the partition should NOT become permanently frozen.
+
+setup_karafka do |config|
+  config.max_messages = 5
+  config.kafka[:"max.poll.interval.ms"] = 10_000
+  config.kafka[:"session.timeout.ms"] = 10_000
+end
+
+class SkipFilter < Karafka::Pro::Processing::Filters::Base
+  def apply!(messages)
+    @applied = false
+    @cursor = nil
+
+    messages.delete_if do |message|
+      if message.raw_payload.include?("odd")
+        @applied = true
+        @cursor = message
+        true
+      else
+        false
+      end
+    end
+  end
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[:processed] << message.offset
+    end
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+    long_running_job true
+    filter ->(*) { SkipFilter.new }
+    virtual_partitions(
+      partitioner: ->(_msg) { rand(2) }
+    )
+  end
+end
+
+payloads = Array.new(20) { |i| i.even? ? "even-#{i}" : "odd-#{i}" }
+produce_many(DT.topic, payloads)
+
+start_karafka_and_wait_until do
+  DT[:processed].size >= 10
+end
+
+even_offsets = (0...20).select(&:even?).to_a
+assert_equal even_offsets, DT[:processed].sort

--- a/spec/lib/karafka/pro/processing/coordinator_spec.rb
+++ b/spec/lib/karafka/pro/processing/coordinator_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe_current do
       before { coordinator.start(messages) }
 
       it "returns true" do
-        expect(coordinator.active_within?(105)).to be(true)
+        expect(coordinator.active_within?(1_000)).to be(true)
       end
     end
   end


### PR DESCRIPTION
ref https://github.com/karafka/karafka/issues/3029

## Summary

- Fix permanent partition freeze when LRJ topics use filters where `applied?` returns `true` and `action` returns `:skip` (the default from `Filters::Base`)
- LRJ pauses the partition with `MAX_PAUSE_TIME` (~31,709 years) before consuming. After successful processing, `handle_post_filtering` returns `nil` for `:skip` action without calling `resume`, leaving the partition paused indefinitely
- Affects all 12 LRJ+FTR strategy combinations: `Lrj::Ftr`, `Lrj::FtrMom`, `Lrj::FtrVp`, `Lrj::FtrMomVp`, `Dlq::FtrLrj`, `Dlq::FtrLrjMom`, `Dlq::FtrLrjVp`, `Dlq::FtrLrjMomVp`, `Aj::FtrLrjMom`, `Aj::FtrLrjMomVp`, `Aj::DlqFtrLrjMom`, `Aj::DlqFtrLrjMomVp`
- Fixed by calling `resume` after `handle_post_filtering` when `coordinator.filter.action == :skip` in all 7 strategy files that define their own `handle_after_consume` (5 others inherit the fix)

## Test plan

- [x] Added 12 integration tests covering every LRJ+FTR strategy combination
- [x] All 12 tests confirmed frozen (exit code 8, "Execution expired") before the fix
- [x] All 12 tests pass (exit code 0) after the fix
- [ ] Verify existing LRJ+FTR integration tests still pass (throttling, error handling, manual pause/seek)