### PR TITLE
Align assert_equal argument order to xUnit convention

### DIFF
--- a/spec/integrations/admin/configs_flow_spec.rb
+++ b/spec/integrations/admin/configs_flow_spec.rb
@@ -50,25 +50,25 @@ sleep(5)
 rtopic1, rtopic2 = Karafka::Admin::Configs.describe(topic1, topic2)
 
 assert_equal rtopic1.name, DT.topics[0]
-assert_equal rtopic1.type, :topic
+assert_equal :topic, rtopic1.type
 assert_equal rtopic2.name, DT.topics[1]
-assert_equal rtopic2.type, :topic
+assert_equal :topic, rtopic2.type
 
 rtopic1.configs.each do |config|
   if config.name == "delete.retention.ms"
-    assert_equal config.name, "delete.retention.ms"
-    assert_equal config.value, "86800123"
+    assert_equal "delete.retention.ms", config.name
+    assert_equal "86800123", config.value
   end
 
   if config.name == "cleanup.policy"
-    assert_equal config.name, "cleanup.policy"
-    assert_equal config.value, "compact"
+    assert_equal "cleanup.policy", config.name
+    assert_equal "compact", config.value
   end
 end
 
 rtopic2.configs.each do |config|
   if config.name == "delete.retention.ms"
-    assert_equal config.name, "delete.retention.ms"
-    assert_equal config.value, "86400000"
+    assert_equal "delete.retention.ms", config.name
+    assert_equal "86400000", config.value
   end
 end

--- a/spec/integrations/admin/replication_info_fetch_spec.rb
+++ b/spec/integrations/admin/replication_info_fetch_spec.rb
@@ -33,6 +33,6 @@ Karafka::Admin::Configs.describe(resource).each do |topic_config|
   end
 end
 
-assert_equal replica_counts.min, 1
-assert_equal min_insync_replicas_config, 1
-assert_equal in_sync_brokers.min, 1
+assert_equal 1, replica_counts.min
+assert_equal 1, min_insync_replicas_config
+assert_equal 1, in_sync_brokers.min

--- a/spec/integrations/cli/declaratives/align/aliased_aligned_spec.rb
+++ b/spec/integrations/cli/declaratives/align/aliased_aligned_spec.rb
@@ -40,17 +40,17 @@ tr1, tr2 = Karafka::Admin::Configs.describe(resources)
 tr1.configs.each do |config|
   case config.name
   when "retention.bytes"
-    assert_equal config.value, "-1"
+    assert_equal "-1", config.value
   when "cleanup.policy"
-    assert_equal config.value, "delete"
+    assert_equal "delete", config.value
   end
 end
 
 tr2.configs.each do |config|
   case config.name
   when "retention.bytes"
-    assert_equal config.value, "-1"
+    assert_equal "-1", config.value
   when "cleanup.policy"
-    assert_equal config.value, "delete"
+    assert_equal "delete", config.value
   end
 end

--- a/spec/integrations/cli/declaratives/align/aligned_spec.rb
+++ b/spec/integrations/cli/declaratives/align/aligned_spec.rb
@@ -34,17 +34,17 @@ tr1, tr2 = Karafka::Admin::Configs.describe(resources)
 tr1.configs.each do |config|
   case config.name
   when "retention.ms"
-    assert_equal config.value, "604800000"
+    assert_equal "604800000", config.value
   when "cleanup.policy"
-    assert_equal config.value, "delete"
+    assert_equal "delete", config.value
   end
 end
 
 tr2.configs.each do |config|
   case config.name
   when "retention.ms"
-    assert_equal config.value, "604800000"
+    assert_equal "604800000", config.value
   when "cleanup.policy"
-    assert_equal config.value, "delete"
+    assert_equal "delete", config.value
   end
 end

--- a/spec/integrations/cli/declaratives/align/existing_spec.rb
+++ b/spec/integrations/cli/declaratives/align/existing_spec.rb
@@ -50,17 +50,17 @@ tr1, tr2 = Karafka::Admin::Configs.describe(resources)
 tr1.configs.each do |config|
   case config.name
   when "retention.ms"
-    assert_equal config.value, 86_500_000.to_s
+    assert_equal 86_500_000.to_s, config.value
   when "cleanup.policy"
-    assert_equal config.value, "delete"
+    assert_equal "delete", config.value
   end
 end
 
 tr2.configs.each do |config|
   case config.name
   when "retention.ms"
-    assert_equal config.value, 76_500_000.to_s
+    assert_equal 76_500_000.to_s, config.value
   when "cleanup.policy"
-    assert_equal config.value, "compact,delete"
+    assert_equal "compact,delete", config.value
   end
 end

--- a/spec/integrations/consumption/pausing_not_unlocking_spec.rb
+++ b/spec/integrations/consumption/pausing_not_unlocking_spec.rb
@@ -42,6 +42,6 @@ start_karafka_and_wait_until do
   DT.key?(:post)
 end
 
-assert_equal errors.first.code, :max_poll_exceeded
+assert_equal :max_poll_exceeded, errors.first.code
 assert DT.key?(:post)
 assert DT[:post].first - DT[:pre].first >= 15

--- a/spec/integrations/consumption/retrying_flow_spec.rb
+++ b/spec/integrations/consumption/retrying_flow_spec.rb
@@ -21,5 +21,5 @@ start_karafka_and_wait_until do
 end
 
 DT[0].each_with_index do |aggro, index|
-  assert_equal aggro, [index.positive?, index + 1]
+  assert_equal [index.positive?, index + 1], aggro
 end

--- a/spec/integrations/consumption/strategies/aj_mom/tagging_with_job_class_spec.rb
+++ b/spec/integrations/consumption/strategies/aj_mom/tagging_with_job_class_spec.rb
@@ -27,4 +27,4 @@ start_karafka_and_wait_until do
   DT.key?(0)
 end
 
-assert_equal DT[:tags], [Job.to_s]
+assert_equal [Job.to_s], DT[:tags]

--- a/spec/integrations/consumption/strategies/default/kip_848/post_revocation_recovery_spec.rb
+++ b/spec/integrations/consumption/strategies/default/kip_848/post_revocation_recovery_spec.rb
@@ -38,4 +38,4 @@ start_karafka_and_wait_until do
   DT.key?(:done)
 end
 
-assert_equal DT[:offsets], [0, 0, 1]
+assert_equal [0, 0, 1], DT[:offsets]

--- a/spec/integrations/consumption/strategies/dlq/manual_dispatch_to_dlq_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/manual_dispatch_to_dlq_spec.rb
@@ -42,5 +42,5 @@ start_karafka_and_wait_until do
   DT.key?(:broken)
 end
 
-assert_equal DT[:broken].size, 1, DT.data
+assert_equal 1, DT[:broken].size, DT.data
 assert_equal elements[0], DT[:broken].first, DT.data

--- a/spec/integrations/consumption/strategies/dlq/with_error_handling_pipeline_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/with_error_handling_pipeline_spec.rb
@@ -46,5 +46,5 @@ end
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[0]

--- a/spec/integrations/consumption/strategies/dlq/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/with_non_recoverable_error_with_retries_spec.rb
@@ -57,5 +57,5 @@ assert_equal (0..99).to_a - [10], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[10]

--- a/spec/integrations/consumption/strategies/dlq/with_non_recoverable_error_without_retries_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/with_non_recoverable_error_without_retries_spec.rb
@@ -57,5 +57,5 @@ assert_equal (0..99).to_a - [10], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[10]

--- a/spec/integrations/consumption/strategies/dlq/with_non_recoverable_first_message_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/with_non_recoverable_first_message_spec.rb
@@ -57,5 +57,5 @@ assert_equal (0..99).to_a - [0], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[0]

--- a/spec/integrations/consumption/strategies/dlq/with_non_recoverable_last_message_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/with_non_recoverable_last_message_spec.rb
@@ -63,5 +63,5 @@ assert_equal (0..100).to_a - [99], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[99]

--- a/spec/integrations/consumption/strategies/dlq/without_marking_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq/without_marking_spec.rb
@@ -40,4 +40,4 @@ start_karafka_and_wait_until do
   DT[:broken].size >= 3
 end
 
-assert_equal fetch_next_offset, 0
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/consumption/strategies/dlq_mom/with_error_handling_pipeline_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_error_handling_pipeline_spec.rb
@@ -48,5 +48,5 @@ end
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[0]

--- a/spec/integrations/consumption/strategies/dlq_mom/with_first_crashing_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_first_crashing_spec.rb
@@ -42,4 +42,4 @@ start_karafka_and_wait_until do
   DT[:offsets].uniq.size > 1
 end
 
-assert_equal DT[:offsets].uniq, [0, 1]
+assert_equal [0, 1], DT[:offsets].uniq

--- a/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_error_with_retries_spec.rb
@@ -58,5 +58,5 @@ assert_equal (0..99).to_a - [10], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[10]

--- a/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_error_without_retries_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_error_without_retries_spec.rb
@@ -58,5 +58,5 @@ assert_equal (0..99).to_a - [10], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[10]

--- a/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_first_message_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_first_message_spec.rb
@@ -58,5 +58,5 @@ assert_equal (0..99).to_a - [0], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[0]

--- a/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_last_message_spec.rb
+++ b/spec/integrations/consumption/strategies/dlq_mom/with_non_recoverable_last_message_spec.rb
@@ -64,5 +64,5 @@ assert_equal (0..100).to_a - [99], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[99]

--- a/spec/integrations/consumption/when_initialization_happens_spec.rb
+++ b/spec/integrations/consumption/when_initialization_happens_spec.rb
@@ -25,5 +25,5 @@ start_karafka_and_wait_until do
 end
 
 assert_equal DT[:topic].name, DT.topic
-assert_equal DT[:partition], 0
+assert_equal 0, DT[:partition]
 assert DT[:messages].empty?

--- a/spec/integrations/consumption/with_sync_mark_sa_consumed_after_revoke_spec.rb
+++ b/spec/integrations/consumption/with_sync_mark_sa_consumed_after_revoke_spec.rb
@@ -45,5 +45,5 @@ end
 
 other_consumer.join
 
-assert_equal DT[:post_closed_mark], false
-assert_equal DT[:pre_closed_mark], true
+assert_equal false, DT[:post_closed_mark]
+assert_equal true, DT[:pre_closed_mark]

--- a/spec/integrations/consumption/with_unwanted_offset_reset_spec.rb
+++ b/spec/integrations/consumption/with_unwanted_offset_reset_spec.rb
@@ -27,4 +27,4 @@ end
 
 # No data should be consumed
 assert DT[:messages].empty?
-assert_equal DT[:error].code, :auto_offset_reset
+assert_equal :auto_offset_reset, DT[:error].code

