### PR TITLE
Fix puma poro specs sharing the same SPEC_HASH due to \$PROGRAM_NAME …

### DIFF
--- a/spec/integrations/embedding/puma_long_running_job_early_stop_poro/config/puma.rb
+++ b/spec/integrations/embedding/puma_long_running_job_early_stop_poro/config/puma.rb
@@ -16,7 +16,7 @@ require "karafka"
 require "securerandom"
 require "digest"
 
-SPEC_HASH = Digest::MD5.hexdigest($PROGRAM_NAME)[0, 6]
+SPEC_HASH = Digest::MD5.hexdigest(ENV.fetch("KARAFKA_SPEC_PATH", $PROGRAM_NAME))[0, 6]
 TOPIC = "it-#{SPEC_HASH}-#{SecureRandom.hex(6)}".freeze
 PID = Process.pid
 RESULT_FILE = File.join(__dir__, "..", "result.txt")

--- a/spec/integrations/embedding/puma_long_running_job_poro/config/puma.rb
+++ b/spec/integrations/embedding/puma_long_running_job_poro/config/puma.rb
@@ -16,7 +16,7 @@ require "karafka"
 require "securerandom"
 require "digest"
 
-SPEC_HASH = Digest::MD5.hexdigest($PROGRAM_NAME)[0, 6]
+SPEC_HASH = Digest::MD5.hexdigest(ENV.fetch("KARAFKA_SPEC_PATH", $PROGRAM_NAME))[0, 6]
 TOPIC = "it-#{SPEC_HASH}-#{SecureRandom.hex(6)}".freeze
 PID = Process.pid
 RESULT_FILE = File.join(__dir__, "..", "result.txt")

--- a/spec/integrations/embedding/puma_single_poro/config/puma.rb
+++ b/spec/integrations/embedding/puma_single_poro/config/puma.rb
@@ -4,7 +4,7 @@ require "karafka"
 require "securerandom"
 require "digest"
 
-SPEC_HASH = Digest::MD5.hexdigest($PROGRAM_NAME)[0, 6]
+SPEC_HASH = Digest::MD5.hexdigest(ENV.fetch("KARAFKA_SPEC_PATH", $PROGRAM_NAME))[0, 6]
 TOPIC = "it-#{SPEC_HASH}-#{SecureRandom.hex(6)}".freeze
 PID = Process.pid
 

--- a/spec/integrations/embedding/puma_with_worker_poro/config/puma.rb
+++ b/spec/integrations/embedding/puma_with_worker_poro/config/puma.rb
@@ -4,7 +4,7 @@ require "karafka"
 require "securerandom"
 require "digest"
 
-SPEC_HASH = Digest::MD5.hexdigest($PROGRAM_NAME)[0, 6]
+SPEC_HASH = Digest::MD5.hexdigest(ENV.fetch("KARAFKA_SPEC_PATH", $PROGRAM_NAME))[0, 6]
 TOPIC = "it-#{SPEC_HASH}-#{SecureRandom.hex(6)}".freeze
 PID = Process.pid
 


### PR DESCRIPTION
…collision

All four puma _poro specs invoke 'bundle exec ruby config/app.rb -s puma', which sets \$PROGRAM_NAME to 'config/app.rb' in every puma process. Since SPEC_HASH was computed from \$PROGRAM_NAME, all four specs produced topics in the same it-390239-* namespace and raced on Kafka auto-creation.

Fix by using KARAFKA_SPEC_PATH (set by bin/integrations to the unique flow_spec.rb path for each spec) so each puma process gets a distinct hash. \$PROGRAM_NAME is kept as the fallback for running specs outside CI.