### PR TITLE
Add integration specs for shutdowns during stuck rebalances

### DIFF
--- a/bin/integrations
+++ b/bin/integrations
@@ -45,6 +45,7 @@ class Scenario
     'shutdown/on_hanging_on_shutdown_job_and_a_shutdown_spec.rb' => [2].freeze,
     'shutdown/on_hanging_listener_and_shutdown_spec.rb' => [2].freeze,
     'shutdown/on_forceful_shutdown_reports_blocking_details_spec.rb' => [2].freeze,
+    'rebalancing/stuck_rebalance_forceful_shutdown_spec.rb' => [2].freeze,
     'swarm/forceful_shutdown_of_hanging_spec.rb' => [2].freeze,
     'swarm/with_blocking_at_exit_spec.rb' => [2].freeze,
     # Segfault in the below spec can be expected because we pretty much force terminate handing

--- a/spec/integrations/rebalancing/kip_848/stuck_rebalance_graceful_shutdown_spec.rb
+++ b/spec/integrations/rebalancing/kip_848/stuck_rebalance_graceful_shutdown_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+# The KIP-848 counterpart of rebalancing/stuck_rebalance_forceful_shutdown_spec.rb showing that
+# the new consumer group protocol mitigates the forceful shutdowns caused by rebalances stuck
+# for longer than `shutdown_timeout`.
+#
+# The hostile conditions are the same: another group member takes over one of our partitions
+# and never polls, so its part of the reassignment never finishes. Under the classic protocol
+# such a member wedges the whole group (everyone waits on the join barrier until the offender
+# gets fenced out after its `max.poll.interval.ms`) and on affected librdkafka versions a
+# consumer closed during that window blocks inside `rd_kafka_consumer_close`, exceeding
+# `shutdown_timeout` and ending in a forceful termination.
+#
+# Under KIP-848 the reconciliation is broker-driven and per-member: there is no group-wide
+# barrier a non-cooperating member could wedge and no rebalance state the consumer close would
+# have to wait for. The stalling member delays only its own partition takeover, while our
+# shutdown mid-reconciliation stays fast and graceful.
+
+setup_karafka(consumer_group_protocol: true) do |config|
+  # Explicit (it is also the suite default) as this spec is about not reaching this timeout
+  # despite the unresolved reassignment
+  config.shutdown_timeout = 30_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[:consumed] << messages.metadata.partition
+  end
+end
+
+draw_topics do
+  topic DT.topic do
+    partitions 2
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+  end
+end
+
+produce(DT.topic, "1", partition: 0)
+produce(DT.topic, "1", partition: 1)
+
+# Fires when the broker takes one of our partitions to reassign it to the stalling member -
+# from that moment the reassignment is in-flight and cannot finish (the staller never polls)
+Karafka.monitor.subscribe("rebalance.partitions_revoked") do |_event|
+  DT[:revoked_at] = Time.now.to_f unless DT.key?(:revoked_at)
+end
+
+start_karafka_and_wait_until do
+  if DT[:consumed].empty?
+    false
+  else
+    unless DT.key?(:staller_started)
+      staller = Rdkafka::Config.new(
+        Karafka::Setup::AttributesMap.consumer(
+          "bootstrap.servers": ENV.fetch("KAFKA_BOOTSTRAP_SERVERS", "127.0.0.1:9092"),
+          "group.id": Karafka::App.routes.first.id,
+          "group.protocol": "consumer"
+        )
+      ).consumer
+
+      # Joins the group (KIP-848 members join via background heartbeats, no polling needed) but
+      # never polls, so it never activates the partition the broker routes to it
+      staller.subscribe(DT.topic)
+
+      # Keep the reference alive so it is not garbage collected mid-spec (finalizers would close
+      # it and let the reassignment finish)
+      DT[:stallers] << staller
+      DT[:staller_started] = true
+    end
+
+    # Initiate the shutdown once our partition got revoked for the staller and its takeover
+    # hangs (2 extra seconds is well beyond the broker-side reconciliation heartbeats cadence)
+    if DT.key?(:revoked_at) && (Time.now.to_f - DT[:revoked_at]) > 2
+      DT[:stop_requested_at] = Time.now.to_f
+      true
+    else
+      false
+    end
+  end
+end
+
+shutdown_took = Time.now.to_f - DT[:stop_requested_at]
+
+# The revocation towards the staller must have really happened prior to the shutdown
+assert DT.key?(:revoked_at)
+
+# Shutdown happened mid unresolved reassignment and still must be quick - way below both the
+# 30s `shutdown_timeout` and the staller fencing time. Any close-time hang comparable with the
+# classic protocol behavior would exceed this
+assert shutdown_took < 15, "graceful shutdown expected to be quick, took #{shutdown_took}s"
+
+# Close the staller in a bounded way (it has a pending never-served assignment)
+closer = Thread.new { DT[:stallers].first.close }
+closer.join(10) || closer.kill