--- a/spec/integrations/deserialization/custom_per_topic_spec.rb
+++ b/spec/integrations/deserialization/custom_per_topic_spec.rb
@@ -50,10 +50,10 @@ start_karafka_and_wait_until do
     DT[DT.topics[1]].size >= 1
 end
 
-assert_equal DT[DT.topics[0]][0], "m11"
-assert_equal DT[DT.topics[0]][1], "x11"
-assert_equal DT[DT.topics[0]][2][:nested1], { "test" => "1" }
+assert_equal "m11", DT[DT.topics[0]][0]
+assert_equal "x11", DT[DT.topics[0]][1]
+assert_equal({ "test" => "1" }, DT[DT.topics[0]][2][:nested1])
 
-assert_equal DT[DT.topics[1]][0], "m22"
-assert_equal DT[DT.topics[1]][1], "x22"
-assert_equal DT[DT.topics[1]][2][:nested2], { "test" => "2" }
+assert_equal "m22", DT[DT.topics[1]][0]
+assert_equal "x22", DT[DT.topics[1]][1]
+assert_equal({ "test" => "2" }, DT[DT.topics[1]][2][:nested2])

--- a/spec/integrations/deserialization/routing_default_deserializer_usage_spec.rb
+++ b/spec/integrations/deserialization/routing_default_deserializer_usage_spec.rb
@@ -32,6 +32,6 @@ start_karafka_and_wait_until do
   DT[0].size >= 1
 end
 
-assert_equal DT[0][0][0], 0
-assert_equal DT[0][0][1], 1
-assert_equal DT[0][0][2], 2
+assert_equal 0, DT[0][0][0]
+assert_equal 1, DT[0][0][1]
+assert_equal 2, DT[0][0][2]

--- a/spec/integrations/instrumentation/consumer_seeking_spec.rb
+++ b/spec/integrations/instrumentation/consumer_seeking_spec.rb
@@ -24,9 +24,9 @@ start_karafka_and_wait_until do
   DT[:messages].size >= 5
 end
 
-assert_equal DT[:messages].uniq, [0]
+assert_equal [0], DT[:messages].uniq
 assert DT[:seeks].size >= 4
 
 assert DT[:seeks].first[:caller].is_a?(Consumer)
 assert_equal DT[:seeks].first[:topic], DT.topic
-assert_equal DT[:seeks].first[:message].offset, 0
+assert_equal 0, DT[:seeks].first[:message].offset

--- a/spec/integrations/instrumentation/consumption_event_vs_processing_spec.rb
+++ b/spec/integrations/instrumentation/consumption_event_vs_processing_spec.rb
@@ -37,7 +37,7 @@ assert_equal DT[1], DT[2]
 
 # Make sure that we have detected proper assignments
 assert_equal DT[:assignments].keys.first.name, DT.topic
-assert_equal DT[:assignments].values.first, [0]
+assert_equal [0], DT[:assignments].values.first
 
 # Last state after shutdown should indicate no assignments
 assert Karafka::App.assignments.empty?

--- a/spec/integrations/instrumentation/error_callback_on_max_poll_interval_spec.rb
+++ b/spec/integrations/instrumentation/error_callback_on_max_poll_interval_spec.rb
@@ -29,4 +29,4 @@ start_karafka_and_wait_until do
   DT.key?(:errors)
 end
 
-assert_equal DT[:errors].last.code, :max_poll_exceeded
+assert_equal :max_poll_exceeded, DT[:errors].last.code

--- a/spec/integrations/instrumentation/vendors/kubernetes/consuming_liveness_timeout_flow_spec.rb
+++ b/spec/integrations/instrumentation/vendors/kubernetes/consuming_liveness_timeout_flow_spec.rb
@@ -54,17 +54,17 @@ assert DT[:probing].include?("500")
 
 responses = raw_flows.split("\n").select { |line| line.start_with?("->") }
 
-assert_equal responses[0], '-> "HTTP/1.1 200 OK\r\n"', responses[0]
-assert_equal responses[1], '-> "Content-Type: application/json\r\n"', responses[1]
-assert_equal responses[3], '-> "\r\n"', responses[3]
+assert_equal '-> "HTTP/1.1 200 OK\r\n"', responses[0], responses[0]
+assert_equal '-> "Content-Type: application/json\r\n"', responses[1], responses[1]
+assert_equal '-> "\r\n"', responses[3], responses[3]
 
 position = responses.index { |line| line.include?(" 500 ") }
 
 resp500 = responses[position..]
 
-assert_equal resp500[0], '-> "HTTP/1.1 500 Internal Server Error\r\n"', resp500[0]
-assert_equal resp500[1], '-> "Content-Type: application/json\r\n"', resp500[1]
-assert_equal resp500[3], '-> "\r\n"', resp500[3]
+assert_equal '-> "HTTP/1.1 500 Internal Server Error\r\n"', resp500[0], resp500[0]
+assert_equal '-> "Content-Type: application/json\r\n"', resp500[1], resp500[1]
+assert_equal '-> "\r\n"', resp500[3], resp500[3]
 
 last = JSON.parse(DT[:bodies].last)
 

--- a/spec/integrations/instrumentation/vendors/kubernetes/liveness_all_good_spec.rb
+++ b/spec/integrations/instrumentation/vendors/kubernetes/liveness_all_good_spec.rb
@@ -58,8 +58,8 @@ assert !DT[:probing].include?("500")
 
 responses = raw_flows.split("\n").select { |line| line.start_with?("->") }
 
-assert_equal responses[0], '-> "HTTP/1.1 200 OK\r\n"', responses[0]
-assert_equal responses[1], '-> "Content-Type: application/json\r\n"', responses[1]
+assert_equal '-> "HTTP/1.1 200 OK\r\n"', responses[0], responses[0]
+assert_equal '-> "Content-Type: application/json\r\n"', responses[1], responses[1]
 
 last = JSON.parse(DT[:bodies].last)
 

--- a/spec/integrations/instrumentation/vendors/kubernetes/swarm_liveness_all_good_spec.rb
+++ b/spec/integrations/instrumentation/vendors/kubernetes/swarm_liveness_all_good_spec.rb
@@ -55,8 +55,8 @@ assert !DT[:probing].include?("500")
 
 responses = raw_flows.split("\n").select { |line| line.start_with?("->") }
 
-assert_equal responses[0], '-> "HTTP/1.1 200 OK\r\n"', responses[0]
-assert_equal responses[1], '-> "Content-Type: application/json\r\n"', responses[1]
+assert_equal '-> "HTTP/1.1 200 OK\r\n"', responses[0], responses[0]
+assert_equal '-> "Content-Type: application/json\r\n"', responses[1], responses[1]
 
 last = JSON.parse(DT[:bodies].last)
 

--- a/spec/integrations/instrumentation/vendors/kubernetes/swarm_liveness_not_controlling_often_spec.rb
+++ b/spec/integrations/instrumentation/vendors/kubernetes/swarm_liveness_not_controlling_often_spec.rb
@@ -55,10 +55,10 @@ assert DT[:probing].include?("500")
 
 responses = raw_flows.split("\n").select { |line| line.start_with?("->") }
 
-assert_equal responses[0], '-> "HTTP/1.1 500 Internal Server Error\r\n"', responses[0]
-assert_equal responses[1], '-> "Content-Type: application/json\r\n"', responses[1]
+assert_equal '-> "HTTP/1.1 500 Internal Server Error\r\n"', responses[0], responses[0]
+assert_equal '-> "Content-Type: application/json\r\n"', responses[1], responses[1]
 assert responses[2].include?("Content-Length: "), responses[2]
-assert_equal responses[3], '-> "\r\n"', responses[3]
+assert_equal '-> "\r\n"', responses[3], responses[3]
 
 last = JSON.parse(DT[:bodies].last)
 

--- a/spec/integrations/instrumentation/with_offset_querying_spec.rb
+++ b/spec/integrations/instrumentation/with_offset_querying_spec.rb
@@ -23,4 +23,4 @@ start_karafka_and_wait_until do
   DT[:offsets].any? { |offsets| offsets.last >= 10 }
 end
 
-assert_equal DT[:offsets].map(&:first).uniq, [0]
+assert_equal [0], DT[:offsets].map(&:first).uniq

--- a/spec/integrations/offset_management/commit_offset_after_exceeding_max_poll_spec.rb
+++ b/spec/integrations/offset_management/commit_offset_after_exceeding_max_poll_spec.rb
@@ -33,4 +33,4 @@ start_karafka_and_wait_until do
   DT.key?(:done)
 end
 
-assert_equal DT[:results], [false, false]
+assert_equal [false, false], DT[:results]

--- a/spec/integrations/offset_management/commit_offset_sync_when_no_offsets_spec.rb
+++ b/spec/integrations/offset_management/commit_offset_sync_when_no_offsets_spec.rb
@@ -30,4 +30,4 @@ start_karafka_and_wait_until do
   DT.key?(:done)
 end
 
-assert_equal DT[:results].uniq, [true]
+assert_equal [true], DT[:results].uniq

--- a/spec/integrations/pro/cli/parallel_segments/collapse/with_conclusive_offsets_spec.rb
+++ b/spec/integrations/pro/cli/parallel_segments/collapse/with_conclusive_offsets_spec.rb
@@ -59,5 +59,5 @@ assert results.include?("successfully")
 
 # Verify the segment origin group now has the offsets
 offsets = Karafka::Admin.read_lags_with_offsets({ DT.consumer_group => [DT.topic] })
-assert_equal offsets[DT.consumer_group][DT.topic][0][:offset], 1
-assert_equal offsets[DT.consumer_group][DT.topic][1][:offset], 2
+assert_equal 1, offsets[DT.consumer_group][DT.topic][0][:offset]
+assert_equal 2, offsets[DT.consumer_group][DT.topic][1][:offset]

--- a/spec/integrations/pro/cli/parallel_segments/collapse/with_force_and_inconclusive_offsets_spec.rb
+++ b/spec/integrations/pro/cli/parallel_segments/collapse/with_force_and_inconclusive_offsets_spec.rb
@@ -58,5 +58,5 @@ assert results.include?("Collapse completed")
 assert results.include?("successfully")
 
 offsets = Karafka::Admin.read_lags_with_offsets({ DT.consumer_group => [DT.topic] })
-assert_equal offsets[DT.consumer_group][DT.topic][0][:offset], 3
-assert_equal offsets[DT.consumer_group][DT.topic][1][:offset], 2
+assert_equal 3, offsets[DT.consumer_group][DT.topic][0][:offset]
+assert_equal 2, offsets[DT.consumer_group][DT.topic][1][:offset]

