### PR TITLE
Remove verbose section banner comments from pause integration tests

### DIFF
--- a/spec/integrations/pro/routing/pausing/with_bidirectional_compatibility_spec.rb
+++ b/spec/integrations/pro/routing/pausing/with_bidirectional_compatibility_spec.rb
@@ -51,7 +51,6 @@ end
 
 topics = Karafka::App.routes.first.topics
 
-# ========== Test Topic A: pause() method ==========
 topic_a = topics[0]
 
 # Verify new API works
@@ -66,7 +65,6 @@ assert_equal 1_500, topic_a.pause_timeout
 assert_equal 6_000, topic_a.pause_max_timeout
 assert_equal true, topic_a.pause_with_exponential_backoff
 
-# ========== Test Topic B: old setters ==========
 topic_b = topics[1]
 
 # Verify old accessors work
@@ -83,7 +81,6 @@ assert_equal false, topic_b.pausing.with_exponential_backoff?
 # With old setters, pausing is not explicitly active
 assert_equal false, topic_b.pausing.active?
 
-# ========== Test Topic C: defaults ==========
 topic_c = topics[2]
 
 # Verify defaults through old API
@@ -98,14 +95,12 @@ assert_equal false, topic_c.pausing.with_exponential_backoff
 assert_equal false, topic_c.pausing.with_exponential_backoff?
 assert_equal false, topic_c.pausing.active?
 
-# ========== Test bidirectional updates (Topic A) ==========
 # Calling pause() again should update values and old accessors should reflect it
 topic_a.pause(timeout: 2_000)
 
 assert_equal 2_000, topic_a.pausing.timeout
 assert_equal 2_000, topic_a.pause_timeout # old accessor reflects new value
 
-# ========== Test serialization includes both formats ==========
 topic_a_hash = topic_a.to_h
 
 # Old format (backwards compatibility)

--- a/spec/integrations/routing/pausing/with_global_config_backwards_compatibility_spec.rb
+++ b/spec/integrations/routing/pausing/with_global_config_backwards_compatibility_spec.rb
@@ -10,17 +10,14 @@ setup_karafka do |config|
   config.pause.with_exponential_backoff = true
 end
 
-# ========== Test new API returns correct values ==========
 assert_equal 1_500, Karafka::App.config.pause.timeout
 assert_equal 6_000, Karafka::App.config.pause.max_timeout
 assert_equal true, Karafka::App.config.pause.with_exponential_backoff
 
-# ========== Test backwards compatibility - old accessors reflect new config ==========
 assert_equal 1_500, Karafka::App.config.pause_timeout
 assert_equal 6_000, Karafka::App.config.pause_max_timeout
 assert_equal true, Karafka::App.config.pause_with_exponential_backoff
 
-# ========== Test both APIs return the same values ==========
 assert_equal Karafka::App.config.pause.timeout, Karafka::App.config.pause_timeout
 assert_equal Karafka::App.config.pause.max_timeout, Karafka::App.config.pause_max_timeout
 assert_equal(
@@ -28,7 +25,6 @@ assert_equal(
   Karafka::App.config.pause_with_exponential_backoff
 )
 
-# ========== Test updating via old API updates new API ==========
 Karafka::App.config.pause_timeout = 2_000
 assert_equal 2_000, Karafka::App.config.pause.timeout
 assert_equal 2_000, Karafka::App.config.pause_timeout
@@ -41,7 +37,6 @@ Karafka::App.config.pause_with_exponential_backoff = false
 assert_equal false, Karafka::App.config.pause.with_exponential_backoff
 assert_equal false, Karafka::App.config.pause_with_exponential_backoff
 
-# ========== Test updating via new API updates old API ==========
 Karafka::App.config.pause.timeout = 3_000
 assert_equal 3_000, Karafka::App.config.pause_timeout
 assert_equal 3_000, Karafka::App.config.pause.timeout

--- a/spec/integrations/routing/pausing/with_global_config_new_api_spec.rb
+++ b/spec/integrations/routing/pausing/with_global_config_new_api_spec.rb
@@ -9,17 +9,14 @@ setup_karafka do |config|
   config.pause.with_exponential_backoff = true
 end
 
-# ========== Test new API returns correct values ==========
 assert_equal 2_000, Karafka::App.config.pause.timeout
 assert_equal 8_000, Karafka::App.config.pause.max_timeout
 assert_equal true, Karafka::App.config.pause.with_exponential_backoff
 
-# ========== Test backwards compatibility - old accessors still work ==========
 assert_equal 2_000, Karafka::App.config.pause_timeout
 assert_equal 8_000, Karafka::App.config.pause_max_timeout
 assert_equal true, Karafka::App.config.pause_with_exponential_backoff
 
-# ========== Test both APIs are synchronized ==========
 assert_equal Karafka::App.config.pause.timeout, Karafka::App.config.pause_timeout
 assert_equal Karafka::App.config.pause.max_timeout, Karafka::App.config.pause_max_timeout
 assert_equal(

--- a/spec/integrations/routing/pausing/with_global_config_old_api_spec.rb
+++ b/spec/integrations/routing/pausing/with_global_config_old_api_spec.rb
@@ -10,17 +10,14 @@ setup_karafka do |config|
   config.pause_with_exponential_backoff = true
 end
 
-# ========== Test old API returns correct values ==========
 assert_equal 2_000, Karafka::App.config.pause_timeout
 assert_equal 8_000, Karafka::App.config.pause_max_timeout
 assert_equal true, Karafka::App.config.pause_with_exponential_backoff
 
-# ========== Test new API reflects old config ==========
 assert_equal 2_000, Karafka::App.config.pause.timeout
 assert_equal 8_000, Karafka::App.config.pause.max_timeout
 assert_equal true, Karafka::App.config.pause.with_exponential_backoff
 
-# ========== Test both APIs are synchronized ==========
 assert_equal Karafka::App.config.pause_timeout, Karafka::App.config.pause.timeout
 assert_equal Karafka::App.config.pause_max_timeout, Karafka::App.config.pause.max_timeout
 assert_equal(


### PR DESCRIPTION
## Summary
- Removes `# ========== ... ==========` section banner comments from pause routing integration tests
- These verbose banners are unnecessary noise since tests run primarily in CI
- Existing meaningful inline comments are preserved

## Test plan
- No test logic changed, only decorative comments removed