### PR TITLE
Prevent duplicate topic creation in consumer_groups_spec

### DIFF
--- a/spec/lib/karafka/admin/consumer_groups_spec.rb
+++ b/spec/lib/karafka/admin/consumer_groups_spec.rb
@@ -125,7 +125,10 @@ RSpec.describe Karafka::Admin::ConsumerGroups do
     end
 
     context "when querying existing topic with a CG that never consumed it" do
-      before { PRODUCERS.regular.produce_sync(topic: name, payload: "1") }
+      before do
+        Karafka::Admin::Topics.create(name, 1, 1)
+        PRODUCERS.regular.produce_sync(topic: name, payload: "1")
+      end
 
       let(:cgs_t) { { "doesnotexist" => [name] } }
 


### PR DESCRIPTION
## Summary
- Explicitly create topic before producing in `#read_lags_with_offsets` spec to avoid relying on Kafka auto-topic-creation, which causes `TOPIC_ALREADY_EXISTS` warnings

## Context
The `consumer_groups_spec.rb` `#read_lags_with_offsets` test was producing to a topic without explicitly creating it first. This caused Kafka's auto-topic-creation to trigger duplicate creation attempts, resulting in `TOPIC_ALREADY_EXISTS` warnings that fail `bin/verify_kafka_warnings`.

Follows the same fix pattern as d2b35f1c and 11019fb7.