### PR TITLE
Add retry backoff loop for docker compose Kafka startup

### DIFF
--- a/.github/workflows/ci_linux_ubuntu_x86_64_gnu.yml
+++ b/.github/workflows/ci_linux_ubuntu_x86_64_gnu.yml
@@ -117,9 +117,9 @@ jobs:
         run: |
           for attempt in 1 2 3 4 5; do
             docker compose up -d && break
-            echo "Attempt $attempt/5 failed, retrying in $((attempt * 15))s..."
+            echo "Attempt $attempt/5 failed."
             docker compose down -v 2>/dev/null || true
-            sleep $((attempt * 15))
+            [ $attempt -lt 5 ] && echo "Retrying in $((attempt * 15))s..." && sleep $((attempt * 15)) || exit 1
           done
 
       - name: Remove Gemfile.lock for Ruby dev/preview versions
@@ -174,9 +174,9 @@ jobs:
         run: |
           for attempt in 1 2 3 4 5; do
             docker compose up -d && break
-            echo "Attempt $attempt/5 failed, retrying in $((attempt * 15))s..."
+            echo "Attempt $attempt/5 failed."
             docker compose down -v 2>/dev/null || true
-            sleep $((attempt * 15))
+            [ $attempt -lt 5 ] && echo "Retrying in $((attempt * 15))s..." && sleep $((attempt * 15)) || exit 1
           done
 
       - name: Set up Ruby
@@ -248,9 +248,9 @@ jobs:
         run: |
           for attempt in 1 2 3 4 5; do
             docker compose up -d && break
-            echo "Attempt $attempt/5 failed, retrying in $((attempt * 15))s..."
+            echo "Attempt $attempt/5 failed."
             docker compose down -v 2>/dev/null || true
-            sleep $((attempt * 15))
+            [ $attempt -lt 5 ] && echo "Retrying in $((attempt * 15))s..." && sleep $((attempt * 15)) || exit 1
           done
 
       - name: Set up Ruby

--- a/.github/workflows/ci_linux_ubuntu_x86_64_gnu.yml
+++ b/.github/workflows/ci_linux_ubuntu_x86_64_gnu.yml
@@ -115,7 +115,12 @@ jobs:
 
       - name: Start Kafka with docker compose
         run: |
-          docker compose up -d || (sleep 5 && docker compose up -d)
+          for attempt in 1 2 3 4 5; do
+            docker compose up -d && break
+            echo "Attempt $attempt/5 failed, retrying in $((attempt * 15))s..."
+            docker compose down -v 2>/dev/null || true
+            sleep $((attempt * 15))
+          done
 
       - name: Remove Gemfile.lock for Ruby dev/preview versions
         if: contains(matrix.ruby, 'dev') || contains(matrix.ruby, 'preview') || contains(matrix.ruby, 'rc')
@@ -167,7 +172,12 @@ jobs:
 
       - name: Start Kafka with docker compose
         run: |
-          docker compose up -d || (sleep 5 && docker compose up -d)
+          for attempt in 1 2 3 4 5; do
+            docker compose up -d && break
+            echo "Attempt $attempt/5 failed, retrying in $((attempt * 15))s..."
+            docker compose down -v 2>/dev/null || true
+            sleep $((attempt * 15))
+          done
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
@@ -236,7 +246,12 @@ jobs:
 
       - name: Start Kafka with docker compose
         run: |
-          docker compose up -d || (sleep 5 && docker compose up -d)
+          for attempt in 1 2 3 4 5; do
+            docker compose up -d && break
+            echo "Attempt $attempt/5 failed, retrying in $((attempt * 15))s..."
+            docker compose down -v 2>/dev/null || true
+            sleep $((attempt * 15))
+          done
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0

--- a/.github/workflows/ci_multi_broker.yml
+++ b/.github/workflows/ci_multi_broker.yml
@@ -50,9 +50,9 @@ jobs:
         run: |
           for attempt in 1 2 3 4 5; do
             docker compose -f docker-compose.multi-broker.yml up -d && break
-            echo "Attempt $attempt/5 failed, retrying in $((attempt * 15))s..."
+            echo "Attempt $attempt/5 failed."
             docker compose -f docker-compose.multi-broker.yml down -v 2>/dev/null || true
-            sleep $((attempt * 15))
+            [ $attempt -lt 5 ] && echo "Retrying in $((attempt * 15))s..." && sleep $((attempt * 15)) || exit 1
           done
 
           echo "Waiting for Kafka brokers to initialize..."

--- a/.github/workflows/ci_multi_broker.yml
+++ b/.github/workflows/ci_multi_broker.yml
@@ -48,8 +48,12 @@ jobs:
 
       - name: Start Multi-Broker Kafka cluster
         run: |
-          docker compose -f docker-compose.multi-broker.yml up -d || \
-            (sleep 5 && docker compose -f docker-compose.multi-broker.yml up -d)
+          for attempt in 1 2 3 4 5; do
+            docker compose -f docker-compose.multi-broker.yml up -d && break
+            echo "Attempt $attempt/5 failed, retrying in $((attempt * 15))s..."
+            docker compose -f docker-compose.multi-broker.yml down -v 2>/dev/null || true
+            sleep $((attempt * 15))
+          done
 
           echo "Waiting for Kafka brokers to initialize..."
           sleep 30


### PR DESCRIPTION
Docker Hub registry occasionally times out on GH Actions infrastructure, causing the single-retry pattern to fail both attempts. Replace with a 5-attempt loop with linear backoff (15s/30s/45s/60s) and a compose down between retries to ensure a clean state on each attempt.