### PR TITLE
Fix flaky per-topic pause timing specs under CI load

### DIFF
--- a/spec/integrations/pro/pausing/with_per_topic_pause_setup_old_api_spec.rb
+++ b/spec/integrations/pro/pausing/with_per_topic_pause_setup_old_api_spec.rb
@@ -70,13 +70,16 @@ end
 3.times { |i| produce(DT.topics[i], "0") }
 
 start_karafka_and_wait_until do
-  DT.data.size >= 3 && DT.data.all? { |_, v| v.size >= 5 }
+  DT.data.size >= 3 &&
+    DT[DT.topics[0]].size >= 6 &&
+    DT[DT.topics[1]].size >= 6 &&
+    DT[DT.topics[2]].size >= 5
 end
 
 previous = nil
 
-# Limit to first 6 entries (5 diffs) to avoid CI timing artifacts from late-collected
-# entries that may have large gaps due to runner load at test teardown
+# Use first(6) (5 diffs) to avoid CI timing artifacts: late-collected entries near
+# teardown can have large gaps unrelated to the configured pause value
 DT[DT.topics[0]].first(6).each do |time|
   unless previous
     previous = time
@@ -93,6 +96,7 @@ end
 
 previous = nil
 
+# Same first(6) limit as topic[0] — guaranteed by the wait condition above
 DT[DT.topics[1]].first(6).each do |time|
   unless previous
     previous = time

--- a/spec/integrations/pro/pausing/with_per_topic_pause_setup_old_api_spec.rb
+++ b/spec/integrations/pro/pausing/with_per_topic_pause_setup_old_api_spec.rb
@@ -75,7 +75,9 @@ end
 
 previous = nil
 
-DT[DT.topics[0]].each do |time|
+# Limit to first 6 entries (5 diffs) to avoid CI timing artifacts from late-collected
+# entries that may have large gaps due to runner load at test teardown
+DT[DT.topics[0]].first(6).each do |time|
   unless previous
     previous = time
     next
@@ -91,7 +93,7 @@ end
 
 previous = nil
 
-DT[DT.topics[1]].each do |time|
+DT[DT.topics[1]].first(6).each do |time|
   unless previous
     previous = time
     next

--- a/spec/integrations/pro/pausing/with_per_topic_pause_setup_spec.rb
+++ b/spec/integrations/pro/pausing/with_per_topic_pause_setup_spec.rb
@@ -77,7 +77,9 @@ end
 
 previous = nil
 
-DT[DT.topics[0]].each do |time|
+# Limit to first 6 entries (5 diffs) to avoid CI timing artifacts from late-collected
+# entries that may have large gaps due to runner load at test teardown
+DT[DT.topics[0]].first(6).each do |time|
   unless previous
     previous = time
     next
@@ -93,7 +95,7 @@ end
 
 previous = nil
 
-DT[DT.topics[1]].each do |time|
+DT[DT.topics[1]].first(6).each do |time|
   unless previous
     previous = time
     next

--- a/spec/integrations/pro/pausing/with_per_topic_pause_setup_spec.rb
+++ b/spec/integrations/pro/pausing/with_per_topic_pause_setup_spec.rb
@@ -72,13 +72,16 @@ end
 3.times { |i| produce(DT.topics[i], "0") }
 
 start_karafka_and_wait_until do
-  DT.data.size >= 3 && DT.data.all? { |_, v| v.size >= 5 }
+  DT.data.size >= 3 &&
+    DT[DT.topics[0]].size >= 6 &&
+    DT[DT.topics[1]].size >= 6 &&
+    DT[DT.topics[2]].size >= 5
 end
 
 previous = nil
 
-# Limit to first 6 entries (5 diffs) to avoid CI timing artifacts from late-collected
-# entries that may have large gaps due to runner load at test teardown
+# Use first(6) (5 diffs) to avoid CI timing artifacts: late-collected entries near
+# teardown can have large gaps unrelated to the configured pause value
 DT[DT.topics[0]].first(6).each do |time|
   unless previous
     previous = time
@@ -95,6 +98,7 @@ end
 
 previous = nil
 
+# Same first(6) limit as topic[0] — guaranteed by the wait condition above
 DT[DT.topics[1]].first(6).each do |time|
   unless previous
     previous = time


### PR DESCRIPTION
When waiting for topic[2] (5s pause) to accumulate 5 entries, topics[0] and [1] collect 12+ entries each. Near the end of the run, all three consumers fire simultaneously after a CI-induced stall (observed: 7.8s gap), which violates the `diff <= 5` upper-bound assertion on topics[0] and [1] even though their pause config is correct.

Limit the diff checks to the first 6 entries (5 diffs) for topics[0] and [1], which were always collected while the runner was fresh. The test intent is preserved: lower bounds still confirm each topic honours its own pause setting, and upper bounds still confirm topics[0]/[1] are not accidentally using topic[2]'s 5-second pause.