### PR TITLE
Stabilize flaky DLQ dispatch_skipped_on_revoked_partition specs

### DIFF
--- a/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_lrj_mom/dispatch_skipped_on_revoked_partition_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_lrj_mom/dispatch_skipped_on_revoked_partition_spec.rb
@@ -94,6 +94,7 @@ Job.perform_later(1)
 # Partitions held by the second consumer (i.e. revoked from Karafka). Captured inside the poll
 # thread because an rdkafka consumer must only be touched from one thread.
 held_partitions = []
+held_snapshot = []
 holder = nil
 holder_thread = nil
 
@@ -121,26 +122,31 @@ start_karafka_and_wait_until do
     # Give both after-consume flows time to run before asserting
     sleep(8)
 
+    # Freeze the holder's assignment while Karafka is still running. Returning true below stops
+    # Karafka, whose shutdown rebalance hands its still-owned partition to the holder - capturing
+    # that post-shutdown state would wrongly flag a partition that was dispatched while owned.
+    held_snapshot = held_partitions.dup
+    DT[:stop_holder] = true
+
     true
   else
     false
   end
 end
 
-DT[:stop_holder] = true
 holder_thread&.join
 holder&.close
 
 # The rebalance must actually have moved a partition to the second consumer, otherwise there was
 # no revocation to test
-assert held_partitions.size >= 1, "second consumer got no partition - no revocation happened"
+assert held_snapshot.size >= 1, "second consumer got no partition - no revocation happened"
 
 # Karafka must not dispatch a DLQ message for any partition it no longer owns. With the guard the
 # revoked partition stays silent; without it the revoked owner dispatches too.
-leaked = DT[:dispatched] & held_partitions
+leaked = DT[:dispatched] & held_snapshot
 
 assert(
   leaked.empty?,
   "DLQ dispatch happened on revoked partition(s) #{leaked} (dispatched: #{DT[:dispatched]}, " \
-  "held by new owner: #{held_partitions})"
+  "held by new owner: #{held_snapshot})"
 )

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_lrj_mom_vp/dispatch_skipped_on_revoked_partition_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_ftr_lrj_mom_vp/dispatch_skipped_on_revoked_partition_spec.rb
@@ -97,6 +97,7 @@ Job.perform_later(1)
 # Partitions held by the second consumer (i.e. revoked from Karafka). Captured inside the poll
 # thread because an rdkafka consumer must only be touched from one thread.
 held_partitions = []
+held_snapshot = []
 holder = nil
 holder_thread = nil
 
@@ -121,23 +122,28 @@ start_karafka_and_wait_until do
 
     sleep(8)
 
+    # Freeze the holder's assignment while Karafka is still running. Returning true below stops
+    # Karafka, whose shutdown rebalance hands its still-owned partition to the holder - capturing
+    # that post-shutdown state would wrongly flag a partition that was dispatched while owned.
+    held_snapshot = held_partitions.dup
+    DT[:stop_holder] = true
+
     true
   else
     false
   end
 end
 
-DT[:stop_holder] = true
 holder_thread&.join
 holder&.close
 
-assert held_partitions.size >= 1, "second consumer got no partition - no revocation happened"
+assert held_snapshot.size >= 1, "second consumer got no partition - no revocation happened"
 
 # Karafka must not dispatch a DLQ message for any partition it no longer owns
-leaked = DT[:dispatched] & held_partitions
+leaked = DT[:dispatched] & held_snapshot
 
 assert(
   leaked.empty?,
   "DLQ dispatch happened on revoked partition(s) #{leaked} (dispatched: #{DT[:dispatched]}, " \
-  "held by new owner: #{held_partitions})"
+  "held by new owner: #{held_snapshot})"
 )

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_lrj_mom/dispatch_skipped_on_revoked_partition_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_lrj_mom/dispatch_skipped_on_revoked_partition_spec.rb
@@ -93,6 +93,7 @@ Job.perform_later(1)
 # Partitions held by the second consumer (i.e. revoked from Karafka). Captured inside the poll
 # thread because an rdkafka consumer must only be touched from one thread.
 held_partitions = []