--- a/spec/integrations/pro/cli/parallel_segments/collapse/with_multiple_segments_spec.rb
+++ b/spec/integrations/pro/cli/parallel_segments/collapse/with_multiple_segments_spec.rb
@@ -66,7 +66,7 @@ assert results.include?("Collapse completed")
 assert results.include?("successfully")
 
 offsets = Karafka::Admin.read_lags_with_offsets({ DT.consumer_group => [DT.topic] })
-assert_equal offsets[DT.consumer_group][DT.topic][0][:offset], 5
-assert_equal offsets[DT.consumer_group][DT.topic][1][:offset], 7
-assert_equal offsets[DT.consumer_group][DT.topic][2][:offset], 3
-assert_equal offsets[DT.consumer_group][DT.topic][3][:offset], 9
+assert_equal 5, offsets[DT.consumer_group][DT.topic][0][:offset]
+assert_equal 7, offsets[DT.consumer_group][DT.topic][1][:offset]
+assert_equal 3, offsets[DT.consumer_group][DT.topic][2][:offset]
+assert_equal 9, offsets[DT.consumer_group][DT.topic][3][:offset]

--- a/spec/integrations/pro/cli/parallel_segments/collapse/with_multiple_topics_spec.rb
+++ b/spec/integrations/pro/cli/parallel_segments/collapse/with_multiple_topics_spec.rb
@@ -72,6 +72,6 @@ assert results.include?("successfully")
 offsets = Karafka::Admin.read_lags_with_offsets({ DT.consumer_group => topics })
 
 topics.each do |topic_name|
-  assert_equal offsets[DT.consumer_group][topic_name][0][:offset], 3
-  assert_equal offsets[DT.consumer_group][topic_name][1][:offset], 2
+  assert_equal 3, offsets[DT.consumer_group][topic_name][0][:offset]
+  assert_equal 2, offsets[DT.consumer_group][topic_name][1][:offset]
 end

--- a/spec/integrations/pro/cli/parallel_segments/collapse/with_specific_consumer_groups_spec.rb
+++ b/spec/integrations/pro/cli/parallel_segments/collapse/with_specific_consumer_groups_spec.rb
@@ -81,10 +81,10 @@ assert !results.include?("#{DT.consumer_group}_2")
 
 # Verify only the first consumer group was collapsed
 offsets1 = Karafka::Admin.read_lags_with_offsets({ DT.consumer_group => [DT.topic] })
-assert_equal offsets1[DT.consumer_group][DT.topic][0][:offset], 3
-assert_equal offsets1[DT.consumer_group][DT.topic][1][:offset], 5
+assert_equal 3, offsets1[DT.consumer_group][DT.topic][0][:offset]
+assert_equal 5, offsets1[DT.consumer_group][DT.topic][1][:offset]
 
 # The second group should have no offsets in the origin consumer group
 offsets2 = Karafka::Admin.read_lags_with_offsets({ "#{DT.consumer_group}_2" => ["#{DT.topic}_2"] })
-assert_equal offsets2["#{DT.consumer_group}_2"]["#{DT.topic}_2"][0][:offset], -1
-assert_equal offsets2["#{DT.consumer_group}_2"]["#{DT.topic}_2"][1][:offset], -1
+assert_equal(-1, offsets2["#{DT.consumer_group}_2"]["#{DT.topic}_2"][0][:offset])
+assert_equal(-1, offsets2["#{DT.consumer_group}_2"]["#{DT.topic}_2"][1][:offset])

--- a/spec/integrations/pro/cli/parallel_segments/distribute/with_empty_topics_spec.rb
+++ b/spec/integrations/pro/cli/parallel_segments/distribute/with_empty_topics_spec.rb
@@ -56,7 +56,7 @@ assert results.include?("successfully")
 offsets1 = Karafka::Admin.read_lags_with_offsets({ segment1 => [DT.topic] })
 offsets2 = Karafka::Admin.read_lags_with_offsets({ segment2 => [DT.topic] })
 
-assert_equal offsets1[segment1][DT.topic][0][:offset], -1
-assert_equal offsets1[segment1][DT.topic][1][:offset], -1
-assert_equal offsets2[segment2][DT.topic][0][:offset], -1
-assert_equal offsets2[segment2][DT.topic][1][:offset], -1
+assert_equal(-1, offsets1[segment1][DT.topic][0][:offset])
+assert_equal(-1, offsets1[segment1][DT.topic][1][:offset])
+assert_equal(-1, offsets2[segment2][DT.topic][0][:offset])
+assert_equal(-1, offsets2[segment2][DT.topic][1][:offset])

--- a/spec/integrations/pro/cli/parallel_segments/distribute/with_force_and_existing_offsets_spec.rb
+++ b/spec/integrations/pro/cli/parallel_segments/distribute/with_force_and_existing_offsets_spec.rb
@@ -64,7 +64,7 @@ offsets1 = Karafka::Admin.read_lags_with_offsets({ segment1 => [DT.topic] })
 offsets2 = Karafka::Admin.read_lags_with_offsets({ segment2 => [DT.topic] })
 
 # Both segments should get the offsets from origin group
-assert_equal offsets1[segment1][DT.topic][0][:offset], 5
-assert_equal offsets1[segment1][DT.topic][1][:offset], 7
-assert_equal offsets2[segment2][DT.topic][0][:offset], 5
-assert_equal offsets2[segment2][DT.topic][1][:offset], 7
+assert_equal 5, offsets1[segment1][DT.topic][0][:offset]
+assert_equal 7, offsets1[segment1][DT.topic][1][:offset]
+assert_equal 5, offsets2[segment2][DT.topic][0][:offset]
+assert_equal 7, offsets2[segment2][DT.topic][1][:offset]

--- a/spec/integrations/pro/cli/parallel_segments/distribute/with_multiple_segments_spec.rb
+++ b/spec/integrations/pro/cli/parallel_segments/distribute/with_multiple_segments_spec.rb
@@ -68,8 +68,8 @@ assert results.include?("successfully")
 # Verify all segments received the offsets
 segments.each do |segment|
   offsets = Karafka::Admin.read_lags_with_offsets({ segment => [DT.topic] })
-  assert_equal offsets[segment][DT.topic][0][:offset], 5
-  assert_equal offsets[segment][DT.topic][1][:offset], 7
-  assert_equal offsets[segment][DT.topic][2][:offset], 3
-  assert_equal offsets[segment][DT.topic][3][:offset], 9
+  assert_equal 5, offsets[segment][DT.topic][0][:offset]
+  assert_equal 7, offsets[segment][DT.topic][1][:offset]
+  assert_equal 3, offsets[segment][DT.topic][2][:offset]
+  assert_equal 9, offsets[segment][DT.topic][3][:offset]
 end

--- a/spec/integrations/pro/cli/parallel_segments/distribute/with_multiple_topics_spec.rb
+++ b/spec/integrations/pro/cli/parallel_segments/distribute/with_multiple_topics_spec.rb
@@ -70,7 +70,7 @@ assert results.include?("successfully")
   offsets = Karafka::Admin.read_lags_with_offsets({ segment => topics })
 
   topics.each do |topic_name|
-    assert_equal offsets[segment][topic_name][0][:offset], 3
-    assert_equal offsets[segment][topic_name][1][:offset], 2
+    assert_equal 3, offsets[segment][topic_name][0][:offset]
+    assert_equal 2, offsets[segment][topic_name][1][:offset]
   end
 end

--- a/spec/integrations/pro/cli/parallel_segments/distribute/with_specific_consumer_groups_spec.rb
+++ b/spec/integrations/pro/cli/parallel_segments/distribute/with_specific_consumer_groups_spec.rb
@@ -84,15 +84,15 @@ assert !results.include?("#{DT.consumer_group}_2")
 # Verify only the first consumer group was distributed
 offsets1_1 = Karafka::Admin.read_lags_with_offsets({ segment1_1 => [DT.topic] })
 offsets1_2 = Karafka::Admin.read_lags_with_offsets({ segment1_2 => [DT.topic] })
-assert_equal offsets1_1[segment1_1][DT.topic][0][:offset], 3
-assert_equal offsets1_1[segment1_1][DT.topic][1][:offset], 5
-assert_equal offsets1_2[segment1_2][DT.topic][0][:offset], 3
-assert_equal offsets1_2[segment1_2][DT.topic][1][:offset], 5
+assert_equal 3, offsets1_1[segment1_1][DT.topic][0][:offset]
+assert_equal 5, offsets1_1[segment1_1][DT.topic][1][:offset]
+assert_equal 3, offsets1_2[segment1_2][DT.topic][0][:offset]
+assert_equal 5, offsets1_2[segment1_2][DT.topic][1][:offset]
 
 # The second group segments should not have any offsets
 offsets2_1 = Karafka::Admin.read_lags_with_offsets({ segment2_1 => ["#{DT.topic}_2"] })
 offsets2_2 = Karafka::Admin.read_lags_with_offsets({ segment2_2 => ["#{DT.topic}_2"] })
-assert_equal offsets2_1[segment2_1]["#{DT.topic}_2"][0][:offset], -1
-assert_equal offsets2_1[segment2_1]["#{DT.topic}_2"][1][:offset], -1
-assert_equal offsets2_2[segment2_2]["#{DT.topic}_2"][0][:offset], -1
-assert_equal offsets2_2[segment2_2]["#{DT.topic}_2"][1][:offset], -1
+assert_equal(-1, offsets2_1[segment2_1]["#{DT.topic}_2"][0][:offset])
+assert_equal(-1, offsets2_1[segment2_1]["#{DT.topic}_2"][1][:offset])
+assert_equal(-1, offsets2_2[segment2_2]["#{DT.topic}_2"][0][:offset])
+assert_equal(-1, offsets2_2[segment2_2]["#{DT.topic}_2"][1][:offset])

--- a/spec/integrations/pro/cli/parallel_segments/reset_combined_operation_spec.rb
+++ b/spec/integrations/pro/cli/parallel_segments/reset_combined_operation_spec.rb
@@ -63,13 +63,13 @@ assert results.include?("successfully")
 
 # Verify the origin consumer group received the offsets
 origin_offsets = Karafka::Admin.read_lags_with_offsets({ DT.consumer_group => [DT.topic] })
-assert_equal origin_offsets[DT.consumer_group][DT.topic][0][:offset], 5
-assert_equal origin_offsets[DT.consumer_group][DT.topic][1][:offset], 2
+assert_equal 5, origin_offsets[DT.consumer_group][DT.topic][0][:offset]
+assert_equal 2, origin_offsets[DT.consumer_group][DT.topic][1][:offset]
 
 # Verify segments received the offsets back from origin
 segment1_offsets = Karafka::Admin.read_lags_with_offsets({ segment1 => [DT.topic] })
 segment2_offsets = Karafka::Admin.read_lags_with_offsets({ segment2 => [DT.topic] })
