### PR TITLE
Pre-create topics in pattern integration tests to fix Kafka warnings

### DIFF
--- a/spec/integrations/admin/read_topic/with_default_for_non_routed_topic_spec.rb
+++ b/spec/integrations/admin/read_topic/with_default_for_non_routed_topic_spec.rb
@@ -25,6 +25,8 @@ draw_routes do
   end
 end
 
+Karafka::Admin.create_topic(DT.topic, 1, 1)
+
 produce(DT.topic, "10")
 
 message = Karafka::Admin.read_topic(DT.topic, 0, 1).last

--- a/spec/integrations/pro/consumption/patterns/post_detected_with_default_deserializers_spec.rb
+++ b/spec/integrations/pro/consumption/patterns/post_detected_with_default_deserializers_spec.rb
@@ -54,10 +54,13 @@ draw_routes(create_topics: false) do
   end
 end
 
+TOPIC_NAME = "#{DT.topics[0]}-#{DT.topics[1]}"
+
 start_karafka_and_wait_until do
   unless @created
     sleep(5)
-    produce_many("#{DT.topics[0]}-#{DT.topics[1]}", DT.uuids(1))
+    Karafka::Admin.create_topic(TOPIC_NAME, 1, 1)
+    produce_many(TOPIC_NAME, DT.uuids(1))
     @created = true
   end
 

--- a/spec/integrations/pro/consumption/patterns/postfix_match_spec.rb
+++ b/spec/integrations/pro/consumption/patterns/postfix_match_spec.rb
@@ -47,10 +47,13 @@ draw_routes(create_topics: false) do
 end
 
 # If works, won't hang.
+TOPIC_NAME = "#{DT.topics[0]}-#{DT.topics[1]}"
+
 start_karafka_and_wait_until do
   unless @created
     sleep(5)
-    produce_many("#{DT.topics[0]}-#{DT.topics[1]}", DT.uuids(1))
+    Karafka::Admin.create_topic(TOPIC_NAME, 1, 1)
+    produce_many(TOPIC_NAME, DT.uuids(1))
     @created = true
   end
 

--- a/spec/integrations/pro/consumption/patterns/prefix_match_spec.rb
+++ b/spec/integrations/pro/consumption/patterns/prefix_match_spec.rb
@@ -46,10 +46,13 @@ draw_routes(create_topics: false) do
   end
 end
 
+TOPIC_NAME = "#{DT.topics[1]}-#{DT.topics[0]}"
+
 start_karafka_and_wait_until do
   unless @created
     sleep(5)
-    produce_many("#{DT.topics[1]}-#{DT.topics[0]}", DT.uuids(1))
+    Karafka::Admin.create_topic(TOPIC_NAME, 1, 1)
+    produce_many(TOPIC_NAME, DT.uuids(1))
     @created = true
   end
 


### PR DESCRIPTION
Pattern matching specs were relying on Kafka auto-topic creation when producing to combined topic names, causing TOPIC_ALREADY_EXISTS race warnings that fail the verify_kafka_warnings CI check.