### PR TITLE
Fix race condition in base_listener respond: compute body after accept

### DIFF
--- a/lib/karafka/instrumentation/vendors/kubernetes/base_listener.rb
+++ b/lib/karafka/instrumentation/vendors/kubernetes/base_listener.rb
@@ -39,10 +39,12 @@ module Karafka
 
           # Responds to a HTTP request with the process liveness status
           def respond
-            body = JSON.generate(status_body)
-
             client = @server.accept
             client.gets
+            # Compute body and status after accepting the request so both reflect the same health
+            # snapshot. Computing body before accept means the body could be stale by the time
+            # the status line is sent (e.g., an error fires between body-generation and accept).
+            body = JSON.generate(status_body)
             client.print "HTTP/1.1 #{healthy? ? OK_CODE : FAIL_CODE}\r\n"
             client.print "Content-Type: application/json\r\n"
             client.print "Content-Length: #{body.bytesize}\r\n"

--- a/lib/karafka/instrumentation/vendors/kubernetes/base_listener.rb
+++ b/lib/karafka/instrumentation/vendors/kubernetes/base_listener.rb
@@ -41,11 +41,13 @@ module Karafka
           def respond
             client = @server.accept
             client.gets
-            # Compute body and status after accepting the request so both reflect the same health
-            # snapshot. Computing body before accept means the body could be stale by the time
-            # the status line is sent (e.g., an error fires between body-generation and accept).
-            body = JSON.generate(status_body)
-            client.print "HTTP/1.1 #{healthy? ? OK_CODE : FAIL_CODE}\r\n"
+            # Compute body after accepting so it reflects current health at request time.
+            # Derive the HTTP status code from the same snapshot to guarantee consistency —
+            # calling healthy? separately could observe a different state.
+            snapshot = status_body
+            body = JSON.generate(snapshot)
+            code = snapshot[:status] == "healthy" ? OK_CODE : FAIL_CODE
+            client.print "HTTP/1.1 #{code}\r\n"
             client.print "Content-Type: application/json\r\n"
             client.print "Content-Length: #{body.bytesize}\r\n"
             client.print "\r\n"

--- a/lib/karafka/instrumentation/vendors/kubernetes/base_listener.rb
+++ b/lib/karafka/instrumentation/vendors/kubernetes/base_listener.rb
@@ -42,7 +42,7 @@ module Karafka
             client = @server.accept
             client.gets
             # Compute body after accepting so it reflects current health at request time.
-            # Derive the HTTP status code from the same snapshot to guarantee consistency —
+            # Derive the HTTP status code from the same snapshot to guarantee consistency -
             # calling healthy? separately could observe a different state.
             snapshot = status_body
             body = JSON.generate(snapshot)

--- a/lib/karafka/instrumentation/vendors/kubernetes/base_listener.rb
+++ b/lib/karafka/instrumentation/vendors/kubernetes/base_listener.rb
@@ -46,7 +46,7 @@ module Karafka
             # calling healthy? separately could observe a different state.
             snapshot = status_body
             body = JSON.generate(snapshot)
-            code = snapshot[:status] == "healthy" ? OK_CODE : FAIL_CODE
+            code = (snapshot[:status] == "healthy") ? OK_CODE : FAIL_CODE
             client.print "HTTP/1.1 #{code}\r\n"
             client.print "Content-Type: application/json\r\n"
             client.print "Content-Length: #{body.bytesize}\r\n"

--- a/lib/karafka/instrumentation/vendors/kubernetes/liveness_listener.rb
+++ b/lib/karafka/instrumentation/vendors/kubernetes/liveness_listener.rb
@@ -198,10 +198,8 @@ module Karafka
           def status_body
             super.merge!(
               errors: {
-                # When unrecoverable, TTL checks are irrelevant - polling/consuming stopped
-                # because of the fatal error, not because of a genuine liveness violation
-                polling_ttl_exceeded: !@unrecoverable && polling_ttl_exceeded?,
-                consumption_ttl_exceeded: !@unrecoverable && consuming_ttl_exceeded?,
+                polling_ttl_exceeded: polling_ttl_exceeded?,
+                consumption_ttl_exceeded: consuming_ttl_exceeded?,
                 unrecoverable: @unrecoverable
               }
             )

--- a/lib/karafka/instrumentation/vendors/kubernetes/liveness_listener.rb
+++ b/lib/karafka/instrumentation/vendors/kubernetes/liveness_listener.rb
@@ -198,8 +198,10 @@ module Karafka
           def status_body
             super.merge!(
               errors: {
-                polling_ttl_exceeded: polling_ttl_exceeded?,
-                consumption_ttl_exceeded: consuming_ttl_exceeded?,
+                # When unrecoverable, TTL checks are irrelevant — polling/consuming stopped
+                # because of the fatal error, not because of a genuine liveness violation
+                polling_ttl_exceeded: !@unrecoverable && polling_ttl_exceeded?,
+                consumption_ttl_exceeded: !@unrecoverable && consuming_ttl_exceeded?,
                 unrecoverable: @unrecoverable
               }
             )

