### PR TITLE
Tolerate a single process-freeze outlier in periodic custom frequencies spec

### DIFF
--- a/spec/integrations/pro/consumption/periodic_jobs/with_custom_frequencies_spec.rb
+++ b/spec/integrations/pro/consumption/periodic_jobs/with_custom_frequencies_spec.rb
@@ -76,6 +76,7 @@ end
   [1_000, 2_000]
 ].each_with_index do |(min, max), index|
   previous = nil
+  over_max = 0
 
   DT[DT.topics[index]].each do |time|
     unless previous
@@ -87,8 +88,10 @@ end
     delta = ((time - previous) * 1_000).ceil
 
     assert delta >= min, [delta, min]
-    assert delta <= max, [delta, max]
+    over_max += 1 if delta > max
 
     previous = time
   end
+
+  assert over_max <= 1, [over_max, max]
 end


### PR DESCRIPTION
A stop-the-world GC pause or shared-runner deschedule stalls the whole process for ~2s, slipping every topic's tick at once and blowing the tight upper bound on the 100ms-interval topic (seen as assert_equal [2004, 1000]). Keep the lower bound strict per tick (the real frequency invariant) but allow at most one upper-bound outlier per topic to absorb a single freeze.