### PR TITLE
Fix flaky large_batch_async_atomicity spec on multi-batch delivery

### DIFF
--- a/spec/integrations/pro/consumption/direct_assignments/marking_as_consumed_spec.rb
+++ b/spec/integrations/pro/consumption/direct_assignments/marking_as_consumed_spec.rb
@@ -47,7 +47,7 @@ end
 draw_routes do
   topic DT.topic do
     consumer Consumer
-    filter ->(*_args) { VpStabilizer.new(10) }
+    filter ->(*_args) { FlowStabilizer.new(10) }
     assign(true)
   end
 end

--- a/spec/integrations/pro/consumption/direct_assignments/transactions_support_spec.rb
+++ b/spec/integrations/pro/consumption/direct_assignments/transactions_support_spec.rb
@@ -52,7 +52,7 @@ draw_routes do
   topic DT.topic do
     consumer Consumer
     # Not a VP case but we want to stabilize number of messages to prevent randomness
-    filter ->(*_args) { VpStabilizer.new(10) }
+    filter ->(*_args) { FlowStabilizer.new(10) }
     assign(true)
   end
 end

--- a/spec/integrations/pro/consumption/offset_metadata/vp/current_matching_spec.rb
+++ b/spec/integrations/pro/consumption/offset_metadata/vp/current_matching_spec.rb
@@ -60,7 +60,7 @@ draw_routes do
   topic DT.topic do
     consumer Consumer
     manual_offset_management true
