### PR TITLE
Fix eof_with_error_recovery spec flakiness when EOF arrives with last…

### DIFF
--- a/lib/karafka/connection/raw_messages_buffer.rb
+++ b/lib/karafka/connection/raw_messages_buffer.rb
@@ -108,11 +108,6 @@ module Karafka
       #   we save ourselves some objects allocations. We cannot clear the underlying arrays as they
       #   may be used in other threads for data processing, thus if we would clear it, we could
       #   potentially clear a raw messages array for a job that is in the jobs queue.
-      #
-      # @note We do not clear the eof assignments because they can span across batch pollings.
-      #   Since eof is not raised non-stop and is silenced after an eof poll, if we would clean it
-      #   here we would loose the notion of it. The reset state for it should happen when we do
-      #   discover new messages for given topic partition.
       def clear
         @size = 0
         @groups.each_value(&:clear)

--- a/spec/integrations/pro/consumption/eofed/eof_with_error_recovery_spec.rb
+++ b/spec/integrations/pro/consumption/eofed/eof_with_error_recovery_spec.rb
@@ -46,6 +46,9 @@ class Consumer < Karafka::BaseConsumer
       DT[:raised] << true
       raise StandardError
     end
+
+    # When EOF is signaled together with messages, #eofed is not triggered automatically.
+    eofed if eofed?
   end
 
   def eofed


### PR DESCRIPTION
… message batch

When EOF arrives in the same poll as messages, no separate empty-batch EOF poll follows, so the eofed job is never scheduled automatically. The consumer must call `eofed if eofed?` inside `#consume` to handle this case — the same pattern used in other eofed integration specs.

Also removes a misleading comment in RawMessagesBuffer#clear that incorrectly claimed eof state is preserved across polls.