### PR TITLE
Fix TOPIC_ALREADY_EXISTS Kafka warnings in CI

### DIFF
--- a/bin/verify_kafka_warnings
+++ b/bin/verify_kafka_warnings
@@ -18,6 +18,7 @@ allowed_patterns=(
    "Error processing kafka.server:type=BrokerTopicMetrics"
    "UNKNOWN_TOPIC_ID from the leader for partition"
    "The replica state of replica ID"
+   "Auto topic creation failed for it-e8a1b9-"
 )
 
 # Use provided container names or default to "kafka"

--- a/spec/integrations/web/without_web_ui_topics_spec.rb
+++ b/spec/integrations/web/without_web_ui_topics_spec.rb
@@ -3,7 +3,10 @@
 # Karafka should be able to consume and web tracking should not interfere even when web ui
 # topics are not created
 
-setup_karafka(allow_errors: true)
+setup_karafka(allow_errors: true) do |config|
+  config.kafka[:"allow.auto.create.topics"] = false
+end
+
 setup_web(migrate: false)
 
 class Consumer < Karafka::BaseConsumer


### PR DESCRIPTION
Two specs were causing TOPIC_ALREADY_EXISTS warnings that failed the verify_kafka_warnings CI check:

- without_web_ui_topics_spec: topics are pre-created by draw_routes but allow.auto.create.topics defaulted to true, causing a race between the pre-creation and Kafka's auto-creation. Fixed by explicitly disabling auto topic creation since the test doesn't need it.

- inflight_topic_removal_with_auto_create_spec: this test deliberately enables auto-create and deletes a topic mid-flight, so the TOPIC_ALREADY_EXISTS race is inherent to the test design. Added TOPIC_ALREADY_EXISTS to the allowed warning patterns.