### PR TITLE
Fix flaky kip_848 post_revocation_recovery spec by tolerating both recovery paths

### DIFF
--- a/spec/integrations/consumption/strategies/default/kip_848/post_revocation_recovery_spec.rb
+++ b/spec/integrations/consumption/strategies/default/kip_848/post_revocation_recovery_spec.rb
@@ -42,4 +42,16 @@ start_karafka_and_wait_until do
   DT.key?(:done)
 end
 
-assert_equal [0, 0, 1], DT[:offsets]
+# Two recovery paths are valid here and which one we hit is decided inside
+# librdkafka's KIP-848 ConsumerGroupHeartbeat state machine, not by us:
+#
+# - if our local max.poll.interval kick-in revokes the partition first, offset 0
+#   stays uncommitted and is replayed on recovery => [0, 0, 1]
+# - if the broker heartbeat evicts us first (fatal `Invalid request`), offset 0
+#   is not replayed and we resume from offset 1 => [0, 1]
+#
+# Both prove the thing this spec cares about: Karafka recovers from the expired
+# poll interval and processes every message to completion. The offset-0 replay is
+# a librdkafka-internal detail we cannot force deterministically, so asserting the
+# exact [0, 0, 1] sequence makes this spec flaky on CI.
+assert [[0, 1], [0, 0, 1]].include?(DT[:offsets])


### PR DESCRIPTION
The spec asserted the exact offset sequence [0, 0, 1], which requires offset 0 to be replayed after a max.poll.interval.ms-triggered revocation. Whether that replay happens is decided inside librdkafka's KIP-848 ConsumerGroupHeartbeat state machine, not by Karafka:

- if our local poll-interval kick-in revokes first, offset 0 stays uncommitted and is replayed on recovery => [0, 0, 1]
- if the broker heartbeat evicts first (fatal 'Invalid request'), offset 0 is not replayed and we resume from offset 1 => [0, 1]

The earlier stabilization (#3168) bumped the 5s/10s budget to 10s/15s, but that only lowered the probability of the broker-first path; it cannot remove the race since the winner is librdkafka-internal. CI still hit [0, 1] and failed.

Assert the property the spec actually guarantees - Karafka recovers from the expired poll interval and processes every message to completion - and accept both valid replay outcomes. A genuinely broken recovery ([0], [0, 0], []) still fails.