### PR TITLE
Align wrapped comment lines to the 100-char RuboCop line length limit

### DIFF
--- a/lib/active_job/queue_adapters/karafka_adapter.rb
+++ b/lib/active_job/queue_adapters/karafka_adapter.rb
@@ -28,8 +28,7 @@ module ActiveJob
       Object
     end
 
-    # Karafka adapter for enqueuing jobs
-    # This is here for ease of integration with ActiveJob.
+    # Karafka adapter for enqueuing jobs This is here for ease of integration with ActiveJob.
     class KarafkaAdapter < base
       include ::Karafka::Helpers::ConfigImporter.new(
         dispatcher: %i[internal active_job dispatcher]

--- a/lib/karafka/active_job/job_extensions.rb
+++ b/lib/karafka/active_job/job_extensions.rb
@@ -19,8 +19,7 @@ module Karafka
       def karafka_options(new_options = {})
         return _karafka_options if new_options.empty?
 
-        # Make sure, that karafka options that someone wants to use are valid before assigning
-        # them
+        # Make sure, that karafka options that someone wants to use are valid before assigning them
         App.config.internal.active_job.job_options_contract.validate!(
           new_options,
           scope: %w[active_job]

--- a/lib/karafka/admin.rb
+++ b/lib/karafka/admin.rb
@@ -163,8 +163,7 @@ module Karafka
         new.trigger_rebalance(group_id)
       end
 
-      # Reads lags and offsets for given topics in the context of groups defined in the
-      #   routing
+      # Reads lags and offsets for given topics in the context of groups defined in the routing
       # @param groups_with_topics [Hash{String => Array<String>}] hash with group
       #   names with array of topics to query per group inside
       # @param active_topics_only [Boolean] if set to false, when we use routing topics, will

--- a/lib/karafka/admin/configs/resource.rb
+++ b/lib/karafka/admin/configs/resource.rb
@@ -76,8 +76,7 @@ module Karafka
 
         private
 
-        # Recognizes whether the type is provided and remaps it to a symbol representation if
-        # needed
+        # Recognizes whether the type is provided and remaps it to a symbol representation if needed
         #
         # @param type [Symbol, Integer]
         # @return [Symbol]

--- a/lib/karafka/admin/topics.rb
+++ b/lib/karafka/admin/topics.rb
@@ -193,8 +193,7 @@ module Karafka
         end
       end
 
-      # Fetches the watermark offsets for a given topic partition or multiple topics and
-      # partitions
+      # Fetches the watermark offsets for a given topic partition or multiple topics and partitions
       #
       # @param name_or_hash [String, Symbol, Hash] topic name or hash with topics and partitions
       # @param partition [Integer, nil] partition number

--- a/lib/karafka/connection/client.rb
+++ b/lib/karafka/connection/client.rb
@@ -815,8 +815,7 @@ module Karafka
       # Decides whether or not we should unsubscribe prior to closing.
       #
       # We cannot do it when there is a static group membership assignment as it would be
-      # reassigned.
-      # We cannot do it also for assign mode because then there are no subscriptions
+      # reassigned. We cannot do it also for assign mode because then there are no subscriptions
       # We also do not do it if there are no assignments at all as it does not make sense
       #
       # @return [Boolean] should we unsubscribe prior to shutdown

--- a/lib/karafka/connection/mode.rb
+++ b/lib/karafka/connection/mode.rb
@@ -31,8 +31,7 @@ module Karafka
       end
 
       # Define query and setter methods for each mode using meta-programming
-      # This creates methods like: subscribe?, assign?
-      # And bang methods like: subscribe!, assign!
+      # This creates methods like: subscribe?, assign? And bang methods like: subscribe!, assign!
       MODES.each do |mode_name|
         # @return [Boolean] true if the current mode matches this mode
         define_method("#{mode_name}?") do

--- a/lib/karafka/instrumentation/callbacks/consumer_groups/error.rb
+++ b/lib/karafka/instrumentation/callbacks/consumer_groups/error.rb
@@ -26,8 +26,7 @@ module Karafka
           # @param error [Rdkafka::Error] error that occurred
           # @note It will only instrument on errors of the client of our consumer
           def call(client_name, error)
-            # Emit only errors related to our client
-            # Same as with statistics (mor explanation there)
+            # Emit only errors related to our client Same as with statistics (mor explanation there)
             return unless @client_name == client_name
 
             monitor.instrument(

--- a/lib/karafka/instrumentation/logger_listener.rb
+++ b/lib/karafka/instrumentation/logger_listener.rb
@@ -494,8 +494,7 @@ module Karafka
       def error_details(event)
         caller_ref = event[:caller]
 
-        # Collect extra info if it was a consumer related error.
-        # Those come from user code
+        # Collect extra info if it was a consumer related error. Those come from user code
         details = case caller_ref
         when Karafka::BaseConsumer
           extract_consumer_info(caller_ref)

--- a/lib/karafka/instrumentation/vendors/appsignal/metrics_listener.rb
+++ b/lib/karafka/instrumentation/vendors/appsignal/metrics_listener.rb
@@ -188,8 +188,7 @@ module Karafka
             when :brokers
               statistics.fetch("brokers").each_value do |broker_statistics|
                 # Skip bootstrap nodes
-                # Bootstrap nodes have nodeid -1, other nodes have positive
-                # node ids
+                # Bootstrap nodes have nodeid -1, other nodes have positive node ids
                 next if broker_statistics["nodeid"] == -1
 
                 public_send(

--- a/lib/karafka/instrumentation/vendors/datadog/metrics_listener.rb
+++ b/lib/karafka/instrumentation/vendors/datadog/metrics_listener.rb
@@ -241,8 +241,7 @@ module Karafka
             when :brokers
               statistics.fetch("brokers").each_value do |broker_statistics|
                 # Skip bootstrap nodes
-                # Bootstrap nodes have nodeid -1, other nodes have positive
-                # node ids
+                # Bootstrap nodes have nodeid -1, other nodes have positive node ids
                 next if broker_statistics["nodeid"] == -1
 
                 tags = ["broker:#{broker_statistics["nodename"]}"]

--- a/lib/karafka/pro/active_job/consumer.rb
+++ b/lib/karafka/pro/active_job/consumer.rb
@@ -48,8 +48,7 @@ module Karafka
             break if revoked?
 
             # We cannot early stop when running virtual partitions because the intermediate state
-            # would force us not to commit the offsets. This would cause extensive
-            # double-processing
+            # would force us not to commit the offsets. This would cause extensive double-processing
             break if ::Karafka::App.stopping? && !topic.virtual_partitions?
 
             consume_job(message)

--- a/lib/karafka/pro/active_job/dispatcher.rb
+++ b/lib/karafka/pro/active_job/dispatcher.rb
@@ -40,8 +40,7 @@ module Karafka
           deserializer: %i[internal active_job deserializer]
         )
 
-        # Defaults for dispatching
-        # They can be updated by using `#karafka_options` on the job
+        # Defaults for dispatching They can be updated by using `#karafka_options` on the job
         DEFAULTS = {
           dispatch_method: :produce_async,
           dispatch_many_method: :produce_many_async,

--- a/lib/karafka/pro/cli/parallel_segments/base.rb
+++ b/lib/karafka/pro/cli/parallel_segments/base.rb
@@ -83,8 +83,7 @@ module Karafka
 
           # Collects the offsets for the segment origin consumer group and the parallel segments
           # consumers groups. We use segment origin group offsets as a baseline for the
-          # distribution and use existing (if any) parallel segments groups offsets for
-          # validations.
+          # distribution and use existing (if any) parallel segments groups offsets for validations.
           #
           # @param segment_origin [String] name of the origin consumer group
           # @param segments [Array<Karafka::Routing::ConsumerGroup>]

--- a/lib/karafka/pro/iterator/tpl_builder.rb
+++ b/lib/karafka/pro/iterator/tpl_builder.rb
@@ -94,8 +94,7 @@ module Karafka
               # Skip negative and time based offsets
               next unless offset.is_a?(Integer) && offset >= 0
 
-              # Exact offsets can be used as they are
-              # No need for extra operations
+              # Exact offsets can be used as they are No need for extra operations
               @mapped_topics[name][partition] = offset
             end
           end

--- a/lib/karafka/pro/loader.rb
+++ b/lib/karafka/pro/loader.rb
@@ -49,8 +49,7 @@ module Karafka
         cli/topics
       ].freeze
 
-      # Zeitwerk pro loader
-      # We need to have one per process, that's why it's set as a constant
+      # Zeitwerk pro loader We need to have one per process, that's why it's set as a constant
       PRO_LOADER = Zeitwerk::Loader.new
 
       private_constant :PRO_LOADER

--- a/lib/karafka/pro/processing/consumer_groups/filters/base.rb
+++ b/lib/karafka/pro/processing/consumer_groups/filters/base.rb
@@ -36,8 +36,7 @@ module Karafka
       # lands.
       module ConsumerGroups
         module Filters
-          # Base for all the filters.
-          # All filters (including custom) need to use this API.
+          # Base for all the filters. All filters (including custom) need to use this API.
           #
           # Due to the fact, that filters can limit data in such a way, that we need to pause or
           # seek (throttling for example), the api is not just "remove some things from batch" but

--- a/lib/karafka/pro/processing/consumer_groups/filters/inline_insights_delayer.rb
+++ b/lib/karafka/pro/processing/consumer_groups/filters/inline_insights_delayer.rb
@@ -66,8 +66,7 @@ module Karafka
               @applied = false
               @cursor = messages.first
 
-              # Nothing to do if there were no messages
-              # This can happen when we chain filters
+              # Nothing to do if there were no messages This can happen when we chain filters
               return unless @cursor
 
               insights = Karafka::Processing::ConsumerGroups::InlineInsights::Tracker.find(

--- a/lib/karafka/pro/processing/consumer_groups/parallel_segments/filters/base.rb
+++ b/lib/karafka/pro/processing/consumer_groups/parallel_segments/filters/base.rb
@@ -77,8 +77,7 @@ module Karafka
               # @param message_segment_key [String, Numeric] segment key to pass to the reducer
               # @return [Integer] segment assignment of a given message
               def reduce(message_segment_key)
-                # Assign to segment 0 always in case of failures in partitioner
-                # This is a fail-safe
+                # Assign to segment 0 always in case of failures in partitioner This is a fail-safe
                 return 0 if message_segment_key == :failure
 
                 @reducer.call(message_segment_key)

--- a/lib/karafka/pro/processing/consumer_groups/strategy_selector.rb
+++ b/lib/karafka/pro/processing/consumer_groups/strategy_selector.rb
@@ -41,8 +41,7 @@ module Karafka
         class StrategySelector
           attr_reader :strategies
 
-          # Strategies that we support in the Pro offering
-          # They can be combined
+          # Strategies that we support in the Pro offering They can be combined
           SUPPORTED_FEATURES = %i[
             active_job
             long_running_job

--- a/lib/karafka/pro/processing/schedulers/default.rb
+++ b/lib/karafka/pro/processing/schedulers/default.rb
@@ -86,8 +86,7 @@ module Karafka
           alias_method :on_schedule_periodic, :schedule_fifo
           alias_method :on_schedule_eofed, :schedule_fifo
 
-          # This scheduler does not have anything to manage as it is a pass through and has no
-          # state
+          # This scheduler does not have anything to manage as it is a pass through and has no state
           def on_manage
             nil
           end

--- a/lib/karafka/pro/recurring_tasks/executor.rb
+++ b/lib/karafka/pro/recurring_tasks/executor.rb
@@ -93,8 +93,7 @@ module Karafka
 
           @replaying = false
 
-          # When there is nothing to replay and synchronize, we can just save the state and
-          # proceed
+          # When there is nothing to replay and synchronize, we can just save the state and proceed
           if @catchup_commands.empty? && @catchup_schedule.nil?
             snapshot
 

--- a/lib/karafka/pro/routing/features/consumer_groups/patterns/config.rb
+++ b/lib/karafka/pro/routing/features/consumer_groups/patterns/config.rb
@@ -40,8 +40,7 @@ module Karafka
           #   `:discovered` - in case it is a real topic on which we started to listed
           #   `:matcher` - represents a regular expression used by librdkafka
           class Patterns < Base
-            # Config for pattern based topic
-            # Only pattern related topics are active in this context
+            # Config for pattern based topic Only pattern related topics are active in this context
             Config = Struct.new(
               :active,
               :type,

--- a/lib/karafka/processing/worker.rb
+++ b/lib/karafka/processing/worker.rb
@@ -38,8 +38,7 @@ module Karafka
 
       private
 
-      # Runs processing of jobs in a loop
-      # Stops when queue is closed.
+      # Runs processing of jobs in a loop Stops when queue is closed.
       def call
         loop { break unless process }
       end

--- a/lib/karafka/routing/contracts/routing.rb
+++ b/lib/karafka/routing/contracts/routing.rb
@@ -29,8 +29,7 @@ module Karafka
           data.each do |group|
             group[:topics].each do |topic|
               pat = topic[:patterns]
-              # Ignore pattern topics because they won't exist and should not be declarative
-              # managed
+              # Ignore pattern topics because they won't exist and should not be declarative managed
               topics << topic[:name] if !pat || !pat[:active]
 
               dlq = topic[:dead_letter_queue]

--- a/lib/karafka/setup/config_proxy.rb
+++ b/lib/karafka/setup/config_proxy.rb
@@ -45,8 +45,7 @@ module Karafka
     # Without the proxy, we'd have two problems:
     #
     # 1. **Permanent API pollution**: Adding a `producer` method to config that accepts blocks
-    #    would change its permanent API, even though this functionality is only needed during
-    #    setup.
+    #    would change its permanent API, even though this functionality is only needed during setup.
     #
     # 2. **Timing issues**: The producer doesn't exist yet when the user's setup block runs.
     #    The producer is created in `configure_components` after all user configuration is

--- a/lib/karafka/status.rb
+++ b/lib/karafka/status.rb
@@ -41,8 +41,7 @@ module Karafka
       @status.to_s
     end
 
-    # Resets the status state
-    # This is used mostly in the integration suite
+    # Resets the status state This is used mostly in the integration suite
     def reset!
       @status = :initializing
     end

--- a/spec/integrations/pro/consumption/strategies/vp/many_batches_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/many_batches_spec.rb
@@ -29,8 +29,7 @@
 # Contact: contact@karafka.io
 
 # When using virtual partitions, we should easily consume data with the same instances on many
-# batches and until there is a rebalance or critical error, the consumer instances should
-# not change
+# batches and until there is a rebalance or critical error, the consumer instances should not change
 
 setup_karafka do |config|
   config.concurrency = 10

--- a/spec/integrations/production/waterdrop_connection_pool_pristine/connection_pool_spec.rb
+++ b/spec/integrations/production/waterdrop_connection_pool_pristine/connection_pool_spec.rb
@@ -35,6 +35,8 @@ setup_karafka
 
 draw_routes(PoolConsumer)
 
+Karafka::Admin.create_topic("#{DT.topic}-responses", 1, 1)
+
 # Send test messages using regular producer
 3.times do |i|
   Karafka.producer.produce_sync(

--- a/spec/integrations/production/waterdrop_transactional_direct_pristine/transactional_pool_spec.rb
+++ b/spec/integrations/production/waterdrop_transactional_direct_pristine/transactional_pool_spec.rb
@@ -43,6 +43,8 @@ setup_karafka
 
 draw_routes(TransactionalConsumer)
 
+Karafka::Admin.create_topic("#{DT.topic}-responses", 1, 1)
+
 # Send test messages using regular producer
 3.times do |i|
   Karafka.producer.produce_sync(

--- a/spec/integrations/production/waterdrop_transactional_pool_pristine/transactional_pool_spec.rb
+++ b/spec/integrations/production/waterdrop_transactional_pool_pristine/transactional_pool_spec.rb
@@ -45,6 +45,8 @@ setup_karafka
 
 draw_routes(TransactionalConsumer)
 
+Karafka::Admin.create_topic("#{DT.topic}-responses", 1, 1)
+
 # Send test messages using regular producer
 3.times do |i|
   Karafka.producer.produce_sync(


### PR DESCRIPTION
Join prose comment lines that were split mid-sentence with no reason to be shorter than the 100-character limit. Skips license headers, YARD tags, intentional feature-list bullets, and comments that are logically separate sentences.