--- a/spec/integrations/rebalancing/stuck_rebalance_extended_timeout_mitigation_spec.rb
+++ b/spec/integrations/rebalancing/stuck_rebalance_extended_timeout_mitigation_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+# The extended `shutdown_timeout` counterpart of the
+# rebalancing/stuck_rebalance_forceful_shutdown_spec.rb scenario.
+#
+# The hostile conditions are identical: the group is stuck in a rebalance (a member that joined,
+# got a partition routed to it and never polls, so the group cannot settle until the broker
+# fences it out after its `max.poll.interval.ms`) and on affected librdkafka versions the
+# consumer close blocks until that resolution (emulated here the same way as in the trigger
+# spec, as recent librdkafka releases close mid-rebalance without blocking).
+#
+# The difference: `shutdown_timeout` is configured to outlast the rebalance resolution. The
+# shutdown is slow (it waits out the remainder of the stuck rebalance inside the consumer
+# close), but it stays graceful - no `app.stopping.error`, no forceful termination, no exit
+# code 2 - which also means offsets and the consumer state are handed over cleanly.
+#
+# This is the "extend the timeout to be able to wait longer than the rebalance process itself"
+# mitigation: the fastest to deploy, at the cost of slower deployments.
+
+setup_karafka do |config|
+  config.kafka[:"partition.assignment.strategy"] = "cooperative-sticky"
+  # Longer than the whole stuck rebalance resolution (staller fencing + slack), so the blocked
+  # close manages to finish before the supervision gives up
+  config.shutdown_timeout = 60_000
+end
+
+# For how long the stalling member wedges the group (its max.poll.interval.ms). Short, so the
+# rebalance resolves while the extended shutdown timeout is still running
+STALL_MS = 10_000
+
+# Extra time on top of the fencing for the group to settle
+STALL_SLACK = 5
+
+# Emulates the `rd_kafka_consumer_close` behavior from the affected librdkafka versions: close
+# blocks until the in-flight rebalance resolves - here that moment does arrive, as the broker
+# fences the staller out after just STALL_MS
+Karafka::Connection::Client.prepend(
+  Module.new do
+    def close
+      sleep(0.1) while DT.key?(:stall_deadline) && Time.now.to_f < DT[:stall_deadline]
+
+      DT[:close_unblocked_at] = Time.now.to_f unless DT.key?(:close_unblocked_at)
+
+      super
+    end
+  end
+)
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[:consumed] << messages.metadata.partition
+  end
+end
+
+draw_topics do
+  topic DT.topic do
+    partitions 2
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+  end
+end
+
+produce(DT.topic, "1", partition: 0)
+produce(DT.topic, "1", partition: 1)
+
+# Fires when the cooperative-sticky assignor pulls a partition from us for the stalling member
+Karafka.monitor.subscribe("rebalance.partitions_revoked") do |_event|
+  DT[:revoked_at] = Time.now.to_f unless DT.key?(:revoked_at)
+end
+
+start_karafka_and_wait_until do
+  if DT[:consumed].empty?
+    false
+  else
+    unless DT.key?(:stall_deadline)
+      staller = setup_rdkafka_consumer(
+        "partition.assignment.strategy": "cooperative-sticky",
+        "max.poll.interval.ms": STALL_MS,
+        # The broker-enforced minimum
+        "session.timeout.ms": 6_000
+      )
+
+      # Joins the group without ever polling - the same wedge as in the trigger spec, just with
+      # a short fencing time
+      staller.subscribe(DT.topic)
+
+      DT[:stallers] << staller
+      DT[:stall_deadline] = Time.now.to_f + (STALL_MS / 1_000) + STALL_SLACK
+    end
+
+    # Initiate the shutdown once we are in the middle of the stuck rebalance
+    if DT.key?(:revoked_at) && (Time.now.to_f - DT[:revoked_at]) > 2
+      DT[:stop_requested_at] = Time.now.to_f
+      true
+    else
+      false
+    end
+  end
+end
+
+shutdown_took = Time.now.to_f - DT[:stop_requested_at]
+
+# The stuck rebalance preconditions were real
+assert DT.key?(:revoked_at)
+
+# The close really was blocked until the rebalance resolution and the shutdown waited it out
+assert DT.key?(:close_unblocked_at)
+assert DT[:close_unblocked_at] >= DT[:stall_deadline]
+
+# Slow (it waited out the stuck rebalance) but nowhere near the extended shutdown_timeout and
+# the forceful path. With the trigger spec 5s timeout this very scenario ends with exit code 2
+assert shutdown_took < 45, "shutdown expected within the extended timeout, took #{shutdown_took}s"
+
+# Close the staller in a bounded way (it has pending never-served rebalance callbacks)
+closer = Thread.new { DT[:stallers].first.close }
+closer.join(10) || closer.kill

