### PR TITLE
Fix TOPIC_ALREADY_EXISTS Kafka warnings for complex_regexp_match spec…

### DIFF
--- a/bin/verify_kafka_warnings
+++ b/bin/verify_kafka_warnings
@@ -22,6 +22,9 @@ allowed_patterns=(
    "Auto topic creation failed for it-2c2272-"
    "Auto topic creation failed for it-4b9ec4-"
    "Auto topic creation failed for it-867e2c-"
+   "Auto topic creation failed for it-production."
+   "Auto topic creation failed for it-us01.production."
+   "Auto topic creation failed for it-sandbox.production."
 )
 
 # Use provided container names or default to "kafka"


### PR DESCRIPTION
… (#3194)

All three topics produced in complex_regexp_match_spec.rb use auto-creation and can race, so add their prefixes to the allowed warning patterns.