### PR TITLE
Stabilize flaky kip_848 post_revocation_recovery integration spec

### DIFF
--- a/spec/integrations/consumption/strategies/default/kip_848/post_revocation_recovery_spec.rb
+++ b/spec/integrations/consumption/strategies/default/kip_848/post_revocation_recovery_spec.rb
@@ -6,9 +6,13 @@ setup_karafka(
   allow_errors: %w[connection.client.poll.error],
   consumer_group_protocol: true
 ) do |config|
-  # Remove session timeout and set very short max poll interval for faster testing
+  # Remove session timeout and set a short (but not too tight) max poll interval.
+  # Going lower (e.g. 5s) races the KIP-848 ConsumerGroupHeartbeat state machine:
+  # the broker can evict the client and return `Invalid request` fatal on the next
+  # heartbeat before our local poll-interval kick-in fires, leaving the client in
+  # a degraded state where offset 0 is not replayed on recovery.
   config.kafka.delete(:"session.timeout.ms")
-  config.kafka[:"max.poll.interval.ms"] = 5_000
+  config.kafka[:"max.poll.interval.ms"] = 10_000
   config.max_messages = 1
 end
 
@@ -26,7 +30,7 @@ class Consumer < Karafka::BaseConsumer
 
     DT[:ticked] = true
 
-    sleep(10)
+    sleep(15)
   end
 end
 


### PR DESCRIPTION
The 5s max.poll.interval.ms + 10s in-consume sleep budget races the KIP-848 ConsumerGroupHeartbeat state machine on CI: the broker can evict the client and return an `Invalid request` fatal on the next heartbeat before the local poll-interval kick-in fires, leaving the client in a degraded state where offset 0 is not replayed on recovery and the assertion sees [0, 1] instead of the expected [0, 0, 1].

Bump the budget to 10s/15s, preserving the same 1.5x over-budget ratio that triggers revocation while giving the new heartbeat protocol enough headroom.