-assert_equal segment1_offsets[segment1][DT.topic][0][:offset], 5
-assert_equal segment1_offsets[segment1][DT.topic][1][:offset], 2
-assert_equal segment2_offsets[segment2][DT.topic][0][:offset], 5
-assert_equal segment2_offsets[segment2][DT.topic][1][:offset], 2
+assert_equal 5, segment1_offsets[segment1][DT.topic][0][:offset]
+assert_equal 2, segment1_offsets[segment1][DT.topic][1][:offset]
+assert_equal 5, segment2_offsets[segment2][DT.topic][0][:offset]
+assert_equal 2, segment2_offsets[segment2][DT.topic][1][:offset]

--- a/spec/integrations/pro/consumption/offset_metadata/basic_automatic_flow_overwritten_last_marking_spec.rb
+++ b/spec/integrations/pro/consumption/offset_metadata/basic_automatic_flow_overwritten_last_marking_spec.rb
@@ -48,4 +48,4 @@ start_karafka_and_wait_until do
   DT[:metadata].size >= 10
 end
 
-assert_equal DT[:metadata].uniq, ["", "cs"]
+assert_equal ["", "cs"], DT[:metadata].uniq

--- a/spec/integrations/pro/consumption/offset_metadata/basic_automatic_flow_overwritten_spec.rb
+++ b/spec/integrations/pro/consumption/offset_metadata/basic_automatic_flow_overwritten_spec.rb
@@ -52,4 +52,4 @@ start_karafka_and_wait_until do
   DT[:metadata].size >= 10
 end
 
-assert_equal DT[:metadata].uniq, ["", "cs"]
+assert_equal ["", "cs"], DT[:metadata].uniq

--- a/spec/integrations/pro/consumption/offset_metadata/basic_automatic_flow_spec.rb
+++ b/spec/integrations/pro/consumption/offset_metadata/basic_automatic_flow_spec.rb
@@ -45,4 +45,4 @@ start_karafka_and_wait_until do
   DT[:metadata].size >= 10
 end
 
-assert_equal DT[:metadata], [""] + (0..8).to_a.map(&:to_s)
+assert_equal [""] + (0..8).to_a.map(&:to_s), DT[:metadata]

--- a/spec/integrations/pro/consumption/offset_metadata/dlq/recovery_with_metadata_spec.rb
+++ b/spec/integrations/pro/consumption/offset_metadata/dlq/recovery_with_metadata_spec.rb
@@ -54,4 +54,4 @@ start_karafka_and_wait_until do
   DT[:metadata].size >= 10
 end
 
-assert_equal DT[:metadata][0..9], ["", "", "", 0, 0, 0, 1, 1, 1, 2].map(&:to_s)
+assert_equal ["", "", "", 0, 0, 0, 1, 1, 1, 2].map(&:to_s), DT[:metadata][0..9]

--- a/spec/integrations/pro/consumption/patterns/post_detected_with_default_deserializers_spec.rb
+++ b/spec/integrations/pro/consumption/patterns/post_detected_with_default_deserializers_spec.rb
@@ -56,6 +56,6 @@ start_karafka_and_wait_until do
   DT.key?(0)
 end
 
-assert_equal DT[0].payload, 1
-assert_equal DT[0].key, 2
-assert_equal DT[0].headers, { "test" => 3 }
+assert_equal 1, DT[0].payload
+assert_equal 2, DT[0].key
+assert_equal({ "test" => 3 }, DT[0].headers)

--- a/spec/integrations/pro/consumption/periodic_jobs/with_eof_status_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/with_eof_status_spec.rb
@@ -49,4 +49,4 @@ start_karafka_and_wait_until do
   DT[:ticks].size >= 3
 end
 
-assert_equal DT[:ticks].uniq, [true]
+assert_equal [true], DT[:ticks].uniq

--- a/spec/integrations/pro/consumption/periodic_jobs/without_any_data_ever_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/without_any_data_ever_spec.rb
@@ -50,4 +50,4 @@ start_karafka_and_wait_until do
   DT[:used].size >= 5
 end
 
-assert_equal DT[:used].uniq, [false]
+assert_equal [false], DT[:used].uniq

--- a/spec/integrations/pro/consumption/piping/with_key/with_alteration_to_headers_spec.rb
+++ b/spec/integrations/pro/consumption/piping/with_key/with_alteration_to_headers_spec.rb
@@ -90,6 +90,6 @@ DT[:piped].each do |message|
   assert EXPECTED_KEYS.include?(message.key)
   assert_equal headers["source_topic"], DT.topics.first
   assert_equal headers["source_topic"], DT.topics.first
-  assert_equal headers["extra_data"], "1"
+  assert_equal "1", headers["extra_data"]
   assert_equal message.raw_payload, headers["extra_test"]
 end

--- a/spec/integrations/pro/consumption/piping/without_key/with_alteration_to_headers_spec.rb
+++ b/spec/integrations/pro/consumption/piping/without_key/with_alteration_to_headers_spec.rb
@@ -90,6 +90,6 @@ DT[:piped].each do |message|
   assert EXPECTED_KEYS.include?(message.key)
   assert_equal headers["source_topic"], DT.topics.first
   assert_equal headers["source_topic"], DT.topics.first
-  assert_equal headers["extra_data"], "1"
+  assert_equal "1", headers["extra_data"]
   assert_equal message.raw_payload, headers["extra_test"]
 end

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_mom_vp/with_non_recoverable_job_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_mom_vp/with_non_recoverable_job_error_spec.rb
@@ -67,4 +67,4 @@ start_karafka_and_wait_until do
   DT[0].size >= 24 && DT[1].size >= 5
 end
 
-assert_equal DT[1][0..4], [0, 1, 2, 3, 4]
+assert_equal [0, 1, 2, 3, 4], DT[1][0..4]

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_mom/tagging_with_job_class_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_mom/tagging_with_job_class_spec.rb
@@ -49,4 +49,4 @@ start_karafka_and_wait_until do
   DT.key?(0)
 end
 
-assert_equal DT[:tags], [Job.to_s]
+assert_equal [Job.to_s], DT[:tags]

--- a/spec/integrations/pro/consumption/strategies/aj/ftr_lrj_mom/with_recoverable_slow_jobs_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/ftr_lrj_mom/with_recoverable_slow_jobs_error_spec.rb
@@ -52,4 +52,4 @@ start_karafka_and_wait_until do
   DT[0].uniq.size >= 50
 end
 
-assert_equal DT[0], [0, 0, 0, 0, 0] + (1..49).to_a
+assert_equal [0, 0, 0, 0, 0] + (1..49).to_a, DT[0]

--- a/spec/integrations/pro/consumption/strategies/aj/ftr_mom/with_non_recoverable_job_error_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/ftr_mom/with_non_recoverable_job_error_spec.rb
@@ -59,4 +59,4 @@ start_karafka_and_wait_until do
   DT[:errors].size >= 10
 end
 
-assert_equal DT[0].uniq, [0]
+assert_equal [0], DT[0].uniq

--- a/spec/integrations/pro/consumption/strategies/aj/mom/with_multiple_custom_partitioners_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/mom/with_multiple_custom_partitioners_spec.rb
@@ -55,10 +55,10 @@ class JobC < JobA
   )
 end
 
-assert_equal Default.karafka_options[:dispatch_method], nil
-assert_equal JobA.karafka_options[:dispatch_method], :produce_sync
-assert_equal JobB.karafka_options[:dispatch_method], :produce_sync
-assert_equal JobC.karafka_options[:dispatch_method], :produce_async
+assert_equal nil, Default.karafka_options[:dispatch_method]
+assert_equal :produce_sync, JobA.karafka_options[:dispatch_method]
+assert_equal :produce_sync, JobB.karafka_options[:dispatch_method]
+assert_equal :produce_async, JobC.karafka_options[:dispatch_method]
 
 assert Default.karafka_options != JobA
 assert Default.karafka_options != JobB

--- a/spec/integrations/pro/consumption/strategies/dlq/default/details_dispatch_transfer_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/details_dispatch_transfer_spec.rb
@@ -69,8 +69,8 @@ end
   assert_equal dlq_message.raw_payload, elements[i]
   assert_equal dlq_message.headers["test#{i}"], (i + 1).to_s
   assert_equal dlq_message.headers.fetch("source_topic"), DT.topic
-  assert_equal dlq_message.headers.fetch("source_partition"), 0.to_s
+  assert_equal 0.to_s, dlq_message.headers.fetch("source_partition")
   assert_equal dlq_message.headers.fetch("source_offset"), i.to_s
-  assert_equal dlq_message.headers.fetch("source_attempts"), "1"
+  assert_equal "1", dlq_message.headers.fetch("source_attempts")
   assert_equal dlq_message.headers.fetch("source_consumer_group"), cg
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/default/details_dispatch_transfer_with_enhancement_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/details_dispatch_transfer_with_enhancement_spec.rb
@@ -78,8 +78,8 @@ end
   assert_equal dlq_message.raw_payload, expected_payload
   assert_equal dlq_message.headers["test#{i}"], (i + 1).to_s
   assert_equal dlq_message.headers.fetch("source_topic"), DT.topic
-  assert_equal dlq_message.headers.fetch("source_partition"), 0.to_s
+  assert_equal 0.to_s, dlq_message.headers.fetch("source_partition")
   assert_equal dlq_message.headers.fetch("source_offset"), i.to_s
   assert_equal dlq_message.headers.fetch("source_consumer_group"), cg
-  assert_equal dlq_message.headers.fetch("total-remap"), "yes"
+  assert_equal "yes", dlq_message.headers.fetch("total-remap")
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/default/manual_dispatch_to_dlq_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/manual_dispatch_to_dlq_spec.rb
@@ -62,12 +62,12 @@ start_karafka_and_wait_until do
   DT.key?(:broken)
 end
 
-assert_equal DT[:broken].size, 1, DT.data
+assert_equal 1, DT[:broken].size, DT.data
 
 broken = DT[:broken].first
 
 assert_equal elements[0], broken.raw_payload, DT.data
 assert_equal broken.headers["source_topic"], DT.topic
-assert_equal broken.headers["source_partition"], "0"
-assert_equal broken.headers["source_offset"], "0"
+assert_equal "0", broken.headers["source_partition"]
+assert_equal "0", broken.headers["source_offset"]
 assert_equal broken.headers["source_consumer_group"], Karafka::App.consumer_groups.first.id

