### PR TITLE
Standardize yard-lint config: enable em-dash substitution as error

### DIFF
--- a/.yard-lint.yml
+++ b/.yard-lint.yml
@@ -82,6 +82,14 @@ Documentation/LineLength:
   # Aligned with RuboCop's Layout/LineLength (Max: 100).
   MaxLength: 100
 
+Documentation/TextSubstitution:
+  Description: Detects em/en-dashes in documentation and replaces them with hyphens.
+  Enabled: true
+  Severity: error
+  Substitutions:
+    "—": "-"    # em-dash (U+2014)
+    "–": "-"    # en-dash (U+2013)
+
 # Tags validators
 Tags/Order:
   Description: Enforces consistent ordering of YARD tags.

--- a/lib/karafka/admin/replication.rb
+++ b/lib/karafka/admin/replication.rb
@@ -467,7 +467,7 @@ module Karafka
       end
 
       # Builds the kafka-reassign-partitions.sh --generate command that asks Kafka to propose
-      # its own reassignment plan. This is optional — you can compare Kafka's suggestion against
+      # its own reassignment plan. This is optional - you can compare Kafka's suggestion against
       # the plan Karafka already computed, or skip this step and go straight to --execute.
       # @return [String] command template with placeholders for broker addresses and IDs
       def build_generate_command

--- a/lib/karafka/admin/topics.rb
+++ b/lib/karafka/admin/topics.rb
@@ -277,8 +277,8 @@ module Karafka
       #   `READ_COMMITTED` consumer will never see those messages, so lag calculated from the
       #   high-watermark is overstated on transactionally-produced topics. Passing
       #   `isolation_level: Karafka::Admin::IsolationLevels::READ_COMMITTED` here
-      #   returns the Last Stable Offset (LSO) — the highest offset a `READ_COMMITTED` consumer
-      #   would actually reach — giving accurate lag figures.
+      #   returns the Last Stable Offset (LSO) - the highest offset a `READ_COMMITTED` consumer
+      #   would actually reach - giving accurate lag figures.
       #
       # - `:max_timestamp` spec: returns the offset of the message with the highest timestamp
       #   in the partition. Not available via watermarks.

--- a/lib/karafka/app.rb
+++ b/lib/karafka/app.rb
@@ -57,7 +57,7 @@ module Karafka
 
       # Just a nicer name for the consumer groups
       alias_method :routes, :consumer_groups
-      # Generalized alias — routing entries are "groups" (consumer groups today, other kinds
+      # Generalized alias - routing entries are "groups" (consumer groups today, other kinds
       # of groups like KIP-932 share groups in the future).
       alias_method :groups, :consumer_groups
 

--- a/lib/karafka/pro/admin/recovery.rb
+++ b/lib/karafka/pro/admin/recovery.rb
@@ -168,7 +168,7 @@ module Karafka
         #   offsets = Karafka::Admin::Recovery.read_committed_offsets('sync')
         #   #=> { 'events' => { 0 => 1400, 1 => 1402 }, 'orders' => { 0 => 890 } }
         #
-        #   # Step 2: Inspect the recovered offsets — verify all expected topics and partitions
+        #   # Step 2: Inspect the recovered offsets - verify all expected topics and partitions
         #   # are present and the offset values look reasonable before committing them
         #
         #   # Step 3: Write the offsets to the target group using standard Admin APIs
@@ -195,11 +195,11 @@ module Karafka
             next unless parsed[:group] == group_id
 
             if parsed[:offset].nil?
-              # Tombstone — offset was deleted, remove from results
+              # Tombstone - offset was deleted, remove from results
               committed[parsed[:topic]].delete(parsed[:partition])
               committed.delete(parsed[:topic]) if committed[parsed[:topic]].empty?
             else
-              # Last write wins — scanning forward means we naturally end up with the most
+              # Last write wins - scanning forward means we naturally end up with the most
               # recent commit per partition
               committed[parsed[:topic]][parsed[:partition]] = parsed[:offset]
             end

--- a/lib/karafka/pro/iterator/tpl_builder.rb
+++ b/lib/karafka/pro/iterator/tpl_builder.rb
@@ -129,7 +129,7 @@ module Karafka
           # librdkafka's per-partition metadata cache for all integer-offset partitions in
           # one roundtrip. Without this pre-fetch, librdkafka triggers a much broader
           # metadata refresh when assign is called later, adding at least a second to
-          # iterator startup — noticeable in latency-sensitive contexts like Puma.
+          # iterator startup - noticeable in latency-sensitive contexts like Puma.
           # The epoch timestamp ensures every partition returns its LWM; the result is
           # intentionally discarded since we only need the warm-up side effect here.
           warm_up_tpl = Rdkafka::Consumer::TopicPartitionList.new

--- a/lib/karafka/routing/subscription_group.rb
+++ b/lib/karafka/routing/subscription_group.rb
@@ -16,7 +16,7 @@ module Karafka
 
       attr_reader :id, :name, :topics, :kafka, :group, :position
 
-      # Backwards compatible alias for `#group`. Kept purely for compatibility — this is an
+      # Backwards compatible alias for `#group`. Kept purely for compatibility - this is an
       # unconditional alias and performs no type validation, so callers should prefer `#group`
       # once additional group types (e.g. KIP-932 share groups) land.
       alias_method :consumer_group, :group

--- a/lib/karafka/routing/topic.rb
+++ b/lib/karafka/routing/topic.rb
@@ -14,7 +14,7 @@ module Karafka
       attr_reader :id, :name, :group
       attr_writer :consumer
 
-      # Backwards compatible alias for `#group`. Kept purely for compatibility — this is an
+      # Backwards compatible alias for `#group`. Kept purely for compatibility - this is an
       # unconditional alias and performs no type validation, so callers should prefer `#group`
       # once additional group types (e.g. KIP-932 share groups) land.
       alias_method :consumer_group, :group


### PR DESCRIPTION
Enable Documentation/TextSubstitution (em/en-dash -> hyphen) as an error to match the ecosystem standard, and replace existing em/en-dashes in documentation.