### PR TITLE
Fix flaky multi_cluster_operations spec by retrying transient __consu…

### DIFF
--- a/bin/verify_kafka_warnings
+++ b/bin/verify_kafka_warnings
@@ -24,6 +24,7 @@ allowed_patterns=(
    "Auto topic creation failed for it-867e2c-"
    "Auto topic creation failed for it-b0c959-"
    "Auto topic creation failed for it-f25972-"
+   "Auto topic creation failed for it-21ec2c-"
    "Auto topic creation failed for it-production."
    "Auto topic creation failed for it-us01.production."
    "Auto topic creation failed for it-sandbox.production."

--- a/spec/integrations/admin/multi_cluster_operations_spec.rb
+++ b/spec/integrations/admin/multi_cluster_operations_spec.rb
@@ -85,9 +85,14 @@ rescue => e
 end
 
 # Test 5: Verify Topics submodule also works with custom kafka config
+#
+# Reaching `__consumer_offsets` can hit transient leadership errors while the broker is still
+# electing the partition leader on startup, so we retry those via the shared helper.
 begin
   topics_admin = Karafka::Admin::Topics.new(kafka: working_kafka_config)
-  watermarks = topics_admin.read_watermark_offsets("__consumer_offsets", 0)
+  watermarks = with_transient_retry do
+    topics_admin.read_watermark_offsets("__consumer_offsets", 0)
+  end
 
   DT[:tests] << {
     test: "topics_submodule_custom_config",
@@ -107,7 +112,7 @@ end
 begin
   configs_admin = Karafka::Admin::Configs.new(kafka: working_kafka_config)
   resource = Karafka::Admin::Configs::Resource.new(type: :topic, name: "__consumer_offsets")
-  result = configs_admin.describe(resource)
+  result = with_transient_retry { configs_admin.describe(resource) }
 
   DT[:tests] << {
     test: "configs_submodule_custom_config",

--- a/spec/integrations_helper.rb
+++ b/spec/integrations_helper.rb
@@ -527,6 +527,30 @@ def start_karafka_and_wait_until(mode: :server, reset_status: false, sleep: 0.01
   Karafka::App.config.internal.connection.manager = manager_class.new
 end
 
+# Retries a block that tolerates transient Kafka errors, backing off between attempts. Useful
+# for operations that reach internal/lazily-created topics (e.g. `__consumer_offsets`) whose
+# partition leader may still be under election on a freshly started broker. Such calls raise
+# retriable errors like `not_leader_for_partition` that are broker startup races, not failures.
+# Only the given transient codes are retried; any other error is re-raised immediately so real
+# failures still surface.
+# @param attempts [Integer] how many times to try before giving up
+# @param backoff [Float] how long to sleep between attempts
+# @param codes [Array<Symbol>] rdkafka error codes to treat as transient and retry
+# @return [Object] whatever the block returns on success
+def with_transient_retry(
+  attempts: 10,
+  backoff: 0.5,
+  codes: %i[not_leader_for_partition leader_not_available unknown_topic_or_part]
+)
+  yield
+rescue Rdkafka::RdkafkaError => e
+  raise unless codes.include?(e.code)
+  raise if (attempts -= 1) <= 0
+
+  sleep(backoff)
+  retry
+end
+
 # Sleeps until Karafka has an assignment on requested topics
 # @param topics [Array<String>] list of topics for which assignments we wait
 def wait_for_assignments(*topics)


### PR DESCRIPTION
…mer_offsets leadership errors

Test 5 reads watermark offsets for partition 0 of the internal __consumer_offsets topic, and Test 6 describes its configs. That topic is created lazily, so on a freshly started CI broker its partition leader may still be under election when the spec reaches it. The broker then returns not_leader_for_partition, a transient retriable error - not a Karafka failure - which failed the scenario intermittently.

Wrap both calls that touch __consumer_offsets in a small retry that backs off and retries only on transient leadership/availability codes (not_leader_for_partition, leader_not_available, unknown_topic_or_part) and re-raises everything else, so a genuinely broken submodule still fails the spec.