### PR TITLE
Fix swarm supervisor leaking pipe FDs on node restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [Fix] Fire liveness events during `wait_pinging` so nodes continue reporting health status during shutdown with active LRJ jobs.
 - [Maintenance] Use namespaced topic naming format in all integration specs for consistent traceability.
 - [Fix] Fix `DataCollector::SPEC_HASH` producing non-deterministic hashes for pristine and poro specs by passing the original spec path via `KARAFKA_SPEC_PATH` env var.
+- [Fix] Fix swarm supervisor leaking reader pipe file descriptors on node restarts by closing the old reader before creating a new pipe in `Node#start`.
 - [Maintenance] Add `bin/tests_topics_hashes` script for looking up spec files by their topic name hash prefix.
 - [Change] Require `karafka-rdkafka` `>=` `0.26.1` to support upcoming features relying on low-level Rdkafka APIs.
 

--- a/bin/verify_kafka_warnings
+++ b/bin/verify_kafka_warnings
@@ -12,6 +12,7 @@ allowed_patterns=(
    "Creating new"
    "Unloaded transaction metadata"
    "Topic '__consumer_offsets' already exists"
+   "Topic '__transaction_state' already exists"
    "Node may not be available"
    "UNKNOWN_TOPIC_OR_PARTITION from the leader for partition"
    "Error processing kafka.server:type=BrokerTopicMetrics"

--- a/lib/karafka/swarm/node.rb
+++ b/lib/karafka/swarm/node.rb
@@ -45,7 +45,7 @@ module Karafka
       #   - recreates producer and web producer
       # @note Parent API
       def start
-        @reader&.close
+        @reader.close if @reader && !@reader.closed?
         @reader, @writer = IO.pipe
         # Reset alive status when starting/restarting a node
         # nil means unknown status - will check with waitpid

--- a/lib/karafka/swarm/node.rb
+++ b/lib/karafka/swarm/node.rb
@@ -48,7 +48,11 @@ module Karafka
         # Close the previous reader pipe if it exists to prevent FD leaks on node restarts.
         # Without this, each restart orphans the old reader pipe in the supervisor, and forked
         # children inherit all accumulated leaked FDs.
-        @reader&.close rescue nil
+        begin
+          @reader&.close
+        rescue IOError
+          nil
+        end
         @reader, @writer = IO.pipe
         # Reset alive status when starting/restarting a node
         # nil means unknown status - will check with waitpid

--- a/lib/karafka/swarm/node.rb
+++ b/lib/karafka/swarm/node.rb
@@ -45,6 +45,9 @@ module Karafka
       #   - recreates producer and web producer
       # @note Parent API
       def start
+        # Close the previous reader pipe if it exists to prevent FD leaks on node restarts.
+        # Without this, each restart orphans the old reader pipe in the supervisor, and forked
+        # children inherit all accumulated leaked FDs.
         @reader&.close rescue nil
         @reader, @writer = IO.pipe
         # Reset alive status when starting/restarting a node

--- a/lib/karafka/swarm/node.rb
+++ b/lib/karafka/swarm/node.rb
@@ -45,7 +45,7 @@ module Karafka
       #   - recreates producer and web producer
       # @note Parent API
       def start
-        @reader.close if @reader && !@reader.closed?
+        @reader&.close rescue nil
         @reader, @writer = IO.pipe
         # Reset alive status when starting/restarting a node
         # nil means unknown status - will check with waitpid

--- a/lib/karafka/swarm/node.rb
+++ b/lib/karafka/swarm/node.rb
@@ -45,6 +45,7 @@ module Karafka
       #   - recreates producer and web producer
       # @note Parent API
       def start
+        @reader&.close
         @reader, @writer = IO.pipe
         # Reset alive status when starting/restarting a node
         # nil means unknown status - will check with waitpid

--- a/spec/integrations/connection/consumer_cycle_pipe_fd_leak_spec.rb
+++ b/spec/integrations/connection/consumer_cycle_pipe_fd_leak_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+# Repeatedly creating and closing rdkafka consumers (the way Karafka does during multiplexing
+# scale-up / scale-down) must not leak pipe file descriptors. Each consumer cycle creates a new
+# librdkafka client with internal pipes; rd_kafka_destroy must clean them all up.
+#
+# We also cycle a WaterDrop producer alongside each consumer to exercise the producer pipe
+# (QueuePipe) lifecycle, since a real swarm node has both consumers and producers active.
+
+LINUX = RUBY_PLATFORM.include?("linux")
+
+setup_karafka do |config|
+  config.kafka[:"max.poll.interval.ms"] = 10_000
+  config.kafka[:"session.timeout.ms"] = 10_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+  end
+end
+
+draw_routes(Consumer)
+
+produce_many(DT.topic, DT.uuids(1))
+
+def count_pipe_fds
+  Dir.glob("/proc/self/fd/*").count do |fd_path|
+    File.readlink(fd_path).start_with?("pipe:")
+  rescue Errno::ENOENT
+    false
+  end
+end
+
+# Build kafka config exactly the way Karafka::Connection::Client#build_consumer does
+def build_kafka_config
+  sg = Karafka::App.subscription_groups.values.flatten.first
+
+  config = Rdkafka::Config.new(sg.kafka.merge("group.id": SecureRandom.uuid))
+  # Karafka always splits events queue from consumer queue
+  config.consumer_poll_set = false
+  config
+end
+
+# Cycle: create consumer, subscribe, poll briefly, close — mirrors multiplexing scale-up/down
+def create_and_destroy_consumer
+  config = build_kafka_config
+  consumer = config.consumer
+  consumer.subscribe(DT.topic)
+
+  # Poll a few times to let librdkafka establish internal threads/pipes
+  3.times do
+    consumer.poll(100)
+    consumer.events_poll(50)
+  end
+
+  consumer.close
+end
+
+# Also cycle a WaterDrop producer alongside to exercise producer QueuePipe lifecycle
+def create_and_destroy_producer
+  kafka_config = Karafka::Setup::AttributesMap.producer(Karafka::App.config.kafka.dup)
+
+  producer = WaterDrop::Producer.new do |p_config|
+    p_config.kafka = kafka_config
+    p_config.logger = Karafka::App.config.logger
+  end
+
+  producer.produce_sync(topic: DT.topic, payload: "test")
+  producer.close
+end
+
+pipe_counts = []
+
+# Warm up — let the first consumer/producer creation settle
+create_and_destroy_consumer
+create_and_destroy_producer
+
+# Wait for background librdkafka threads to fully shut down
+sleep(1)
+
+pipe_counts << count_pipe_fds if LINUX
+
+# Run 20 create/destroy cycles to expose any per-cycle FD leak
+20.times do |i|
+  create_and_destroy_consumer
+  create_and_destroy_producer
+
+  # Let librdkafka fully clean up between cycles
+  sleep(0.5) if (i % 5).zero?
+
+  pipe_counts << count_pipe_fds if LINUX
+end
+
+# Final settle
+sleep(1)
+pipe_counts << count_pipe_fds if LINUX
+
+if LINUX && pipe_counts.size >= 2
+  growth = pipe_counts.last - pipe_counts.first
+
+  # With 20 cycles, if each leaks even 1 pipe we'd see growth of 20+.
+  # Allow small tolerance for timing/GC variance.
+  assert(
+    growth <= 4,
+    "Pipe FDs grew by #{growth} over 20 consumer+producer cycles " \
+    "(#{pipe_counts.first} -> #{pipe_counts.last}), counts: #{pipe_counts.inspect}"
+  )
+end

--- a/spec/integrations/pro/swarm/pipe_fd_stability_with_multiplexing_spec.rb
+++ b/spec/integrations/pro/swarm/pipe_fd_stability_with_multiplexing_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+# Karafka Pro - Source Available Commercial Software
+# Copyright (c) 2017-present Maciej Mensfeld. All rights reserved.
+#
+# This software is NOT open source. It is source-available commercial software
+# requiring a paid license for use. It is NOT covered by LGPL.
+#
+# The author retains all right, title, and interest in this software,
+# including all copyrights, patents, and other intellectual property rights.
+# No patent rights are granted under this license.
+#
+# PROHIBITED:
+# - Use without a valid commercial license
+# - Redistribution, modification, or derivative works without authorization
+# - Reverse engineering, decompilation, or disassembly of this software
+# - Use as training data for AI/ML models or inclusion in datasets
+# - Scraping, crawling, or automated collection for any purpose
+#
+# PERMITTED:
+# - Reading, referencing, and linking for personal or commercial use
+# - Runtime retrieval by AI assistants, coding agents, and RAG systems
+#   for the purpose of providing contextual help to Karafka users
+#
+# Receipt, viewing, or possession of this software does not convey or
+# imply any license or right beyond those expressly stated above.
+#
+# License: https://karafka.io/docs/Pro-License-Comm/
+# Contact: contact@karafka.io
+
+# Comprehensive pipe FD stability test under realistic swarm workload.
+# Runs 2 nodes with multiplexing, consumer-side producing, and periodic node restarts.
+# Asserts that pipe FD count in the supervisor does not grow over time — catching leaks
+# from any source (node management, librdkafka, WaterDrop, etc.).
+
+setup_karafka do |config|
+  config.swarm.nodes = 2
+  config.internal.swarm.node_restart_timeout = 1_000
+  config.internal.swarm.supervision_interval = 1_000
+  config.kafka[:"max.poll.interval.ms"] = 10_000
+  config.kafka[:"session.timeout.ms"] = 10_000
+end
+
+READER, WRITER = IO.pipe
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      # Produce back to exercise WaterDrop producer pipes in forked process
+      produce_sync(topic: DT.topics[1], payload: message.raw_payload)
+    end
+
+    WRITER.puts("1")
+    WRITER.flush
+
+    @consume_count ||= 0
+    @consume_count += 1
+
+    # Trigger node restart every 3rd consume call to exercise the fork cycle
+    exit! if (@consume_count % 3).zero?
+  end
+end
+
+draw_routes do
+  subscription_group do
+    multiplexing(max: 2, min: 1, boot: 2)
+
+    topic DT.topics[0] do
+      consumer Consumer
+      config(partitions: 4)
+    end
+
+    topic DT.topics[1] do
+      consumer Consumer
+      config(partitions: 4)
+    end
+  end
+end
+
+def count_pipe_fds
+  Dir.glob("/proc/self/fd/*").count do |fd_path|
+    File.readlink(fd_path).start_with?("pipe:")
+  rescue Errno::ENOENT
+    false
+  end
+end
+
+# Sample pipe FD count in the supervisor after every fork
+Karafka::App.monitor.subscribe("swarm.manager.after_fork") do
+  DT[:pipe_counts] << count_pipe_fds
+end
+
+# Produce enough messages to sustain consumption for ~60s across restarts
+4.times do |i|
+  produce_many(DT.topics[0], DT.uuids(100), partition: i)
+end
+
+START_TIME = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+start_karafka_and_wait_until(mode: :swarm) do
+  READER.gets
+  # Run for at least 60 seconds to catch slow leaks (e.g. every 10s)
+  Process.clock_gettime(Process::CLOCK_MONOTONIC) - START_TIME >= 60
+end
+
+pipe_counts = DT[:pipe_counts]
+
+# On Linux we expect meaningful pipe FD samples from the supervisor
+# On non-Linux, count_pipe_fds returns 0 (no /proc/self/fd), so the assertion trivially passes
+if pipe_counts.size >= 2
+  growth = pipe_counts.last - pipe_counts.first
+  assert growth <= 4, "Pipe FDs grew by #{growth} (#{pipe_counts.first} -> #{pipe_counts.last}), indicating a leak"
+end

--- a/spec/integrations/swarm/node_pipe_fd_leak_on_restart_spec.rb
+++ b/spec/integrations/swarm/node_pipe_fd_leak_on_restart_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# When nodes restart, the supervisor should close old reader pipes to prevent FD leaks.
+# Each node restart creates a new IO.pipe pair in Node#start. Without proper cleanup,
+# old reader pipe FDs accumulate in the supervisor process, eventually hitting OS limits.
+
+setup_karafka do |config|
+  config.swarm.nodes = 1
+  config.internal.swarm.node_restart_timeout = 1_000
+  config.internal.swarm.supervision_interval = 1_000
+  config.kafka[:"max.poll.interval.ms"] = 10_000
+  config.kafka[:"session.timeout.ms"] = 10_000
+end
+
+READER, WRITER = IO.pipe
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    WRITER.puts("1")
+    WRITER.flush
+    exit!
+  end
+end
+
+draw_routes(Consumer)
+
+produce_many(DT.topic, DT.uuids(10))
+
+def count_pipe_fds
+  Dir.glob("/proc/self/fd/*").count do |fd_path|
+    File.readlink(fd_path).start_with?("pipe:")
+  rescue Errno::ENOENT
+    false
+  end
+end
+
+Karafka::App.monitor.subscribe("swarm.manager.after_fork") do
+  DT[:pipe_counts] << count_pipe_fds
+end
+
+done = []
+start_karafka_and_wait_until(mode: :swarm) do
+  done << READER.gets
+  done.size >= 5
+end
+
+pipe_counts = DT[:pipe_counts]
+
+# We should have at least 5 forks (1 initial + 4 restarts)
+assert pipe_counts.size >= 5
+
+# After multiple node restarts, pipe FD count in the supervisor should remain stable.
+# With the leak: each restart adds 1 orphaned reader pipe FD, so we see linear growth.
+# Without the leak: old readers are closed before creating new pipes, count stays stable.
+growth = pipe_counts.last - pipe_counts.first
+assert growth <= 2, "Pipe FDs grew by #{growth} (#{pipe_counts.first} -> #{pipe_counts.last}), indicating a leak"


### PR DESCRIPTION
Node#start creates a new IO.pipe pair on each call but never closed the old @reader when restarting a node. This caused reader pipe FDs to accumulate in the supervisor process over time, and each new fork inherited all leaked FDs. In long-running swarm deployments with frequent node restarts, this could exhaust the OS file descriptor limit.

Fix: close the existing @reader before creating the new pipe.