--- a/spec/integrations/rebalancing/stuck_rebalance_forceful_shutdown_spec.rb
+++ b/spec/integrations/rebalancing/stuck_rebalance_forceful_shutdown_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+# When Karafka is being stopped while its consumer group is stuck in a rebalance that takes
+# longer than `shutdown_timeout`, the shutdown must not wait forever: supervision should kick
+# in, emit `app.stopping.error` with the blocking details and forcefully terminate the process
+# with exit code 2 (this spec is registered in `bin/integrations` as expecting exit code 2).
+#
+# This reproduces the "consumption lag after deployments due to forceful shutdowns" scenario:
+# rolling deployments constantly trigger rebalances and a consumer stopped mid-rebalance gets
+# stuck inside `rd_kafka_consumer_close`, which on affected librdkafka versions blocks until
+# the rebalance resolves. With a rebalance stuck for longer than `shutdown_timeout` (30s by
+# default), each such pod ends up being killed forcefully without committing its progress,
+# which after the deployment manifests as consumption lag.
+#
+# The stuck rebalance is real: a second group member joins (with cooperative-sticky this forces
+# a revocation on the Karafka process) and never polls, so the partition routed to it stays
+# inactive and the group does not settle until the broker fences that member out after its
+# `max.poll.interval.ms`. The close-time hang itself is emulated on the Karafka client, because
+# recent librdkafka versions no longer block inside `rd_kafka_consumer_close` in this state
+# (they close mid-rebalance and let the group recover) - the hang "gets back every few versions"
+# though, and Karafka's supervision contract verified here must hold whenever it does.
+#
+# See the mitigation counterparts of this spec:
+# - rebalancing/kip_848/stuck_rebalance_graceful_shutdown_spec.rb
+# - rebalancing/stuck_rebalance_static_membership_mitigation_spec.rb
+# - rebalancing/stuck_rebalance_extended_timeout_mitigation_spec.rb
+#
+# @see https://github.com/confluentinc/librdkafka/issues/4792
+# @see https://github.com/confluentinc/librdkafka/issues/4527
+
+setup_karafka(allow_errors: %w[app.stopping.error]) do |config|
+  config.kafka[:"partition.assignment.strategy"] = "cooperative-sticky"
+  # Shorter than the stuck rebalance so the spec (and the forceful path) runs fast
+  config.shutdown_timeout = 5_000
+end
+
+# For how long the stalling member wedges the group (its max.poll.interval.ms). It must outlast
+# the shutdown timeout - this is the "rebalance longer than shutdown" precondition
+STALL_MS = 60_000
+
+# Emulates the `rd_kafka_consumer_close` behavior from the affected librdkafka versions: close
+# blocks until the in-flight rebalance resolves, which here can happen only once the broker
+# fences the stalling member out (it never polls, so it never leaves on its own)
+Karafka::Connection::Client.prepend(
+  Module.new do
+    def close
+      sleep(0.1) while DT.key?(:stall_deadline) && Time.now.to_f < DT[:stall_deadline]
+
+      super
+    end
+  end
+)
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    DT[:consumed] << messages.metadata.partition
+  end
+end
+
+draw_topics do
+  topic DT.topic do
+    partitions 2
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+  end
+end
+
+produce(DT.topic, "1", partition: 0)
+produce(DT.topic, "1", partition: 1)
+
+# Fires when the cooperative-sticky assignor pulls a partition from us to hand it over to the
+# stalling member - from that moment on the group cannot settle until the staller gets fenced
+Karafka.monitor.subscribe("rebalance.partitions_revoked") do |_event|
+  DT[:revoked_at] = Time.now.to_f unless DT.key?(:revoked_at)
+end
+
+# Not asserted in-process (the forceful exit is the assertion, enforced by the runner via the
+# exit code) but useful when debugging this spec
+Karafka.monitor.subscribe("error.occurred") do |event|
+  DT[:forceful] = true if event[:type] == "app.stopping.error"
+end
+
+start_karafka_and_wait_until do
+  if DT[:consumed].empty?
+    false
+  else
+    unless DT.key?(:stall_deadline)
+      staller = setup_rdkafka_consumer(
+        "partition.assignment.strategy": "cooperative-sticky",
+        "max.poll.interval.ms": STALL_MS,
+        "session.timeout.ms": 30_000
+      )
+
+      # Subscribing is enough to join the group (librdkafka drives the group protocol from its
+      # background threads) but since this consumer never polls, it never activates its new
+      # assignment and the rebalance stays unresolved until the broker fences it out
+      staller.subscribe(DT.topic)
+
+      # Keep the reference alive for the whole process lifetime so it is not garbage collected
+      # (finalizers would close it and un-wedge the group)
+      DT[:stallers] << staller
+      DT[:stall_deadline] = Time.now.to_f + (STALL_MS / 1_000)
+    end
+
+    # Initiate the shutdown once we are in the middle of the stuck rebalance: our partition got
+    # revoked for the staller and the staller will not let the group settle
+    DT.key?(:revoked_at) && (Time.now.to_f - DT[:revoked_at]) > 2
+  end
+end
+
+# The forceful shutdown exits with code 2 before this line is ever reached. Reaching it means
+# Karafka stopped gracefully despite the consumer close being blocked by the stuck rebalance
+# for longer than `shutdown_timeout`, which should never happen
+assert false, "Karafka should have been forcefully terminated, not stopped gracefully"