--- a/spec/integrations/pro/consumption/strategies/dlq/default/post_dispatch_errors_tracker_state_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/post_dispatch_errors_tracker_state_spec.rb
@@ -47,4 +47,4 @@ start_karafka_and_wait_until do
   DT[:tracker].size >= 2
 end
 
-assert_equal DT[:tracker].uniq, [0]
+assert_equal [0], DT[:tracker].uniq

--- a/spec/integrations/pro/consumption/strategies/dlq/default/raw_headers_dispatch_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/raw_headers_dispatch_spec.rb
@@ -75,8 +75,8 @@ end
   assert_equal dlq_message.raw_payload, elements[i]
   assert_equal dlq_message.headers["test#{i}"], (i + 1).to_s
   assert_equal dlq_message.headers.fetch("source_topic"), DT.topic
-  assert_equal dlq_message.headers.fetch("source_partition"), 0.to_s
+  assert_equal 0.to_s, dlq_message.headers.fetch("source_partition")
   assert_equal dlq_message.headers.fetch("source_offset"), i.to_s
-  assert_equal dlq_message.headers.fetch("source_attempts"), "1"
+  assert_equal "1", dlq_message.headers.fetch("source_attempts")
   assert_equal dlq_message.headers.fetch("source_consumer_group"), cg
 end

--- a/spec/integrations/pro/consumption/strategies/dlq/default/with_custom_strategy_using_consumer_group_context_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/with_custom_strategy_using_consumer_group_context_spec.rb
@@ -90,4 +90,4 @@ start_karafka_and_wait_until do
   DT[:dlq_topics].size >= 2
 end
 
-assert_equal DT[:dlq_topics].sort, [DT.topics[1], DT.topics[2]].sort
+assert_equal [DT.topics[1], DT.topics[2]].sort, DT[:dlq_topics].sort

--- a/spec/integrations/pro/consumption/strategies/dlq/default/with_error_handling_pipeline_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/with_error_handling_pipeline_spec.rb
@@ -66,5 +66,5 @@ end
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[0]

--- a/spec/integrations/pro/consumption/strategies/dlq/default/with_non_recoverable_error_with_one_retry_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/with_non_recoverable_error_with_one_retry_spec.rb
@@ -77,5 +77,5 @@ assert_equal (0..99).to_a - [10], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[10]

--- a/spec/integrations/pro/consumption/strategies/dlq/default/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/with_non_recoverable_error_with_retries_spec.rb
@@ -77,5 +77,5 @@ assert_equal (0..99).to_a - [10], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[10]

--- a/spec/integrations/pro/consumption/strategies/dlq/default/with_non_recoverable_error_without_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/with_non_recoverable_error_without_retries_spec.rb
@@ -77,5 +77,5 @@ assert_equal (0..99).to_a - [10], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[10]

--- a/spec/integrations/pro/consumption/strategies/dlq/default/with_non_recoverable_first_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/with_non_recoverable_first_message_spec.rb
@@ -77,5 +77,5 @@ assert_equal (0..99).to_a - [0], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[0]

--- a/spec/integrations/pro/consumption/strategies/dlq/default/with_non_recoverable_last_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/with_non_recoverable_last_message_spec.rb
@@ -83,5 +83,5 @@ assert_equal (0..100).to_a - [99], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[99]

--- a/spec/integrations/pro/consumption/strategies/dlq/default/without_post_dispatch_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/default/without_post_dispatch_marking_spec.rb
@@ -57,4 +57,4 @@ start_karafka_and_wait_until do
   DT[:offsets].size >= 10
 end
 
-assert_equal fetch_next_offset, 1
+assert_equal 1, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr/with_non_recoverable_error_with_one_retry_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr/with_non_recoverable_error_with_one_retry_spec.rb
@@ -81,5 +81,5 @@ assert_equal (0..99).to_a - [10], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[10]

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr/with_non_recoverable_error_with_retries_spec.rb
@@ -81,5 +81,5 @@ assert_equal (0..99).to_a - [10], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[10]

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr/with_non_recoverable_error_without_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr/with_non_recoverable_error_without_retries_spec.rb
@@ -81,5 +81,5 @@ assert_equal (0..99).to_a - [10], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[10]

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj/with_non_recoverable_error_with_one_retry_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj/with_non_recoverable_error_with_one_retry_spec.rb
@@ -82,5 +82,5 @@ assert_equal (0..99).to_a - [10], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[10]

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj/with_non_recoverable_error_with_retries_spec.rb
@@ -82,5 +82,5 @@ assert_equal (0..99).to_a - [10], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[10]

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj/with_non_recoverable_error_without_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_lrj/with_non_recoverable_error_without_retries_spec.rb
@@ -82,5 +82,5 @@ assert_equal (0..99).to_a - [10], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[10]

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_error_handling_pipeline_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_error_handling_pipeline_spec.rb
@@ -70,5 +70,5 @@ end
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[0]

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_error_with_retries_spec.rb
@@ -80,5 +80,5 @@ assert_equal (0..99).to_a - [10], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[10]

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_error_without_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_error_without_retries_spec.rb
@@ -80,5 +80,5 @@ assert_equal (0..99).to_a - [10], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[10]

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_first_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_first_message_spec.rb
@@ -80,5 +80,5 @@ assert_equal (0..99).to_a - [0], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[0]

--- a/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_last_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/ftr_mom/with_non_recoverable_last_message_spec.rb
@@ -86,5 +86,5 @@ assert_equal (0..100).to_a - [99], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[99]

--- a/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/non_recoverable_with_dispatch_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/lrj_mom/non_recoverable_with_dispatch_marking_spec.rb
@@ -62,4 +62,4 @@ start_karafka_and_wait_until do
   DT[:errors].size >= 2 && DT[0].size >= 46 && DT[0].include?(49)
 end
 
-assert_equal fetch_next_offset, 26, fetch_next_offset
+assert_equal 26, fetch_next_offset, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/at_most_once_skipping_on_error_poll_one_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/at_most_once_skipping_on_error_poll_one_spec.rb
@@ -69,4 +69,4 @@ start_karafka_and_wait_until do
 end
 
 assert_equal (DT[0] + DT[:broken]).sort.uniq, (0..19).to_a
-assert_equal DT[:broken], [1, 3, 5, 7, 9, 11, 13, 15, 17, 19]
+assert_equal [1, 3, 5, 7, 9, 11, 13, 15, 17, 19], DT[:broken]

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/non_recoverable_with_dispatch_marking_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/non_recoverable_with_dispatch_marking_spec.rb
@@ -62,4 +62,4 @@ start_karafka_and_wait_until do
   DT[:errors].size >= 2 && DT[0].size >= 46
 end
 
-assert_equal fetch_next_offset, 26
+assert_equal 26, fetch_next_offset

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/with_error_handling_pipeline_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/with_error_handling_pipeline_spec.rb
@@ -68,5 +68,5 @@ end
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[0]

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/with_non_recoverable_error_with_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/with_non_recoverable_error_with_retries_spec.rb
@@ -78,5 +78,5 @@ assert_equal (0..99).to_a - [10], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[10]

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/with_non_recoverable_error_without_retries_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/with_non_recoverable_error_without_retries_spec.rb
@@ -78,5 +78,5 @@ assert_equal (0..99).to_a - [10], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[10]

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/with_non_recoverable_first_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/with_non_recoverable_first_message_spec.rb
@@ -78,5 +78,5 @@ assert_equal (0..99).to_a - [0], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[0]

--- a/spec/integrations/pro/consumption/strategies/dlq/mom/with_non_recoverable_last_message_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/dlq/mom/with_non_recoverable_last_message_spec.rb
@@ -84,5 +84,5 @@ assert_equal (0..100).to_a - [99], DT[:offsets]
 
 assert_equal 1, DT[:broken].size
 # This message will get new offset (first)
-assert_equal DT[:broken][0][0], 0
+assert_equal 0, DT[:broken][0][0]
 assert_equal DT[:broken][0][1], elements[99]

--- a/spec/integrations/pro/consumption/strategies/ftr/starting_from_latest_always_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/starting_from_latest_always_spec.rb
@@ -81,4 +81,4 @@ start_karafka_and_wait_until do
   DT[:offsets].size >= 2
 end
 
-assert_equal DT[:offsets], [99, 100]
+assert_equal [99, 100], DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/ftr/starting_from_latest_transactional_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/starting_from_latest_transactional_spec.rb
@@ -85,4 +85,4 @@ start_karafka_and_wait_until do
   DT[:offsets].size >= 1
 end
 
-assert_equal DT[:offsets], [101]
+assert_equal [101], DT[:offsets]

--- a/spec/integrations/pro/consumption/strategies/vp/collapsing/manual_collapse_and_continuity_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/collapsing/manual_collapse_and_continuity_spec.rb
@@ -60,6 +60,6 @@ start_karafka_and_wait_until do
   DT[0].size >= 100
 end
 
-assert_equal DT[:state][0], false
-assert_equal DT[:post_state][0], false
-assert_equal DT[:state].last, true
+assert_equal false, DT[:state][0]
+assert_equal false, DT[:post_state][0]
+assert_equal true, DT[:state].last

--- a/spec/integrations/pro/consumption/strategies/vp/errors_tracking/consecutive_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/errors_tracking/consecutive_errors_spec.rb
@@ -62,5 +62,5 @@ start_karafka_and_wait_until do
   DT[:errors_collapsed].size >= 2
 end
 
-assert_equal DT[:errors_collapsed].map(&:size).uniq, [10]
-assert_equal DT[:errors_collapsed].map(&:to_a).flatten.map(&:class).uniq.sort_by(&:to_s), [E1, E2]
+assert_equal [10], DT[:errors_collapsed].map(&:size).uniq
+assert_equal [E1, E2], DT[:errors_collapsed].map(&:to_a).flatten.map(&:class).uniq.sort_by(&:to_s)

--- a/spec/integrations/pro/consumption/strategies/vp/with_error_in_partitioner_reduced_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/with_error_in_partitioner_reduced_spec.rb
@@ -70,4 +70,4 @@ start_karafka_and_wait_until do
   DT[:offsets].size >= 20 && DT.key?(:b1) && DT[:raised].size > 5
 end
 
-assert_equal DT[:consumers].uniq.size, 1
+assert_equal 1, DT[:consumers].uniq.size

--- a/spec/integrations/pro/consumption/transactions/dlq/with_crash_during_transational_dispatch_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/dlq/with_crash_during_transational_dispatch_spec.rb
@@ -73,4 +73,4 @@ start_karafka_and_wait_until do
   DT[:errors].size >= 10
 end
 
-assert_equal DT[:offsets].uniq, [0]
+assert_equal [0], DT[:offsets].uniq

