### PR TITLE
dont leak VP in DLQ strategy

### DIFF
--- a/lib/karafka/pro/processing/consumer_groups/strategies/dlq/default.rb
+++ b/lib/karafka/pro/processing/consumer_groups/strategies/dlq/default.rb
@@ -249,19 +249,6 @@ module Karafka
                   return
                 end
 
-                # With virtual partitions, a dispatch/skip decision is never made on a
-                # non-collapsed (parallel) run. The deciding consumer operates only on its own
-                # virtual partition subset there: the skippable message would be selected from
-                # an arbitrary subset and the dispatch marking would commit offsets of messages
-                # other virtual partitions never processed. The failure already requested a
-                # collapse, so we retry and let the decision happen on the collapsed, linear
-                # flow where it is deterministic
-                if topic.virtual_partitions? && !collapsed?
-                  retry_after_pause
-
-                  return
-                end
-
                 flow, target_topic = topic.dead_letter_queue.strategy.call(errors_tracker, attempt)
 
                 case flow

--- a/lib/karafka/pro/processing/consumer_groups/strategies/dlq/vp.rb
+++ b/lib/karafka/pro/processing/consumer_groups/strategies/dlq/vp.rb
@@ -41,10 +41,9 @@ module Karafka
             # Virtual Partitions enabled
             #
             # In general because we collapse processing in virtual partitions to one on errors,
-            # there is no special action that needs to be taken here. `Dlq::Default#apply_dlq_flow`
-            # enforces a collapsed retry before any dispatch/skip decision, so the decision always
-            # happens in the collapsed single state, from which we can mark as consumed the
-            # message that we are moving to the DLQ.
+            # there is no special action that needs to be taken because we warranty that even with
+            # VPson errors a retry collapses into a single state and from this single state we can
+            # mark as consumed the message that we are moving to the DLQ.
             module Vp
               # Features for this strategy
               FEATURES = %i[
@@ -54,6 +53,66 @@ module Karafka
 
               include Strategies::Dlq::Default
               include Strategies::Vp::Default
+
+              # Runs the DLQ strategy and based on it it performs certain operations
+              #
+              # In case of `:skip` and `:dispatch` will run the exact flow provided in a block
+              # In case of `:retry` always `#retry_after_pause` is applied
+              def apply_dlq_flow
+                # Process-critical errors are never dispatched or skipped regardless of the
+                # strategy outcome: the retry pause protects the partition during the critical
+                # shutdown and the failed batch is redelivered after the restart.
+                # We consult `errors_tracker.last` (not the per-consumer consumption cause used
+                # by the OSS strategies, which have no tracker) because it is exactly what the
+                # DLQ strategy callable below receives - this guard judges the same evidence as
+                # the strategy it overrides. The tracker is cleared at attempt zero, so `last`
+                # is always the most recent failure of the current failure streak
+                if critical_error?(errors_tracker.last)
+                  retry_after_pause
+
+                  return
+                end
+
+                # With virtual partitions, a dispatch/skip decision is never made on a
+                # non-collapsed (parallel) run. The deciding consumer operates only on its own
+                # virtual partition subset there: the skippable message would be selected from
+                # an arbitrary subset and the dispatch marking would commit offsets of messages
+                # other virtual partitions never processed. The failure already requested a
+                # collapse, so we retry and let the decision happen on the collapsed, linear
+                # flow where it is deterministic
+                if topic.virtual_partitions? && !collapsed?
+                  retry_after_pause
+
+                  return
+                end
+
+                flow, target_topic = topic.dead_letter_queue.strategy.call(errors_tracker, attempt)
+
+                case flow
+                when :retry
+                  retry_after_pause
+
+                  return
+                when :skip
+                  @_dispatch_to_dlq = false
+                when :dispatch
+                  @_dispatch_to_dlq = true
+                  # Use custom topic if it was returned from the strategy
+                  @_dispatch_to_dlq_topic = target_topic || topic.dead_letter_queue.topic
+                else
+                  raise Karafka::UnsupportedCaseError, flow
+                end
+
+                yield
+
+                # We reset the pause to indicate we will now consider it as "ok".
+                coordinator.pause_tracker.reset
+
+                # Always backoff after DLQ dispatch even on skip to prevent overloads on errors
+                pause(seek_offset, nil, false)
+              ensure
+                @_dispatch_to_dlq_topic = nil
+              end
             end
           end
         end


### PR DESCRIPTION
this PR https://github.com/karafka/karafka/pull/3216/changes had the fix in the wrong file. This cleans that.