### PR TITLE
Bump karafka-web to 1.0.0.rc2 in the spec bundle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ end
 group :integrations do
   gem "activejob", require: false
   gem "karafka-testing", ">= 2.6.0", require: false
-  gem "karafka-web", ">= 1.0.0.beta1", require: false
+  gem "karafka-web", ">= 1.0.0.rc2", require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,10 +101,10 @@ GEM
     karafka-testing (2.6.0)
       karafka (>= 2.5.0, < 2.6.0)
       waterdrop (>= 2.8.0)
-    karafka-web (1.0.0.beta1)
+    karafka-web (1.0.0.rc2)
       erubi (~> 1.4)
-      karafka (>= 2.5.10.rc1, < 2.7.0)
-      karafka-core (>= 2.5.0, < 2.7.0)
+      karafka (>= 2.6.0.rc2, < 2.7.0)
+      karafka-core (>= 2.6.0, < 2.7.0)
       roda (>= 3.100, < 4.0)
       tilt (~> 2.0)
     logger (1.7.0)
@@ -168,7 +168,7 @@ DEPENDENCIES
   fugit
   karafka!
   karafka-testing (>= 2.6.0)
-  karafka-web (>= 1.0.0.beta1)
+  karafka-web (>= 1.0.0.rc2)
   ostruct
   rspec
   simplecov
@@ -213,7 +213,7 @@ CHECKSUMS
   karafka-rdkafka (0.28.0-x86_64-linux-gnu) sha256=34f2deb92d5d4a82b5c80985a6ff4b662a5046d6a23ae4fc9fd1606d4d26d951
   karafka-rdkafka (0.28.0-x86_64-linux-musl) sha256=4388d2c2c316ee62b17fe4c0ceab99bac571454a21534f65cc7e2fe7fe739c52
   karafka-testing (2.6.0) sha256=22df47adbee5e85db5771421b937e5adf6007e499066537547d0c5260790a361
-  karafka-web (1.0.0.beta1) sha256=5ae06fad9cc2a016c05b09781474c7d3607330be5063557b6ec939161296cd8a
+  karafka-web (1.0.0.rc2) sha256=4a7409c4bbe1eb8778dcaffd2146611b7cca7d431a7eea36381444fe65b17616
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mini_portile2 (2.8.9) sha256=0cd7c7f824e010c072e33f68bc02d85a00aeb6fce05bb4819c03dfd3c140c289
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1


### PR DESCRIPTION
Karafka 2.6 removed the flat per-topic pause routing setters. karafka-web 1.0.0.rc2 declares its Web UI topic with the nested pause(...) DSL and requires karafka >= 2.6.0.rc2. Bump the dev dependency floor from >= 1.0.0.beta1 to
>= 1.0.0.rc2 and relock so the web/* and pro/web/* integration specs run
against a compatible Web UI (1.0.0.beta1 used the removed flat setters).