+held_snapshot = []
 holder = nil
 holder_thread = nil
 
@@ -120,26 +121,31 @@ start_karafka_and_wait_until do
     # Give both after-consume flows time to run before asserting
     sleep(8)
 
+    # Freeze the holder's assignment while Karafka is still running. Returning true below stops
+    # Karafka, whose shutdown rebalance hands its still-owned partition to the holder - capturing
+    # that post-shutdown state would wrongly flag a partition that was dispatched while owned.
+    held_snapshot = held_partitions.dup
+    DT[:stop_holder] = true
+
     true
   else
     false
   end
 end
 
-DT[:stop_holder] = true
 holder_thread&.join
 holder&.close
 
 # The rebalance must actually have moved a partition to the second consumer, otherwise there was
 # no revocation to test
-assert held_partitions.size >= 1, "second consumer got no partition - no revocation happened"
+assert held_snapshot.size >= 1, "second consumer got no partition - no revocation happened"
 
 # Karafka must not dispatch a DLQ message for any partition it no longer owns. With the guard the
 # revoked partition stays silent; without it the revoked owner dispatches too.
-leaked = DT[:dispatched] & held_partitions
+leaked = DT[:dispatched] & held_snapshot
 
 assert(
   leaked.empty?,
   "DLQ dispatch happened on revoked partition(s) #{leaked} (dispatched: #{DT[:dispatched]}, " \
-  "held by new owner: #{held_partitions})"
+  "held by new owner: #{held_snapshot})"
 )

--- a/spec/integrations/pro/consumption/strategies/aj/dlq_lrj_mom_vp/dispatch_skipped_on_revoked_partition_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/aj/dlq_lrj_mom_vp/dispatch_skipped_on_revoked_partition_spec.rb
@@ -94,6 +94,7 @@ Job.perform_later(1)
 # Partitions held by the second consumer (i.e. revoked from Karafka). Captured inside the poll
 # thread because an rdkafka consumer must only be touched from one thread.
 held_partitions = []
+held_snapshot = []
 holder = nil
 holder_thread = nil
 
@@ -118,23 +119,28 @@ start_karafka_and_wait_until do
 
     sleep(8)
 
+    # Freeze the holder's assignment while Karafka is still running. Returning true below stops
+    # Karafka, whose shutdown rebalance hands its still-owned partition to the holder - capturing
+    # that post-shutdown state would wrongly flag a partition that was dispatched while owned.
+    held_snapshot = held_partitions.dup
+    DT[:stop_holder] = true
+
     true
   else
     false
   end
 end
 
-DT[:stop_holder] = true
 holder_thread&.join
 holder&.close
 
-assert held_partitions.size >= 1, "second consumer got no partition - no revocation happened"
+assert held_snapshot.size >= 1, "second consumer got no partition - no revocation happened"
 
 # Karafka must not dispatch a DLQ message for any partition it no longer owns
-leaked = DT[:dispatched] & held_partitions
+leaked = DT[:dispatched] & held_snapshot
 
 assert(
   leaked.empty?,
   "DLQ dispatch happened on revoked partition(s) #{leaked} (dispatched: #{DT[:dispatched]}, " \
-  "held by new owner: #{held_partitions})"
+  "held by new owner: #{held_snapshot})"
 )


### PR DESCRIPTION
The specs kept the holder consumer polling and overwriting held_partitions until DT[:stop_holder] was set - which only happened after start_karafka_and_wait_until returned, i.e. after Karafka had already shut down. Karafka's shutdown leaves the group, so its still-owned partition is revoked and handed to the holder during shutdown. The poll loop then captured that post-shutdown assignment, and the leak check flagged a partition that had been dispatched legitimately while Karafka still owned it (seen in CI as 'DLQ dispatch happened on revoked partition(s) [0] ... held by new owner: [0, 1]').

Snapshot the holder's assignment while Karafka is still running (before the block returns true and triggers the stop) and assert against that snapshot. Applied to all four variants sharing the pattern: ftr_lrj_mom_vp, lrj_mom_vp, ftr_lrj_mom and lrj_mom.