### PR TITLE
Raise on incomplete manually-defined License module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [Fix] Fix `DataCollector::SPEC_HASH` producing non-deterministic hashes for pristine and poro specs by passing the original spec path via `KARAFKA_SPEC_PATH` env var.
 - [Maintenance] Add `bin/tests_topics_hashes` script for looking up spec files by their topic name hash prefix.
 - [Change] Require `karafka-rdkafka` `>=` `0.26.1` to support upcoming features relying on low-level Rdkafka APIs.
+- [Fix] Raise `InvalidLicenseTokenError` when a manually-defined `Karafka::License` module is missing required methods (`#token` or `#version`) instead of silently skipping pro component loading, which previously caused confusing `NameError` exceptions later in the boot process.
 
 ## 2.5.9 (2026-03-30)
 - [Enhancement] Validate that `statistics.interval.ms` is not zero when dynamic multiplexing is enabled (Pro).

--- a/lib/karafka/licenser.rb
+++ b/lib/karafka/licenser.rb
@@ -62,7 +62,7 @@ module Karafka
           <<~MSG.tr("\n", " ")
             Karafka::License module is defined but missing required method(s): #{missing.join(", ")}.
             When defining Karafka::License manually, both #token and #version must be implemented.
-            Please refer to https://karafka.io/docs/Pro-Enterprise-License/ for details.
+            Please refer to https://karafka.io/docs/Pro-Enterprise-License-Setup/ for details.
           MSG
         )
       end

--- a/lib/karafka/licenser.rb
+++ b/lib/karafka/licenser.rb
@@ -46,12 +46,25 @@ module Karafka
 
       # Check if License module and required methods are already defined
       # @return [Boolean]
+      # @raise [Errors::InvalidLicenseTokenError] when License module exists but is missing
+      #   required methods (token or version)
       def license_fully_defined?
         return false unless const_defined?("::Karafka::License")
 
-        # Check if the required methods exist
-        ::Karafka::License.respond_to?(:token) &&
-          ::Karafka::License.respond_to?(:version)
+        missing = []
+        missing << "#token" unless ::Karafka::License.respond_to?(:token)
+        missing << "#version" unless ::Karafka::License.respond_to?(:version)
+
+        return true if missing.empty?
+
+        raise(
+          Errors::InvalidLicenseTokenError,
+          <<~MSG.tr("\n", " ")
+            Karafka::License module is defined but missing required method(s): #{missing.join(", ")}.
+            When defining Karafka::License manually, both #token and #version must be implemented.
+            Please refer to https://karafka.io/docs/Pro-Enterprise-License/ for details.
+          MSG
+        )
       end
 
       # Attempt to safely load license without executing gem code

--- a/spec/lib/karafka/licenser_spec.rb
+++ b/spec/lib/karafka/licenser_spec.rb
@@ -257,8 +257,7 @@ RSpec.describe_current do
           described_class.detect { true }
         end
 
-        it "overwrites existing stale License constant with gem data" do
-          # First define a stale License module
+        it "raises when existing License constant is missing version" do
           stale_license = Module.new do
             def self.token
               "stale-token"
@@ -266,12 +265,8 @@ RSpec.describe_current do
           end
           stub_const("Karafka::License", stale_license)
 
-          # Should overwrite with actual gem data
-          described_class.detect { true }
-
-          expect(Karafka::License.token).to eq(license_content)
-          expect(Karafka::License.token).not_to eq("stale-token")
-          expect(Karafka::License.version).to eq(version_content)
+          expect { described_class.detect { true } }
+            .to raise_error(Karafka::Errors::InvalidLicenseTokenError, /missing required method/)
         end
       end
     end
@@ -281,16 +276,14 @@ RSpec.describe_current do
 
       before do
         stub_const("Karafka::License", incomplete_license_module)
-        # Module exists but doesn't have token or version methods
       end
 
-      it "attempts to load the license" do
-        expect(described_class).to receive(:safe_load_license).and_call_original
-        begin
-          described_class.detect { true }
-        rescue
-          nil
-        end
+      it "raises InvalidLicenseTokenError listing missing methods" do
+        expect { described_class.detect { true } }
+          .to raise_error(
+            Karafka::Errors::InvalidLicenseTokenError,
+            /missing required method\(s\): #token, #version/
+          )
       end
     end
   end


### PR DESCRIPTION
When users define Karafka::License manually (e.g. from a secret manager or in tests) without implementing all required methods, Licenser.detect previously failed silently — returning false and skipping pro component loading. This led to confusing NameError exceptions later (e.g. uninitialized constant Cleaner) with no indication of the root cause.

Now raises InvalidLicenseTokenError with a clear message listing which methods are missing when a License module exists but is incomplete.