--- a/spec/integrations/rebalancing/stuck_rebalance_static_membership_mitigation_spec.rb
+++ b/spec/integrations/rebalancing/stuck_rebalance_static_membership_mitigation_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+# The static group membership counterpart of the
+# rebalancing/stuck_rebalance_forceful_shutdown_spec.rb scenario.
+#
+# The forceful shutdowns there require a rebalance to be in-flight while the consumer is being
+# stopped - the deployment itself is what generates those rebalances: every dynamic member that
+# leaves triggers one and every replacement pod that joins triggers another, so with many pods
+# rolling, shutdowns constantly land in the middle of unsettled (and with a slow member, stuck)
+# rebalances.
+#
+# With static group membership (`group.instance.id`) there is nothing to get stuck on:
+# - a stopping static member does not send a leave group request, so its shutdown triggers no
+#   rebalance (and Karafka skips the pre-close unsubscribe on purpose, as re-subscribing would
+#   reshuffle the assignments),
+# - its replacement re-joining within `session.timeout.ms` gets the exact same assignment back
+#   without rebalancing the rest of the group.
+#
+# This spec verifies both: a rolling restart of a static Karafka member is fast + graceful and
+# the other group member observes no assignment change at any point.
+
+setup_karafka do |config|
+  config.kafka[:"partition.assignment.strategy"] = "cooperative-sticky"
+  # Same as in the trigger scenario counterpart - yet with static membership the shutdown does
+  # not even come close to reaching it
+  config.shutdown_timeout = 5_000
+  config.kafka[:"group.instance.id"] = SecureRandom.hex(6)
+  # The restart must happen within this window for the assignment to be preserved
+  config.kafka[:"session.timeout.ms"] = 30_000
+end
+
+class Consumer < Karafka::BaseConsumer
+  def consume
+    messages.each do |message|
+      DT[:consumed] << [message.partition, message.raw_payload]
+    end
+  end
+end
+
+draw_topics do
+  topic DT.topic do
+    partitions 2
+  end
+end
+
+draw_routes do
+  topic DT.topic do
+    consumer Consumer
+  end
+end
+
+# Tracks how long each of the two shutdowns took
+Karafka.monitor.subscribe("app.stopping") { DT[:stopping_at] << Time.now.to_f }
+Karafka.monitor.subscribe("app.stopped") { DT[:stopped_at] << Time.now.to_f }
+
+# Karafka producer gets closed on the first server stop, hence a standalone one
+PRODUCER = WaterDrop::Producer.new do |producer_config|
+  producer_config.kafka = Karafka::Setup::AttributesMap.producer(Karafka::App.config.kafka.dup)
+  producer_config.logger = Karafka::App.config.logger
+  producer_config.max_wait_timeout = 120_000
+end
+
+# The other static group member. It records every distinct assignment it observes - across the
+# Karafka member rolling restart this history must not grow
+other = Thread.new do
+  consumer = setup_rdkafka_consumer(
+    "partition.assignment.strategy": "cooperative-sticky",
+    "group.instance.id": "other-static-member",
+    "session.timeout.ms": 30_000
+  )
+
+  consumer.subscribe(DT.topic)
+  previous = nil
+
+  until DT.key?(:done)
+    consumer.poll(100)
+
+    partitions = (consumer.assignment.to_h[DT.topic] || []).map(&:partition).sort
+
+    if partitions != previous
+      DT[:other_assignments] << partitions
+      previous = partitions
+    end
+  end
+
+  consumer.close
+end
+
+# Wait for the other member to own the whole topic before Karafka joins
+sleep(0.1) until DT[:other_assignments].include?([0, 1])
+
+2.times { |i| PRODUCER.produce_sync(topic: DT.topic, payload: "before-#{i}", partition: i) }
+
+# First run: Karafka joins (this triggers the one and only rebalance in this spec), consumes
+# from its partition and stops
+start_karafka_and_wait_until(reset_status: true) do
+  !DT[:consumed].empty?
+end
+
+# A leaving static member must not trigger a rebalance - give the group a moment to prove it
+sleep(8)
+
+baseline = DT[:other_assignments].dup
+
+2.times { |i| PRODUCER.produce_sync(topic: DT.topic, payload: "after-#{i}", partition: i) }
+
+consumed_before_restart = DT[:consumed].size
+
+# Second run: the "new pod" of the same static member - must get the same partition back and
+# resume consumption without rebalancing anything
+start_karafka_and_wait_until(reset_status: true) do
+  DT[:consumed].size > consumed_before_restart
+end
+
+DT[:done] = true
+other.join
+
+# Both shutdowns must be graceful and fast: no unsubscribe wait dance (Karafka skips it for
+# static members on purpose) and no rebalance-related close blocking
+assert_equal 2, DT[:stopping_at].size
+assert_equal 2, DT[:stopped_at].size
+
+DT[:stopping_at].zip(DT[:stopped_at]).each do |stopping, stopped|
+  took = stopped - stopping
+
+  assert took < 5, "static member shutdown expected to be immediate, took #{took}s"
+end
+
+# Neither the Karafka member leaving, nor its restarted "pod" re-joining is allowed to touch
+# the other member assignments
+assert_equal baseline, DT[:other_assignments], "no rebalance was expected on a rolling restart"
+
+# The other member went empty -> whole topic -> one partition (Karafka joining) and stayed there
+assert_equal [0, 1], DT[:other_assignments][1]
+assert_equal 1, DT[:other_assignments].last.size
+
+# Karafka must have consumed from the very same partition in both runs (assignment preserved
+# across the restart)
+karafka_partitions = DT[:consumed].map(&:first).uniq
+
+assert_equal 1, karafka_partitions.size, "expected the same single partition across restarts"
+
+# And it must have really consumed in both runs (before and after the rolling restart)
+payloads = DT[:consumed].map(&:last)
+
+assert payloads.any? { |payload| payload.start_with?("before-") }
+assert payloads.any? { |payload| payload.start_with?("after-") }


### PR DESCRIPTION
Cover the deployment-time forceful shutdown scenario where a consumer stopped mid-rebalance blocks inside rd_kafka_consumer_close for longer than shutdown_timeout, plus its three mitigations:

- trigger: cooperative-sticky + a stalling member wedging the group, ends with app.stopping.error and a forceful exit (code 2)
- KIP-848: same hostile conditions, per-member broker-driven reconciliation keeps the shutdown fast and graceful
- static group membership: rolling restart triggers no rebalance at all, assignment survives and the other member sees no changes
- extended shutdown_timeout: the blocked close waits the stuck rebalance out and the shutdown stays graceful

The stuck rebalance is real in all specs. The close-time hang itself is emulated on the Karafka client in the trigger and extended timeout specs, since librdkafka 2.14.1 no longer blocks close mid-rebalance (see confluentinc/librdkafka#4792 and confluentinc/librdkafka#4527).