### PR TITLE
Align integration tests warning configuration with spec_helper and ka…

### DIFF
--- a/spec/integrations_helper.rb
+++ b/spec/integrations_helper.rb
@@ -3,11 +3,14 @@
 # This helper content is being used only in the forked integration tests processes.
 
 unless ENV.key?("PRISTINE_MODE")
-  Warning[:performance] = true if RUBY_VERSION >= "3.3"
-  Warning[:deprecated] = true
-  $VERBOSE = true
-
   require "warning"
+
+  if Warning.respond_to?(:categories)
+    (Warning.categories - %i[experimental]).each do |cat|
+      Warning[cat] = true
+    end
+  end
+  $VERBOSE = true
 
   Warning.process do |warning|
     next unless warning.include?(Dir.pwd)


### PR DESCRIPTION
…rafka-rdkafka PR #434

Use dynamic Warning.categories-based setup instead of per-version manual flags, matching the approach adopted in spec_helper.rb via #3192.