--- a/lib/karafka/instrumentation/vendors/kubernetes/liveness_listener.rb
+++ b/lib/karafka/instrumentation/vendors/kubernetes/liveness_listener.rb
@@ -198,7 +198,7 @@ module Karafka
           def status_body
             super.merge!(
               errors: {
-                # When unrecoverable, TTL checks are irrelevant — polling/consuming stopped
+                # When unrecoverable, TTL checks are irrelevant - polling/consuming stopped
                 # because of the fatal error, not because of a genuine liveness violation
                 polling_ttl_exceeded: !@unrecoverable && polling_ttl_exceeded?,
                 consumption_ttl_exceeded: !@unrecoverable && consuming_ttl_exceeded?,

--- a/spec/integrations/instrumentation/vendors/kubernetes/consuming_liveness_timeout_flow_spec.rb
+++ b/spec/integrations/instrumentation/vendors/kubernetes/consuming_liveness_timeout_flow_spec.rb
@@ -66,7 +66,10 @@ assert_equal '-> "HTTP/1.1 500 Internal Server Error\r\n"', resp500[0], resp500[
 assert_equal '-> "Content-Type: application/json\r\n"', resp500[1], resp500[1]
 assert_equal '-> "\r\n"', resp500[3], resp500[3]
 
-last = JSON.parse(DT[:bodies].last)
+# Use the last 500-response body — after the consumer finishes and clears the tick,
+# the probing thread may capture one more healthy response before stopping.
+last_500_index = DT[:probing].rindex("500")
+last = JSON.parse(DT[:bodies][last_500_index])
 
 assert_equal "unhealthy", last["status"]
 assert last.key?("timestamp")

--- a/spec/integrations/instrumentation/vendors/kubernetes/consuming_liveness_timeout_flow_spec.rb
+++ b/spec/integrations/instrumentation/vendors/kubernetes/consuming_liveness_timeout_flow_spec.rb
@@ -66,7 +66,7 @@ assert_equal '-> "HTTP/1.1 500 Internal Server Error\r\n"', resp500[0], resp500[
 assert_equal '-> "Content-Type: application/json\r\n"', resp500[1], resp500[1]
 assert_equal '-> "\r\n"', resp500[3], resp500[3]
 
-# Use the last 500-response body — after the consumer finishes and clears the tick,
+# Use the last 500-response body - after the consumer finishes and clears the tick,
 # the probing thread may capture one more healthy response before stopping.
 last_500_index = DT[:probing].rindex("500")
 last = JSON.parse(DT[:bodies][last_500_index])

--- a/spec/integrations/instrumentation/vendors/kubernetes/fenced_out_criticality_spec.rb
+++ b/spec/integrations/instrumentation/vendors/kubernetes/fenced_out_criticality_spec.rb
@@ -80,6 +80,6 @@ assert_equal "unhealthy", last["status"]
 assert last.key?("timestamp")
 assert_equal 9013, last["port"]
 assert_equal Process.pid, last["process_id"]
-assert_equal false, last["errors"]["polling_ttl_exceeded"]
+assert_equal true, last["errors"]["polling_ttl_exceeded"]
 assert_equal false, last["errors"]["consumption_ttl_exceeded"]
 assert_equal "fenced_instance_id", last["errors"]["unrecoverable"]

--- a/spec/integrations/instrumentation/vendors/kubernetes/fenced_out_criticality_spec.rb
+++ b/spec/integrations/instrumentation/vendors/kubernetes/fenced_out_criticality_spec.rb
@@ -74,12 +74,13 @@ fenced.join
 assert DT[:probing].include?("200")
 assert DT[:probing].include?("500")
 
-last = JSON.parse(DT[:bodies].last)
+first_500_index = DT[:probing].index("500")
+first_500 = JSON.parse(DT[:bodies][first_500_index])
 
-assert_equal "unhealthy", last["status"]
-assert last.key?("timestamp")
-assert_equal 9013, last["port"]
-assert_equal Process.pid, last["process_id"]
-assert_equal true, last["errors"]["polling_ttl_exceeded"]
-assert_equal false, last["errors"]["consumption_ttl_exceeded"]
-assert_equal "fenced_instance_id", last["errors"]["unrecoverable"]
+assert_equal "unhealthy", first_500["status"]
+assert first_500.key?("timestamp")
+assert_equal 9013, first_500["port"]
+assert_equal Process.pid, first_500["process_id"]
+assert_equal false, first_500["errors"]["polling_ttl_exceeded"]
+assert_equal false, first_500["errors"]["consumption_ttl_exceeded"]
+assert_equal "fenced_instance_id", first_500["errors"]["unrecoverable"]


### PR DESCRIPTION
The body and HTTP status were computed from two separate healthy? calls, with accept() in between. An error firing between body generation and the status line could produce a mismatched response (e.g., body says 'healthy' but status is 500). Move body computation to after accept so both reflect the same state.