### PR TITLE
Add no-op Admin#close to normalize the API

### DIFF
--- a/lib/karafka/admin.rb
+++ b/lib/karafka/admin.rb
@@ -38,6 +38,14 @@ module Karafka
       @custom_kafka = kafka
     end
 
+    # No-op close to normalize the API surface.
+    #
+    # Each admin operation opens and closes its own underlying rdkafka admin instance internally,
+    # so there is nothing to release at the `Karafka::Admin` level. This method exists so that
+    # callers who hold an instance and call `#close` on it (matching the pattern of other
+    # closeable resources) do not raise `NoMethodError`.
+    def close; end
+
     class << self
       # Delegate topic-related operations to Topics class
 

--- a/lib/karafka/admin.rb
+++ b/lib/karafka/admin.rb
@@ -40,10 +40,16 @@ module Karafka
 
     # No-op close to normalize the API surface.
     #
-    # Each admin operation opens and closes its own underlying rdkafka admin instance internally,
-    # so there is nothing to release at the `Karafka::Admin` level. This method exists so that
-    # callers who hold an instance and call `#close` on it (matching the pattern of other
-    # closeable resources) do not raise `NoMethodError`.
+    # Each admin operation currently opens and closes its own underlying rdkafka admin instance
+    # internally, so there is nothing to release at the `Karafka::Admin` level right now. This
+    # method exists so that callers who hold an instance and call `#close` on it (matching the
+    # pattern of other closeable resources) do not raise `NoMethodError`.
+    #
+    # In the future, `Karafka::Admin` is planned to be refactored to reuse a single rdkafka admin
+    # instance across multiple operations rather than creating and tearing one down per call. When
+    # that happens, this method will need to release that shared instance. The no-op is here now
+    # so that all callers are already written against the correct API and require no changes when
+    # the real implementation lands.
     def close; end
 
     class << self

--- a/lib/karafka/admin.rb
+++ b/lib/karafka/admin.rb
@@ -50,7 +50,8 @@ module Karafka
     # that happens, this method will need to release that shared instance. The no-op is here now
     # so that all callers are already written against the correct API and require no changes when
     # the real implementation lands.
-    def close; end
+    def close
+    end
 
     class << self
       # Delegate topic-related operations to Topics class

--- a/spec/integrations/admin/close_spec.rb
+++ b/spec/integrations/admin/close_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Karafka::Admin#close is a no-op that exists to normalize the API surface so that callers
+# can treat an admin instance like any other closeable resource. This spec verifies that:
+# 1. close does not raise on a fresh instance
+# 2. close does not raise after performing real operations
+# 3. close can be called multiple times safely
+
+setup_karafka
+
+topic_name = DT.topics[0]
+Karafka::Admin.create_topic(topic_name, 1, 1)
+
+# Test 1: close on a fresh instance
+admin = Karafka::Admin.new
+begin
+  admin.close
+  DT[:results] << { test: :close_fresh_instance, success: true }
+rescue => e
+  DT[:results] << { test: :close_fresh_instance, success: false, error: e.message }
+end
+
+# Test 2: close after performing operations
+admin = Karafka::Admin.new
+admin.topic_info(topic_name)
+admin.cluster_info
+
+begin
+  admin.close
+  DT[:results] << { test: :close_after_operations, success: true }
+rescue => e
+  DT[:results] << { test: :close_after_operations, success: false, error: e.message }
+end
+
+# Test 3: close called multiple times on the same instance
+admin = Karafka::Admin.new
+begin
+  3.times { admin.close }
+  DT[:results] << { test: :close_idempotent, success: true }
+rescue => e
+  DT[:results] << { test: :close_idempotent, success: false, error: e.message }
+end
+
+assert_equal 3, DT[:results].size
+
+DT[:results].each do |result|
+  assert result[:success], "#{result[:test]} failed: #{result[:error]}"
+end

--- a/spec/lib/karafka/admin_spec.rb
+++ b/spec/lib/karafka/admin_spec.rb
@@ -188,4 +188,20 @@ RSpec.describe_current do
       end
     end
   end
+
+  describe "#close" do
+    subject(:admin) { described_class.new }
+
+    it "responds to close" do
+      expect(admin).to respond_to(:close)
+    end
+
+    it "returns nil" do
+      expect(admin.close).to be_nil
+    end
+
+    it "can be called multiple times without error" do
+      expect { 3.times { admin.close } }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
Each operation already opens and closes its own rdkafka admin instance internally, so there is nothing to release. The method exists purely so callers can treat Karafka::Admin like any other closeable resource without hitting NoMethodError.