### PR TITLE
Fix TOPIC_ALREADY_EXISTS Kafka warning for patterns/with_matching_exi…

### DIFF
--- a/bin/verify_kafka_warnings
+++ b/bin/verify_kafka_warnings
@@ -19,6 +19,7 @@ allowed_patterns=(
    "UNKNOWN_TOPIC_ID from the leader for partition"
    "The replica state of replica ID"
    "Auto topic creation failed for it-e8a1b9-"
+   "Auto topic creation failed for it-2c2272-"
 )
 
 # Use provided container names or default to "kafka"


### PR DESCRIPTION
…sting_topic spec

Add it-2c2272- checksum to allowed warning patterns since this spec intentionally tests pattern-matching against a pre-existing topic.