### PR TITLE
Allow-list auto-create TOPIC_ALREADY_EXISTS in pattern parallel segme…

### DIFF
--- a/bin/verify_kafka_warnings
+++ b/bin/verify_kafka_warnings
@@ -28,6 +28,7 @@ allowed_patterns=(
    "Auto topic creation failed for it-production."
    "Auto topic creation failed for it-us01.production."
    "Auto topic creation failed for it-sandbox.production."
+   "Auto topic creation failed for it-parallel-segments-pattern-.*TOPIC_ALREADY_EXISTS"
 )
 
 # Use provided container names or default to "kafka"

--- a/spec/integrations/pro/consumption/parallel_segments/with_pattern_matched_topics_spec.rb
+++ b/spec/integrations/pro/consumption/parallel_segments/with_pattern_matched_topics_spec.rb
@@ -46,7 +46,7 @@ class Consumer < Karafka::BaseConsumer
   end
 end
 
-pattern_base = SecureRandom.hex(4)
+pattern_base = "it-parallel-segments-pattern-#{SecureRandom.hex(4)}"
 topic_pattern = /#{pattern_base}-.*-topic/
 
 draw_routes(create_topics: false) do


### PR DESCRIPTION
…nts spec

The with_pattern_matched_topics parallel segments spec intentionally produces into pattern-matched topics that do not exist yet, letting the broker auto-create them at runtime, to verify the pattern discovers dynamically-created topics. With KAFKA_AUTO_CREATE_TOPICS_ENABLE the concurrent produce/metadata requests race and emit benign 'Auto topic creation failed ... TOPIC_ALREADY_EXISTS' broker warnings that fail bin/verify_kafka_warnings.

The spec's topic base is SecureRandom.hex(4) (random per run), so it cannot be allow-listed by prefix like the it-<SPEC_HASH>- specs. Allow-list the two stable topic suffixes scoped to the benign TOPIC_ALREADY_EXISTS error only, so genuine auto-create failures (e.g. INVALID_REPLICATION_FACTOR) still fail.