### PR TITLE
Restore Ruby 4.0 Datadog integration specs (#2923)

### DIFF
--- a/bin/integrations
+++ b/bin/integrations
@@ -257,19 +257,6 @@ ARGV.each do |filter|
   end
 end
 
-# Remove specs that don't work on Ruby 4.0.0 due to gem compatibility issues
-if RUBY_VERSION.split('.').first.to_i >= 4
-  # Those specs fail as of now because of dependency on gems that do not support Ruby 4.0
-  # This should be revisited once in a while
-  RUBY_4_INCOMPATIBLE_SPECS = [
-    'instrumentation/vendors/datadog_native_pristine/consume_with_tracing_spec.rb',
-    'instrumentation/vendors/datadog/with_original_client_pristine/with_proper_ddtrace_spec.rb'
-  ].freeze
-
-  specs.delete_if do |spec|
-    RUBY_4_INCOMPATIBLE_SPECS.any? { |incompatible| spec.end_with?(incompatible) }
-  end
-end
 
 # Randomize order
 seed = (ENV['SPECS_SEED'] || rand(0..10_000)).to_i


### PR DESCRIPTION
The datadog gem now supports Ruby 4.0 since v2.24.0 (Jan 2026). These specs were excluded in #2922 as a precaution when dd-trace-rb hadn't yet released Ruby 4.0 support. That support has since shipped (DataDog/dd-trace-rb#5043), so the exclusion is no longer needed.

close https://github.com/karafka/karafka/issues/2923