--- a/spec/integrations/pro/consumption/transactions/marking_on_current_assignment_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/marking_on_current_assignment_spec.rb
@@ -43,4 +43,4 @@ start_karafka_and_wait_until do
   DT.key?(:marking_result)
 end
 
-assert_equal DT[:marking_result], true
+assert_equal true, DT[:marking_result]

--- a/spec/integrations/pro/consumption/transactions/marking_on_lost_assignment_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/marking_on_lost_assignment_spec.rb
@@ -48,4 +48,4 @@ start_karafka_and_wait_until do
   DT.key?(:marking_result)
 end
 
-assert_equal DT[:marking_result], false
+assert_equal false, DT[:marking_result]

--- a/spec/integrations/pro/consumption/transactions/vps/all_ok_current_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/all_ok_current_spec.rb
@@ -77,6 +77,6 @@ end
 
 last = DT[:last].last
 
-assert_equal DT[:seek_offset], 100
+assert_equal 100, DT[:seek_offset]
 assert_equal DT[:metadata].last, last
-assert_equal fetch_next_offset, 100
+assert_equal 100, fetch_next_offset

--- a/spec/integrations/pro/consumption/transactions/vps/all_ok_exact_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/all_ok_exact_spec.rb
@@ -66,5 +66,5 @@ start_karafka_and_wait_until do
   DT[:done].uniq.size >= 10
 end
 
-assert_equal fetch_next_offset, 100
-assert_equal DT[:metadata].last, "99"
+assert_equal 100, fetch_next_offset
+assert_equal "99", DT[:metadata].last

--- a/spec/integrations/pro/consumption/transactions/vps/collapsed_transaction_error_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/collapsed_transaction_error_spec.rb
@@ -64,5 +64,5 @@ start_karafka_and_wait_until do
   DT.key?(:done)
 end
 
-assert_equal DT[:metadata].last, ""
-assert_equal fetch_next_offset, 0
+assert_equal "", DT[:metadata].last
+assert_equal 0, fetch_next_offset

--- a/spec/integrations/pro/consumption/transactions/vps/collapsed_transaction_ok_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/collapsed_transaction_ok_spec.rb
@@ -62,5 +62,5 @@ start_karafka_and_wait_until do
   DT.key?(:done)
 end
 
-assert_equal DT[:metadata].last, "test-metadata"
-assert_equal fetch_next_offset, 1
+assert_equal "test-metadata", DT[:metadata].last
+assert_equal 1, fetch_next_offset

--- a/spec/integrations/pro/consumption/transactions/vps/one_ok_rest_error_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/one_ok_rest_error_spec.rb
@@ -71,4 +71,4 @@ start_karafka_and_wait_until do
 end
 
 assert_equal DT[:metadata].uniq, %w[test-metadata]
-assert_equal fetch_next_offset, 1
+assert_equal 1, fetch_next_offset

--- a/spec/integrations/pro/consumption/transactions/vps/post_transaction_error_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/post_transaction_error_spec.rb
@@ -72,5 +72,5 @@ start_karafka_and_wait_until do
   DT[:done].uniq.size >= 10
 end
 
-assert_equal DT[:metadata].last, "second"
-assert_equal fetch_next_offset, 10
+assert_equal "second", DT[:metadata].last
+assert_equal 10, fetch_next_offset

--- a/spec/integrations/pro/instrumentation/first_idle_messages_metadata_spec.rb
+++ b/spec/integrations/pro/instrumentation/first_idle_messages_metadata_spec.rb
@@ -59,15 +59,15 @@ start_karafka_and_wait_until do
 end
 
 assert DT[:consumed].empty?
-assert_equal DT[:messages].size, 1
+assert_equal 1, DT[:messages].size
 
 messages = DT[:messages].first
 
-assert_equal messages.metadata.first_offset, -1001
-assert_equal messages.metadata.last_offset, -1001
-assert_equal messages.metadata.partition, 0
-assert_equal messages.metadata.size, 0
-assert_equal messages.metadata.processed_at, nil
+assert_equal(-1001, messages.metadata.first_offset)
+assert_equal(-1001, messages.metadata.last_offset)
+assert_equal 0, messages.metadata.partition
+assert_equal 0, messages.metadata.size
+assert_equal nil, messages.metadata.processed_at
 assert !messages.metadata.created_at.nil?
 assert messages.empty?
 assert DT.key?(:before_schedule_idle)

--- a/spec/integrations/pro/iterator/from_different_offsets_to_the_end_spec.rb
+++ b/spec/integrations/pro/iterator/from_different_offsets_to_the_end_spec.rb
@@ -52,7 +52,7 @@ iterator.each do |message|
   partitioned_data[message.partition] << message
 end
 
-assert_equal partitioned_data.size, 2
+assert_equal 2, partitioned_data.size
 
 # for partition 0 we start from beginning
 offset = 0
@@ -63,7 +63,7 @@ partitioned_data[0].each do |message|
   offset += 1
 end
 
-assert_equal partitioned_elements[0].size, 20
+assert_equal 20, partitioned_elements[0].size
 
 # for partition 1 we start from the middle
 offset = 10
@@ -74,4 +74,4 @@ partitioned_data[1].each do |message|
   offset += 1
 end
 
-assert_equal partitioned_data[1].size, 10, partitioned_data[1].size
+assert_equal 10, partitioned_data[1].size, partitioned_data[1].size

--- a/spec/integrations/pro/iterator/long_living_iterator_spec.rb
+++ b/spec/integrations/pro/iterator/long_living_iterator_spec.rb
@@ -57,4 +57,4 @@ iterator.each do |message|
   buffer << message if message
 end
 
-assert_equal buffer.size, 100
+assert_equal 100, buffer.size

--- a/spec/integrations/pro/iterator/with_many_partitions_all_subscription_to_the_end_spec.rb
+++ b/spec/integrations/pro/iterator/with_many_partitions_all_subscription_to_the_end_spec.rb
@@ -49,7 +49,7 @@ iterator.each do |message|
 end
 
 # All partitions data should be included
-assert_equal partitioned_data.size, 10
+assert_equal 10, partitioned_data.size
 
 # All data should be in order
 partitioned_data.each do |partition, messages|

--- a/spec/integrations/pro/iterator/with_many_partitions_one_early_stop_spec.rb
+++ b/spec/integrations/pro/iterator/with_many_partitions_one_early_stop_spec.rb
@@ -55,7 +55,7 @@ iterator.each do |message, internal_iterator|
 end
 
 # Zero should not be included
-assert_equal partitioned_data.size, 9, partitioned_data.size
+assert_equal 9, partitioned_data.size, partitioned_data.size
 
 # All data should be in order for the rest
 partitioned_data.each do |partition, messages|

--- a/spec/integrations/pro/iterator/with_many_partitions_one_middle_stop_spec.rb
+++ b/spec/integrations/pro/iterator/with_many_partitions_one_middle_stop_spec.rb
@@ -54,7 +54,7 @@ iterator.each do |message, internal_iterator|
   partitioned_data[message.partition] << message
 end
 
-assert_equal partitioned_data.size, 10
+assert_equal 10, partitioned_data.size
 
 # All data should be in order for the rest
 partitioned_data.each do |partition, messages|

--- a/spec/integrations/pro/iterator/with_negative_lookup_for_last_messages_spec.rb
+++ b/spec/integrations/pro/iterator/with_negative_lookup_for_last_messages_spec.rb
@@ -49,4 +49,4 @@ iterator.each do |message|
   i += 1
 end
 
-assert_equal i, 20
+assert_equal 20, i

--- a/spec/integrations/pro/iterator/with_pause_current_partition_usage_spec.rb
+++ b/spec/integrations/pro/iterator/with_pause_current_partition_usage_spec.rb
@@ -61,7 +61,7 @@ iterator.each do |message, internal_iterator|
   partitioned_data[message.topic] << message
 end
 
-assert_equal partitioned_data.size, 2
+assert_equal 2, partitioned_data.size
 
 # All data should be in order for the rest
 partitioned_data.each do |partition, messages|

--- a/spec/integrations/pro/rails/rails72_pristine/with-active_job_and_current_attributes/active_job_run_spec.rb
+++ b/spec/integrations/pro/rails/rails72_pristine/with-active_job_and_current_attributes/active_job_run_spec.rb
@@ -103,6 +103,6 @@ start_karafka_and_wait_until do
   DT[0].size >= 2
 end
 
-assert_equal DT[:a], [5, 7]
-assert_equal DT[:b], [10, 8]
+assert_equal [5, 7], DT[:a]
+assert_equal [10, 8], DT[:b]
 assert Karafka.pro?

--- a/spec/integrations/pro/rails/rails80_pristine/with-active_job_and_current_attributes/active_job_run_spec.rb
+++ b/spec/integrations/pro/rails/rails80_pristine/with-active_job_and_current_attributes/active_job_run_spec.rb
@@ -103,6 +103,6 @@ start_karafka_and_wait_until do
   DT[0].size >= 2
 end
 
-assert_equal DT[:a], [5, 7]
-assert_equal DT[:b], [10, 8]
+assert_equal [5, 7], DT[:a]
+assert_equal [10, 8], DT[:b]
 assert Karafka.pro?

--- a/spec/integrations/pro/rails/rails81_pristine/with-active_job_and_current_attributes/active_job_run_spec.rb
+++ b/spec/integrations/pro/rails/rails81_pristine/with-active_job_and_current_attributes/active_job_run_spec.rb
@@ -103,6 +103,6 @@ start_karafka_and_wait_until do
   DT[0].size >= 2
 end
 
-assert_equal DT[:a], [5, 7]
-assert_equal DT[:b], [10, 8]
+assert_equal [5, 7], DT[:a]
+assert_equal [10, 8], DT[:b]
 assert Karafka.pro?

--- a/spec/integrations/pro/recurring_tasks/logging_data_published_on_errors_spec.rb
+++ b/spec/integrations/pro/recurring_tasks/logging_data_published_on_errors_spec.rb
@@ -76,15 +76,15 @@ start_karafka_and_wait_until do
 end
 
 DT[:messages].each_with_index do |payload, i|
-  assert_equal payload[:schema_version], "1.0"
-  assert_equal payload[:schedule_version], "1.0.0"
-  assert_equal payload[:type], "log"
+  assert_equal "1.0", payload[:schema_version]
+  assert_equal "1.0.0", payload[:schedule_version]
+  assert_equal "log", payload[:type]
   assert payload[:dispatched_at].is_a?(Float)
 
   task = payload[:task]
 
   # Assertions for the task
   assert_equal task[:id], TASK_IDS[i]
