### PR TITLE
Stabilize flaky ftr/partial_offset_storage_race_condition spec

### DIFF
--- a/spec/integrations/pro/consumption/strategies/ftr/partial_offset_storage_race_condition_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/partial_offset_storage_race_condition_spec.rb
@@ -125,6 +125,7 @@ draw_routes do
   topic DT.topic do
     consumer Consumer
     manual_offset_management true
+    filter ->(*) { VpStabilizer.new(10) }
     filter ->(*) { CursorRaceFilter.new }
   end
 end


### PR DESCRIPTION
Add VpStabilizer to ensure the first batch has at least 10 messages before the CursorRaceFilter runs. Without this, Kafka may deliver fewer messages in the initial poll (e.g. 1), causing offsets 4-6 to be absent from the first batch and the filter to never trigger.