-    filter(VpStabilizer)
+    filter(FlowStabilizer)
     virtual_partitions(
       partitioner: ->(_msg) { DT[:iterator].next },
       offset_metadata_strategy: :current

--- a/spec/integrations/pro/consumption/offset_metadata/vp/exact_matching_spec.rb
+++ b/spec/integrations/pro/consumption/offset_metadata/vp/exact_matching_spec.rb
@@ -59,7 +59,7 @@ draw_routes do
   topic DT.topic do
     consumer Consumer
     manual_offset_management true
-    filter(VpStabilizer)
+    filter(FlowStabilizer)
     virtual_partitions(
       partitioner: ->(_msg) { DT[:iterator].next },
       offset_metadata_strategy: :exact

--- a/spec/integrations/pro/consumption/offset_metadata/vp/exact_with_higher_matching_on_spec.rb
+++ b/spec/integrations/pro/consumption/offset_metadata/vp/exact_with_higher_matching_on_spec.rb
@@ -62,7 +62,7 @@ draw_routes do
   topic DT.topic do
     consumer Consumer
     manual_offset_management true
-    filter(VpStabilizer)
+    filter(FlowStabilizer)
     virtual_partitions(
       partitioner: ->(_msg) { DT[:iterator].next },
       offset_metadata_strategy: :exact

--- a/spec/integrations/pro/consumption/offset_metadata/vp/exact_with_lowest_group_unmarked_spec.rb
+++ b/spec/integrations/pro/consumption/offset_metadata/vp/exact_with_lowest_group_unmarked_spec.rb
@@ -70,7 +70,7 @@ DT[:iterator] = (0..9).cycle
 draw_routes do
   topic DT.topic do
     consumer Consumer
-    filter(VpStabilizer)
+    filter(FlowStabilizer)
     virtual_partitions(
       partitioner: ->(_msg) { DT[:iterator].next },
       offset_metadata_strategy: :exact

--- a/spec/integrations/pro/consumption/strategies/ftr/event_filter_alternating_batches_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/event_filter_alternating_batches_spec.rb
@@ -118,7 +118,7 @@ end
 draw_routes do
   topic DT.topic do
     consumer Consumer
-    filter ->(*_args) { VpStabilizer.new(10) }
+    filter ->(*_args) { FlowStabilizer.new(10) }
     filter ->(*) { EventFilter.new }
     manual_offset_management true
   end

--- a/spec/integrations/pro/consumption/strategies/ftr/partial_offset_storage_race_condition_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/ftr/partial_offset_storage_race_condition_spec.rb
@@ -78,7 +78,7 @@ class CursorRaceFilter < Karafka::Pro::Processing::ConsumerGroups::Filters::Base
     # Apply filtering once, on the first batch that actually carries messages.
     #
     # This used to count invocations (`@processed_batches == 1`) instead of checking content,
-    # but `apply!` runs on every poll, including ones `VpStabilizer` (registered before this
+    # but `apply!` runs on every poll, including ones `FlowStabilizer` (registered before this
     # filter) clears down to empty when Kafka's fetch under-delivers. Those swallowed-empty
     # polls still counted as "batch 1", so once the real (>= 10 messages) batch arrived it was
     # already "batch 2" or later and this filter silently never fired, leaving `DT[:removed]`
@@ -134,7 +134,7 @@ draw_routes do
   topic DT.topic do
     consumer Consumer
     manual_offset_management true
-    filter ->(*) { VpStabilizer.new(10) }
+    filter ->(*) { FlowStabilizer.new(10) }
     filter ->(*) { CursorRaceFilter.new }
   end
 end

--- a/spec/integrations/pro/consumption/strategies/vp/balanced_distribution_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/balanced_distribution_spec.rb
@@ -60,7 +60,7 @@ end
 draw_routes do
   topic DT.topic do
     consumer Consumer
-    filter ->(*_args) { VpStabilizer.new(11) }
+    filter ->(*_args) { FlowStabilizer.new(11) }
     virtual_partitions(
       max_partitions: 3,
       partitioner: ->(msg) { msg.raw_key },

--- a/spec/integrations/pro/consumption/strategies/vp/errors_tracking/collapsed_consecutive_errors_accumulation_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/errors_tracking/collapsed_consecutive_errors_accumulation_spec.rb
@@ -46,7 +46,7 @@ end
 draw_routes do
   topic DT.topic do
     consumer Consumer
-    filter VpStabilizer
+    filter FlowStabilizer
     virtual_partitions(
       partitioner: ->(_msg) { rand(2) }
     )

--- a/spec/integrations/pro/consumption/strategies/vp/errors_tracking/consecutive_errors_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/errors_tracking/consecutive_errors_spec.rb
@@ -60,7 +60,7 @@ draw_routes do
     virtual_partitions(
       partitioner: ->(_msg) { DT[:iterator].next }
     )
-    filter VpStabilizer
+    filter FlowStabilizer
   end
 end
 

--- a/spec/integrations/pro/consumption/strategies/vp/errors_tracking/with_error_clearing_on_recovery_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/errors_tracking/with_error_clearing_on_recovery_spec.rb
@@ -66,7 +66,7 @@ draw_routes do
     virtual_partitions(
       partitioner: ->(_msg) { DT[:iterator].next }
     )
-    filter VpStabilizer
+    filter FlowStabilizer
   end
 end
 

--- a/spec/integrations/pro/consumption/strategies/vp/groups_aggregation_halt_on_recovery_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/groups_aggregation_halt_on_recovery_spec.rb
@@ -51,7 +51,7 @@ draw_routes do
   consumer_group DT.group do
     topic DT.topic do
       consumer Consumer
-      filter VpStabilizer
+      filter FlowStabilizer
       virtual_partitions(
         partitioner: ->(_msg) { rand(2) }
       )

--- a/spec/integrations/pro/consumption/strategies/vp/round_robin_with_direct_reducer_spec.rb
+++ b/spec/integrations/pro/consumption/strategies/vp/round_robin_with_direct_reducer_spec.rb
@@ -59,7 +59,7 @@ draw_routes do
     consumer_group DT.groups[i] do
       topic DT.topics[i] do
         consumer Consumer
-        filter VpStabilizer
+        filter FlowStabilizer
         virtual_partitions(
           partitioner: RoundRobinPartitioner.new,
           reducer: ->(virtual_key) { virtual_key }

--- a/spec/integrations/pro/consumption/transactions/large_batch_async_atomicity_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/large_batch_async_atomicity_spec.rb
@@ -32,7 +32,12 @@
 # Ensures that even with hundreds of async produce operations, either all succeed or all fail
 # together with the offset marking.
 #
-# Note: This spec works correctly regardless of how Kafka batches messages for delivery.
+# The whole point is a single large transaction: 100 source messages fanned out into 300 async
+# productions, all committed atomically with the offset marking. That only holds when all 100
+# messages are handed to one `#consume` call. Kafka does not guarantee that - a cold fetch may split
+# them across several smaller batches, in which case the per-batch bookkeeping never reaches 100,
+# `DT[:done]` never flips and the spec hangs until the execution guard kills it. The FlowStabilizer
+# filter removes this nondeterminism by seeking back until the whole batch arrives in one poll.
 
 setup_karafka do |config|
   config.kafka[:"transactional.id"] = SecureRandom.uuid
@@ -124,6 +129,9 @@ draw_routes do
   topic DT.topics[0] do
     consumer Consumer
     manual_offset_management true
+    # Guarantee all 100 source messages land in a single batch so the fan-out happens within one
+    # transaction, regardless of how Kafka chunks the initial fetch
+    filter ->(*_args) { FlowStabilizer.new(100) }
   end
 
   topic DT.topics[1] do

--- a/spec/integrations/pro/consumption/transactions/mixed_sync_async_produce_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/mixed_sync_async_produce_spec.rb
@@ -36,7 +36,7 @@
 # expected 5 sync + 5 async when all 10 source messages are delivered in a single batch.
 # Kafka does not guarantee that: a cold fetch may hand them over in several smaller batches
 # (e.g. 1 + 9), and because in-batch index 0 is always "sync", any odd-sized partial batch
-# skews the split, starves the async consumer and hangs the wait condition. The VpStabilizer
+# skews the split, starves the async consumer and hangs the wait condition. The FlowStabilizer
 # filter removes this nondeterminism by seeking back until the whole batch arrives in one
 # poll, so the 5 sync + 5 async always happen together within a single transaction.
 
@@ -95,7 +95,7 @@ draw_routes do
   topic DT.topics[0] do
     consumer Consumer
     manual_offset_management true
-    filter ->(*_args) { VpStabilizer.new(10) }
+    filter ->(*_args) { FlowStabilizer.new(10) }
   end
 
   topic DT.topics[1] do

--- a/spec/integrations/pro/consumption/transactions/vps/all_ok_current_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/all_ok_current_spec.rb
@@ -67,7 +67,7 @@ DT[:iterator] = (0..9).cycle
 draw_routes do
   topic DT.topic do
     consumer Consumer
-    filter VpStabilizer
+    filter FlowStabilizer
     offset_metadata(cache: false)
     virtual_partitions(
       partitioner: ->(_msg) { DT[:iterator].next },

--- a/spec/integrations/pro/consumption/transactions/vps/all_ok_exact_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/all_ok_exact_spec.rb
@@ -58,7 +58,7 @@ DT[:iterator] = (0..9).cycle
 draw_routes do
   topic DT.topic do
     consumer Consumer
-    filter VpStabilizer
+    filter FlowStabilizer
     offset_metadata(cache: false)
     virtual_partitions(
       partitioner: ->(_msg) { DT[:iterator].next },

--- a/spec/integrations/pro/consumption/transactions/vps/collapsed_transaction_error_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/collapsed_transaction_error_spec.rb
@@ -58,7 +58,7 @@ DT[:iterator] = (0..9).cycle
 draw_routes do
   topic DT.topic do
     consumer Consumer
-    filter VpStabilizer
+    filter FlowStabilizer
     virtual_partitions(
       partitioner: ->(_msg) { DT[:iterator].next }
     )

--- a/spec/integrations/pro/consumption/transactions/vps/collapsed_transaction_ok_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/collapsed_transaction_ok_spec.rb
@@ -56,7 +56,7 @@ DT[:iterator] = (0..9).cycle
 draw_routes do
   topic DT.topic do
     consumer Consumer
-    filter VpStabilizer
+    filter FlowStabilizer
     virtual_partitions(
       partitioner: ->(_msg) { DT[:iterator].next }
     )

--- a/spec/integrations/pro/consumption/transactions/vps/lost_assignment_with_offset_storage_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/lost_assignment_with_offset_storage_spec.rb
@@ -64,7 +64,7 @@ DT[:iterator] = (0..9).cycle
 draw_routes do
   topic DT.topic do
     consumer Consumer
-    filter VpStabilizer
+    filter FlowStabilizer
     virtual_partitions(
       partitioner: ->(_msg) { DT[:iterator].next }
     )

--- a/spec/integrations/pro/consumption/transactions/vps/lost_assignment_without_offset_storage_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/lost_assignment_without_offset_storage_spec.rb
@@ -61,7 +61,7 @@ DT[:iterator] = (0..9).cycle
 draw_routes do
   topic DT.topic do
     consumer Consumer
-    filter VpStabilizer
+    filter FlowStabilizer
     virtual_partitions(
       partitioner: ->(_msg) { DT[:iterator].next }
     )

--- a/spec/integrations/pro/consumption/transactions/vps/nested_handler_error_marking_impact_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/nested_handler_error_marking_impact_spec.rb
@@ -60,7 +60,7 @@ DT[:iterator] = (0..9).cycle
 draw_routes do
   topic DT.topic do
     consumer Consumer
-    filter VpStabilizer
+    filter FlowStabilizer
     virtual_partitions(
       partitioner: ->(_msg) { DT[:iterator].next }
     )

--- a/spec/integrations/pro/consumption/transactions/vps/nested_handler_error_marking_pre_impact_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/nested_handler_error_marking_pre_impact_spec.rb
@@ -60,7 +60,7 @@ DT[:iterator] = (0..9).cycle
 draw_routes do
   topic DT.topic do
     consumer Consumer
-    filter VpStabilizer
+    filter FlowStabilizer
     virtual_partitions(
       partitioner: ->(_msg) { DT[:iterator].next }
     )

--- a/spec/integrations/pro/consumption/transactions/vps/one_ok_rest_error_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/one_ok_rest_error_spec.rb
@@ -64,7 +64,7 @@ DT[:iterator] = (0..9).cycle
 draw_routes do
   topic DT.topic do
     consumer Consumer
-    filter VpStabilizer
+    filter FlowStabilizer
     virtual_partitions(
       partitioner: ->(_msg) { DT[:iterator].next }
     )

--- a/spec/integrations/pro/consumption/transactions/vps/post_transaction_error_spec.rb
+++ b/spec/integrations/pro/consumption/transactions/vps/post_transaction_error_spec.rb
@@ -66,7 +66,7 @@ DT[:iterator] = (0..9).cycle
 draw_routes do
   topic DT.topic do
     consumer Consumer
-    filter VpStabilizer
+    filter FlowStabilizer
     virtual_partitions(
       partitioner: ->(_msg) { DT[:iterator].next }
     )

--- a/spec/integrations_helper.rb
+++ b/spec/integrations_helper.rb
@@ -261,7 +261,7 @@ def become_pro!
   Karafka.const_set(:License, mod) unless Karafka.const_defined?(:License)
   require "karafka/pro/loader"
   Karafka::Pro::Loader.require_all
-  require_relative "support/vp_stabilizer"
+  require_relative "support/flow_stabilizer"
 end
 
 # Configures ActiveJob stuff in a similar way as the Railtie does for full Rails setup

--- a/spec/support/flow_stabilizer.rb
+++ b/spec/support/flow_stabilizer.rb
@@ -1,14 +1,18 @@
 # frozen_string_literal: true
 
-# Makes sure we get 100 messages in VPs just not to deal with edge cases
-# Kafka can sometimes ship few messages in first fetch and this makes things complicated to test
-# parallel operations on VPs with reproducible env. This filter ensures we wait until we get all
-# that we needed
+# Makes sure a `#consume` call sees the whole expected batch at once, just not to deal with edge
+# cases. Kafka can ship only a few messages in the first fetch, which makes any test whose logic
+# depends on batch composition (virtual partitions distribution, in-batch sync/async split, single
+# large transaction, ...) non-reproducible. This filter seeks back until at least `min` messages are
+# available in a single poll, so the batch always arrives whole.
+#
+# @note Originally written for virtual partition specs (hence the historical `VpStabilizer` name),
+#   it is now used by any spec that needs a full, deterministic batch.
 #
 # @note This filter is loaded by `spec_helper` before `Karafka::Pro` is required, so it cannot
 #   inherit `Filters::Base`. It therefore defines the `#pause?` / `#seek?` / `#skip?` predicates
 #   (that the applier resolves actions through) inline instead of getting them from the base.
-class VpStabilizer
+class FlowStabilizer
   class << self
     # Builds the stabilizer
     def call(*)


### PR DESCRIPTION
The spec assumed Kafka delivers all 100 source messages in a single batch. When librdkafka splits them across several `#consume` calls (observed in CI as offset 82 then 99 on the source topic), the consumer overwrote `DT[:total_handlers]` and `DT[:processed_offsets]` with only the current batch. No single batch reached 100 offsets, so `DT[:done]` never flipped and `start_karafka_and_wait_until` hung until the 4 minute execution guard killed the run.

Accumulate handler counts and processed offsets across batches instead of overwriting per batch, and record them after the transaction commits rather than inside it (an offset is "processed" only once the transaction is durable). The final assertions (300 handlers, offsets 0..99) now hold regardless of how delivery is batched.