-  assert_equal task[:time_taken], -1
-  assert_equal task[:result], "failure"
+  assert_equal(-1, task[:time_taken])
+  assert_equal "failure", task[:result]
 end

--- a/spec/integrations/pro/recurring_tasks/logging_data_published_spec.rb
+++ b/spec/integrations/pro/recurring_tasks/logging_data_published_spec.rb
@@ -70,9 +70,9 @@ start_karafka_and_wait_until do
 end
 
 DT[:messages].each_with_index do |payload, i|
-  assert_equal payload[:schema_version], "1.0"
-  assert_equal payload[:schedule_version], "1.0.0"
-  assert_equal payload[:type], "log"
+  assert_equal "1.0", payload[:schema_version]
+  assert_equal "1.0.0", payload[:schedule_version]
+  assert_equal "log", payload[:type]
   assert payload[:dispatched_at].is_a?(Float)
 
   task = payload[:task]
@@ -80,5 +80,5 @@ DT[:messages].each_with_index do |payload, i|
   # Assertions for the task
   assert_equal task[:id], TASK_IDS[i]
   assert task[:time_taken].is_a?(Float)
-  assert_equal task[:result], "success"
+  assert_equal "success", task[:result]
 end

--- a/spec/integrations/pro/recurring_tasks/routes_creation_spec.rb
+++ b/spec/integrations/pro/recurring_tasks/routes_creation_spec.rb
@@ -35,7 +35,7 @@ schedules = Karafka::Admin.read_topic(
   1
 )
 
