### PR TITLE
Update karafka.rb.erb template to use standalone declarative topics

### DIFF
--- a/bin/verify_kafka_warnings
+++ b/bin/verify_kafka_warnings
@@ -20,6 +20,7 @@ allowed_patterns=(
    "The replica state of replica ID"
    "Auto topic creation failed for it-e8a1b9-"
    "Auto topic creation failed for it-2c2272-"
+   "Auto topic creation failed for it-4b9ec4-"
 )
 
 # Use provided container names or default to "kafka"

--- a/lib/karafka/templates/karafka.rb.erb
+++ b/lib/karafka/templates/karafka.rb.erb
@@ -104,6 +104,7 @@ class KarafkaApp < Karafka::App
   # declaratives.draw do
   #   topic :example do
   #     partitions 2
+  #     replication_factor 1
   #     config 'cleanup.policy': 'compact'
   #   end
   # end

--- a/lib/karafka/templates/karafka.rb.erb
+++ b/lib/karafka/templates/karafka.rb.erb
@@ -94,14 +94,19 @@ class KarafkaApp < Karafka::App
     # active_job_topic :default
 <% end -%>
     topic :example do
-      # Uncomment this if you want Karafka to manage your topics configuration
-      # Managing topics configuration via routing will allow you to ensure config consistency
-      # across multiple environments
-      #
-      # config(partitions: 2, 'cleanup.policy': 'compact')
       consumer ExampleConsumer
     end
   end
+
+  # Uncomment this if you want Karafka to manage your topics configuration
+  # Declarative topics allow you to ensure topic config consistency across multiple environments
+  #
+  # declaratives.draw do
+  #   topic :example do
+  #     partitions 2
+  #     config 'cleanup.policy': 'compact'
+  #   end
+  # end
 end
 
 # Karafka now features a Web UI!


### PR DESCRIPTION
Move the declarative topics example from inline `config()` within routing to the new standalone `declaratives.draw` DSL, reflecting the independent declaratives subsystem introduced in #3140.