### PR TITLE
Pre-create transactional produce target topic in parallel segments spec

### DIFF
--- a/spec/integrations/pro/consumption/parallel_segments/with_transactions/offset_marking_continuity_spec.rb
+++ b/spec/integrations/pro/consumption/parallel_segments/with_transactions/offset_marking_continuity_spec.rb
@@ -65,6 +65,14 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
+# Pre-create the transactional produce target so the parallel segments producing to it
+# concurrently do not trigger racing Kafka auto-topic-creation (TOPIC_ALREADY_EXISTS warnings)
+draw_topics do
+  topic DT.topics[1] do
+    partitions 1
+  end
+end
+
 draw_routes do
   consumer_group DT.group do
     parallel_segments(


### PR DESCRIPTION
The offset_marking_continuity parallel segments spec produces into DT.topics[1] concurrently from 3 parallel segments (concurrency: 10) within transactions, but that target topic was never declared or pre-created. This let Kafka auto-topic creation fire from multiple concurrent produce requests, racing and emitting 'TOPIC_ALREADY_EXISTS' broker warnings (it-992c7a-*) that fail bin/verify_kafka_warnings.

Declare DT.topics[1] via draw_topics so it is created up front, before any producer references it, eliminating the auto-creation race.