-assert_equal schedules, []
+assert_equal [], schedules
 
 # Should not fail as the topic should exist
 logs = Karafka::Admin.read_topic(
@@ -44,4 +44,4 @@ logs = Karafka::Admin.read_topic(
   1
 )
 
-assert_equal logs, []
+assert_equal [], logs

--- a/spec/integrations/pro/recurring_tasks/smarter_reconfiguration_spec.rb
+++ b/spec/integrations/pro/recurring_tasks/smarter_reconfiguration_spec.rb
@@ -42,4 +42,4 @@ rescue Karafka::Errors::CommandValidationError => e
   code = e.cause.code
 end
 
-assert_equal code, :invalid_replication_factor
+assert_equal :invalid_replication_factor, code

--- a/spec/integrations/pro/recurring_tasks/state_structure_spec.rb
+++ b/spec/integrations/pro/recurring_tasks/state_structure_spec.rb
@@ -52,31 +52,31 @@ topic_name = Karafka::App.config.recurring_tasks.topics.schedules.name
 state_message = Karafka::Admin.read_topic(topic_name, 0, 1).last
 payload = state_message.payload
 
-assert_equal state_message.key, "state:schedule"
-assert_equal payload[:schema_version], "1.0"
-assert_equal payload[:schedule_version], "1.0.1"
-assert_equal payload[:type], "schedule"
+assert_equal "state:schedule", state_message.key
+assert_equal "1.0", payload[:schema_version]
+assert_equal "1.0.1", payload[:schedule_version]
+assert_equal "schedule", payload[:type]
 assert payload[:dispatched_at].is_a?(Float)
 
 tasks = payload[:tasks]
 
 # Assertions for task a
-assert_equal tasks[:a][:id], "a"
-assert_equal tasks[:a][:cron], "0 12 31 12 *"
-assert_equal tasks[:a][:previous_time], 0
+assert_equal "a", tasks[:a][:id]
+assert_equal "0 12 31 12 *", tasks[:a][:cron]
+assert_equal 0, tasks[:a][:previous_time]
 assert tasks[:a][:next_time].is_a?(Integer)
-assert_equal tasks[:a][:enabled], false
+assert_equal false, tasks[:a][:enabled]
 
 # Assertions for task b
-assert_equal tasks[:b][:id], "b"
-assert_equal tasks[:b][:cron], "0 12 30 11 *"
-assert_equal tasks[:b][:previous_time], 0
+assert_equal "b", tasks[:b][:id]
+assert_equal "0 12 30 11 *", tasks[:b][:cron]
+assert_equal 0, tasks[:b][:previous_time]
 assert tasks[:b][:next_time].is_a?(Integer)
-assert_equal tasks[:b][:enabled], false
+assert_equal false, tasks[:b][:enabled]
 
 # Assertions for task c
-assert_equal tasks[:c][:id], "c"
-assert_equal tasks[:c][:cron], "* * * * *"
+assert_equal "c", tasks[:c][:id]
+assert_equal "* * * * *", tasks[:c][:cron]
 assert tasks[:c][:next_time].is_a?(Integer)
 assert tasks[:c][:previous_time].is_a?(Integer)
-assert_equal tasks[:c][:enabled], true
+assert_equal true, tasks[:c][:enabled]

--- a/spec/integrations/pro/routing/with_different_backoff_settings_in_one_sg_spec.rb
+++ b/spec/integrations/pro/routing/with_different_backoff_settings_in_one_sg_spec.rb
@@ -49,10 +49,10 @@ t2 = Karafka::App.consumer_groups.first.topics.last
 
 assert_equal t1.subscription_group, t2.subscription_group
 
-assert_equal t1.pause_timeout, 100
-assert_equal t1.pause_max_timeout, 1_000
-assert_equal t1.pause_with_exponential_backoff, true
+assert_equal 100, t1.pause_timeout
+assert_equal 1_000, t1.pause_max_timeout
+assert_equal true, t1.pause_with_exponential_backoff
 
-assert_equal t2.pause_timeout, 200
-assert_equal t2.pause_max_timeout, 2_000
-assert_equal t2.pause_with_exponential_backoff, false
+assert_equal 200, t2.pause_timeout
+assert_equal 2_000, t2.pause_max_timeout
+assert_equal false, t2.pause_with_exponential_backoff

--- a/spec/integrations/pro/scheduled_messages/future_scheduled_cancelling_spec.rb
+++ b/spec/integrations/pro/scheduled_messages/future_scheduled_cancelling_spec.rb
@@ -67,4 +67,4 @@ start_karafka_and_wait_until(sleep: 1) do
 end
 
 # Nothing should have been dispatched
-assert_equal Karafka::Admin.read_topic(DT.topics[1], 0, 1), []
+assert_equal [], Karafka::Admin.read_topic(DT.topics[1], 0, 1)

--- a/spec/integrations/pro/scheduled_messages/with_dispatched_except_one_for_dispatch_spec.rb
+++ b/spec/integrations/pro/scheduled_messages/with_dispatched_except_one_for_dispatch_spec.rb
@@ -103,17 +103,17 @@ start_karafka_and_wait_until(sleep: 1) do
 end
 
 # Only this message should be available
-assert_equal dispatched.raw_key, "key-101"
-assert_equal dispatched.raw_payload, "payload-101"
-assert_equal dispatched.partition, 0
+assert_equal "key-101", dispatched.raw_key
+assert_equal "payload-101", dispatched.raw_payload
+assert_equal 0, dispatched.partition
 
 headers = dispatched.raw_headers
 
-assert_equal headers["id"], "101"
-assert_equal headers["schedule_schema_version"], "1.0.0"
+assert_equal "101", headers["id"]
+assert_equal "1.0.0", headers["schedule_schema_version"]
 assert headers.key?("schedule_target_epoch")
-assert_equal headers["schedule_source_type"], "schedule"
+assert_equal "schedule", headers["schedule_source_type"]
 assert_equal headers["schedule_target_topic"], DT.topics[1]
-assert_equal headers["schedule_target_partition"], "0"
-assert_equal headers["schedule_target_key"], "key-101"
+assert_equal "0", headers["schedule_target_partition"]
+assert_equal "key-101", headers["schedule_target_key"]
 assert_equal headers["schedule_source_topic"], DT.topic

--- a/spec/integrations/pro/scheduled_messages/without_any_messages_spec.rb
+++ b/spec/integrations/pro/scheduled_messages/without_any_messages_spec.rb
@@ -36,8 +36,8 @@ end
 
 today = Date.today.strftime("%Y-%m-%d")
 
-assert_equal state.headers, { "zlib" => "true" }
-assert_equal state.payload[:schema_version], "1.0.0"
-assert_equal state.payload[:state], "loaded"
-assert_equal state.payload[:daily], { today.to_sym => 0 }
+assert_equal({ "zlib" => "true" }, state.headers)
+assert_equal "1.0.0", state.payload[:schema_version]
+assert_equal "loaded", state.payload[:state]
+assert_equal({ today.to_sym => 0 }, state.payload[:daily])
 assert state.payload[:dispatched_at] > Time.now.to_f - 100

--- a/spec/integrations/pro/web/with_tick_and_eofed_errors_spec.rb
+++ b/spec/integrations/pro/web/with_tick_and_eofed_errors_spec.rb
@@ -61,5 +61,5 @@ end
 
 error = Karafka::Admin.read_topic(Karafka::Web.config.topics.errors.name, 0, 1).first.payload
 
-assert_equal error[:details][:first_offset], -1001
-assert_equal error[:details][:last_offset], -1001
+assert_equal(-1001, error[:details][:first_offset])
+assert_equal(-1001, error[:details][:last_offset])

--- a/spec/integrations/production/compression_different_no_conflict_spec.rb
+++ b/spec/integrations/production/compression_different_no_conflict_spec.rb
@@ -33,5 +33,5 @@ variant2.produce_sync(topic: DT.topic, payload: "test2")
 Karafka.producer.close
 
 messages = Karafka::Admin.read_topic(DT.topic, 0, 2)
-assert_equal messages[0].raw_payload, "test1"
-assert_equal messages[1].raw_payload, "test2"
+assert_equal "test1", messages[0].raw_payload
+assert_equal "test2", messages[1].raw_payload

--- a/spec/integrations/production/reject_no_key_message_when_compacted_spec.rb
+++ b/spec/integrations/production/reject_no_key_message_when_compacted_spec.rb
@@ -22,7 +22,7 @@ rescue WaterDrop::Errors::ProduceError => e
   errors << e
 end
 
-assert_equal errors.last.cause.code, :invalid_record
+assert_equal :invalid_record, errors.last.cause.code
 
 Karafka.producer.produce_sync(topic: DT.topic, payload: "test1", key: "1")
 

--- a/spec/integrations/rails/rails72_pristine/with-active_job_and_current_attributes/active_job_run_spec.rb
+++ b/spec/integrations/rails/rails72_pristine/with-active_job_and_current_attributes/active_job_run_spec.rb
@@ -68,5 +68,5 @@ start_karafka_and_wait_until do
   DT[0].size >= 2
 end
 
-assert_equal DT[:a], [5, 7]
-assert_equal DT[:b], [10, 8]
+assert_equal [5, 7], DT[:a]
+assert_equal [10, 8], DT[:b]

--- a/spec/integrations/rails/rails80_pristine/with-active_job_and_current_attributes/active_job_run_spec.rb
+++ b/spec/integrations/rails/rails80_pristine/with-active_job_and_current_attributes/active_job_run_spec.rb
@@ -68,5 +68,5 @@ start_karafka_and_wait_until do
   DT[0].size >= 2
 end
 
-assert_equal DT[:a], [5, 7]
-assert_equal DT[:b], [10, 8]
+assert_equal [5, 7], DT[:a]
+assert_equal [10, 8], DT[:b]

--- a/spec/integrations/rails/rails81_pristine/with-active_job_and_current_attributes/active_job_run_spec.rb
+++ b/spec/integrations/rails/rails81_pristine/with-active_job_and_current_attributes/active_job_run_spec.rb
@@ -68,5 +68,5 @@ start_karafka_and_wait_until do
   DT[0].size >= 2
 end
 
-assert_equal DT[:a], [5, 7]
-assert_equal DT[:b], [10, 8]
+assert_equal [5, 7], DT[:a]
+assert_equal [10, 8], DT[:b]

--- a/spec/integrations/rebalancing/lifecycle_events_spec.rb
+++ b/spec/integrations/rebalancing/lifecycle_events_spec.rb
@@ -78,5 +78,5 @@ REBALANCE_EVENTS.each do |event_name|
   end
 
   assert group_a.size > group_b.size
-  assert_equal group_b.size, 1
+  assert_equal 1, group_b.size
 end

--- a/spec/integrations/rebalancing/message_order_with_sync_commit_spec.rb
+++ b/spec/integrations/rebalancing/message_order_with_sync_commit_spec.rb
@@ -148,7 +148,7 @@ count = DT[:consecutive_messages].count do |key, _, _|
   key == DT[:contested_message].first.payload["key"]
 end
 
-assert_equal(count, 2)
+assert_equal(2, count)
 
 # The only failed commit should be that of the contested message
 assert_equal 1, DT[:failed_commits].size

--- a/spec/integrations/routing/stable_with_subscription_groups_spec.rb
+++ b/spec/integrations/routing/stable_with_subscription_groups_spec.rb
@@ -32,6 +32,6 @@ g01 = Karafka::App.subscription_groups.values[0][1].kafka[:"group.instance.id"]
 g10 = Karafka::App.subscription_groups.values[1][0].kafka[:"group.instance.id"]
 
 assert [g00, g01, g10].uniq.size == 3
-assert_equal g00, "#{UUID}_0"
-assert_equal g01, "#{UUID}_1"
-assert_equal g10, "#{UUID}_2"
+assert_equal "#{UUID}_0", g00
+assert_equal "#{UUID}_1", g01
+assert_equal "#{UUID}_2", g10

--- a/spec/integrations/routing/topic_custom_attributes_spec.rb
+++ b/spec/integrations/routing/topic_custom_attributes_spec.rb
@@ -53,10 +53,10 @@ end
 t1 = Karafka::App.consumer_groups[0].topics.first
 t2 = Karafka::App.consumer_groups[1].topics.first
 
-assert_equal t1.custom_attributes.mine, 1
-assert_equal t1.custom_attributes.yours, 2
-assert_equal t2.custom_attributes.mine, 3
-assert_equal t2.custom_attributes.yours, 4
+assert_equal 1, t1.custom_attributes.mine
+assert_equal 2, t1.custom_attributes.yours
+assert_equal 3, t2.custom_attributes.mine
+assert_equal 4, t2.custom_attributes.yours
 
 produce(DT.topics[0], "{}")
 

--- a/spec/integrations/routing/with_altered_routing_flow_spec.rb
+++ b/spec/integrations/routing/with_altered_routing_flow_spec.rb
@@ -104,6 +104,6 @@ end
 
 dlq_config = Karafka::App.routes.first.topics.first.dead_letter_queue
 
-assert_equal dlq_config.topic, "dead_messages2"
-assert_equal dlq_config.max_retries, 2
-assert_equal dlq_config.independent, false
+assert_equal "dead_messages2", dlq_config.topic
+assert_equal 2, dlq_config.max_retries
+assert_equal false, dlq_config.independent

--- a/spec/integrations/seek/beyond_high_watermark_offset_spec.rb
+++ b/spec/integrations/seek/beyond_high_watermark_offset_spec.rb
@@ -24,4 +24,4 @@ start_karafka_and_wait_until do
   DT[:runs].size >= 5
 end
 
-assert_equal DT[:runs].uniq, [0]
+assert_equal [0], DT[:runs].uniq

--- a/spec/integrations/seek/seek_on_many_partitions_with_reset_spec.rb
+++ b/spec/integrations/seek/seek_on_many_partitions_with_reset_spec.rb
@@ -49,7 +49,7 @@ cg = Karafka::App.consumer_groups.first.id
 part_results = results.fetch(cg).fetch(DT.topic)
 
 PARTITIONS.each do |i|
-  assert_equal DT[i], 19 - i
-  assert_equal part_results[i][:offset], 20 - i
+  assert_equal 19 - i, DT[i]
+  assert_equal 20 - i, part_results[i][:offset]
   assert_equal part_results[i][:lag], i
 end

--- a/spec/integrations/seek/to_high_watermark_offset_spec.rb
+++ b/spec/integrations/seek/to_high_watermark_offset_spec.rb
@@ -24,4 +24,4 @@ start_karafka_and_wait_until do
   DT.key?(:runs) && sleep(3)
 end
 
-assert_equal DT[:runs].size, 1
+assert_equal 1, DT[:runs].size

--- a/spec/integrations/seek/to_latest_spec.rb
+++ b/spec/integrations/seek/to_latest_spec.rb
@@ -39,4 +39,4 @@ start_karafka_and_wait_until do
   DT[0].include?("test")
 end
 
-assert_equal DT[0].last, "test"
+assert_equal "test", DT[0].last

--- a/spec/integrations/setup/config_with_inherited_client_id_spec.rb
+++ b/spec/integrations/setup/config_with_inherited_client_id_spec.rb
@@ -7,8 +7,8 @@ setup_karafka do |config|
   config.client_id = "test-app"
 end
 
-assert_equal Karafka::App.config.kafka[:"client.id"], nil
+assert_equal nil, Karafka::App.config.kafka[:"client.id"]
 
 draw_routes(Karafka::BaseConsumer)
 
-assert_equal Karafka::App.routes.first.subscription_groups.first.kafka[:"client.id"], "test-app"
+assert_equal "test-app", Karafka::App.routes.first.subscription_groups.first.kafka[:"client.id"]

--- a/spec/integrations/setup/config_with_overwritten_client_id_spec.rb
+++ b/spec/integrations/setup/config_with_overwritten_client_id_spec.rb
@@ -7,4 +7,4 @@ setup_karafka do |config|
   config.kafka[:"client.id"] = "alternative-name"
 end
 
-assert_equal Karafka::App.config.kafka[:"client.id"], "alternative-name"
+assert_equal "alternative-name", Karafka::App.config.kafka[:"client.id"]

--- a/spec/integrations/setup/debug_mode_spec.rb
+++ b/spec/integrations/setup/debug_mode_spec.rb
@@ -28,26 +28,26 @@ end
 
 Karafka::App.debug!
 
-assert_equal Karafka::App.logger.level, 0
-assert_equal Karafka::App.producer.config.logger.level, 0
-assert_equal Karafka::App.config.kafka[:debug], "all"
-assert_equal Karafka::App.producer.config.kafka[:debug], "all"
+assert_equal 0, Karafka::App.logger.level
+assert_equal 0, Karafka::App.producer.config.logger.level
+assert_equal "all", Karafka::App.config.kafka[:debug]
+assert_equal "all", Karafka::App.producer.config.kafka[:debug]
 
 Karafka::App.consumer_groups.each do |consumer_group|
   consumer_group.topics.each do |topic|
-    assert_equal topic.kafka[:debug], "all"
+    assert_equal "all", topic.kafka[:debug]
   end
 end
 
 Karafka::App.debug!("test")
 
-assert_equal Karafka::App.logger.level, 0
-assert_equal Karafka::App.producer.config.logger.level, 0
-assert_equal Karafka::App.config.kafka[:debug], "test"
-assert_equal Karafka::App.producer.config.kafka[:debug], "test"
+assert_equal 0, Karafka::App.logger.level
+assert_equal 0, Karafka::App.producer.config.logger.level
+assert_equal "test", Karafka::App.config.kafka[:debug]
+assert_equal "test", Karafka::App.producer.config.kafka[:debug]
 
 Karafka::App.consumer_groups.each do |consumer_group|
   consumer_group.topics.each do |topic|
-    assert_equal topic.kafka[:debug], "test"
+    assert_equal "test", topic.kafka[:debug]
   end
 end

--- a/spec/integrations/setup/with_custom_worker_thread_priority_spec.rb
+++ b/spec/integrations/setup/with_custom_worker_thread_priority_spec.rb
@@ -27,5 +27,5 @@ start_karafka_and_wait_until do
   DT.key?(:done)
 end
 
-assert_equal DT[:worker_thread_priority], 2
-assert_equal DT[:listener_thread_priority], -2
+assert_equal 2, DT[:worker_thread_priority]
+assert_equal(-2, DT[:listener_thread_priority])

--- a/spec/integrations/swarm/with_different_producer_payload_sizes_spec.rb
+++ b/spec/integrations/swarm/with_different_producer_payload_sizes_spec.rb
@@ -39,5 +39,5 @@ start_karafka_and_wait_until(mode: :swarm) do
   DT[:producer_id] = producer_id
 end
 
-assert_equal DT[:max_payload_size], "10999"
+assert_equal "10999", DT[:max_payload_size]
 assert PRODUCER.id != DT[:producer_id]


### PR DESCRIPTION
## Summary

- Swap 304 misordered `assert_equal` calls across 148 integration test files so the expected (literal) value comes first and the actual (dynamic) expression comes second, following standard xUnit convention
- Use parenthesized form `assert_equal(...)` where the expected value starts with `{` (hash literal) or `-` (negative number) to avoid Ruby parsing ambiguities (`Lint/AmbiguousOperator`, block-vs-hash)
- No functional change — `assert_equal` uses `==` which is commutative; this only improves failure message clarity ("expected X, got Y" now labels correctly)

## Test plan

- [x] All 148 modified files pass `rubocop` with no new offenses
- [x] Spot-checked representative samples: DT accessors, method chains, 3-argument forms, hash/array literals, negative numbers, string interpolations
- [x] CI green (cosmetic-only change, no behavior difference)